### PR TITLE
Ht 2219 add holdings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem "canister"
+gem "dotenv"
 gem "mongo"
 gem "mongoid"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
     concurrent-ruby (1.1.6)
     diff-lcs (1.3)
     docile (1.3.2)
+    dotenv (2.7.5)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
@@ -76,6 +77,7 @@ PLATFORMS
 
 DEPENDENCIES
   canister
+  dotenv
   mongo
   mongoid
   pry

--- a/bin/add_holdings.rb
+++ b/bin/add_holdings.rb
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+require "bundler/setup"
+require "cluster"
+require "holding"
+require "json"
+require "optparse"
+
+options = {}
+OptionParser.new do |opts|
+  opts.on("-m",
+          "--member MEMBER",
+          "Member whose holdings are being added") do |m|
+            options[:member] = m
+          end
+  opts.on("-d", "--delete", "Delete member holdings before adding") do |d|
+    options[:delete] = d
+  end
+  opts.on("-h", "--holdings HOLDINGS", "Holdings file") do |h|
+    options[:holdings] = h
+  end
+end.parse!
+raise OptionParser::MissingArgument if options[:holdings].nil?
+raise OptionParser::MissingArgument if options[:member].nil?
+
+# If a full replace of a member's holdings
+if options[:delete]
+  Cluster.where("holdings.organization": options[:member]).each do |c|
+    c.holdings.each do |h|
+      h.delete if h.organization == options[:member]
+    end
+  end
+end
+
+File.open(options[:holdings]) do |line|
+  holding = JSON.parse(line)
+  Holding.add(holding)
+
+  count += 1
+
+  if (count % 10_000).zero?
+    puts "#{Time.now}: #{count} records loaded"
+  end
+end

--- a/bin/update_holdings.rb
+++ b/bin/update_holdings.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "dotenv"
+Dotenv.load(".env")
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+require "bundler/setup"
+require "json"
+require "holding"
+
+holdings = ARGV.shift
+
+File.open(holdings).each do |line|
+  holding = JSON.parse(line)
+  Holding.update(holding)
+
+  count += 1
+
+  if (count % 10_000).zero?
+    puts "#{Time.now}: #{count} records loaded"
+  end
+end

--- a/lib/holding.rb
+++ b/lib/holding.rb
@@ -1,26 +1,112 @@
 # frozen_string_literal: true
 
 require "mongoid"
+require "set"
 
 # A member holding
+# - ocns
+# - organization
+# - local_id
+# - enum_chron
+# - status
+# - condition
+# - gov_doc_flag
+# - mono_multi_serial
+# - date_received
 class Holding
   include Mongoid::Document
-  field :ocn, type: Integer # , type: OCLCNumber
+
+  # OCNS processed when performing updates
+  @ocns_updated = Set.new
+
+  field :ocns, type: Array
   field :organization, type: String
   field :local_id, type: String
   field :enum_chron, type: String
   field :status, type: String
   field :condition, type: String
-  field :gov_doc_flag, type: Boolean
+  field :gov_doc_flag, type: Boolean, default: false
   field :mono_multi_serial, type: String
   field :date_received, type: DateTime
 
   embedded_in :cluster
 
+  validates_presence_of :ocns, :organization, :local_id, :mono_multi_serial
+  validates :mono_multi_serial, inclusion: { in: ["mono", "multi", "serial"] }
+  validates_each :ocns do |record, attr, value|
+    value.each do |ocn|
+      record.errors.add attr, "must be an integer" \
+        unless (ocn.to_i if /\A[+-]?\d+\Z/.match?(ocn.to_s))
+    end
+  end
+
+  # Attach this embedded document to another parent
+  #
+  # @param new_parent, the parent cluster to attach to
   def move(new_parent)
     unless new_parent.id == _parent.id
       new_parent.holdings << dup
       delete
     end
   end
+
+  # Add a new holding record, don't worry about updates,
+  # e.g. full update of a member's records
+  # Attach to first Cluster we find.
+  #
+  # @param holding_hash is a hash of values for a single holding
+  def self.add(holding_hash)
+    ocns = [holding_hash[:ocns]].flatten
+    Cluster.where(ocns: { "$in": ocns }).each do |cluster|
+      cluster.holdings.create(holding_hash)
+      return cluster
+    end
+
+    # Not found, create a cluster
+    cluster = Cluster.new(ocns: [ocns.first])
+    cluster.save
+    cluster.holdings.create(holding_hash)
+    cluster
+  end
+
+  # Update holding records when we aren't sure which records to replace,
+  # e.g. partial update of a member
+  #
+  # @param holding_hash is a hash of values for a single holding
+  def self.update(holding_hash)
+    # blow away the holdings for the cluster if we haven't seen the ocn
+    unless (ocns_updated & holding_hash[:ocns].map(&:to_i)).any?
+      delete(holding_hash[:organization], holding_hash[:ocns])
+        .each {|o| @ocns_updated << o.to_i }
+    end
+    add(holding_hash)
+  end
+
+  # Delete holding records when they match a member/ocn pair
+  #
+  # @param organization is the member organization
+  # @param ocns is the ocns this applies to
+  def self.delete(organization, ocns)
+    ocns_found = []
+    Cluster.where(ocns:
+      { "$in": ocns.map(&:to_i) }).each do |cluster|
+        cluster.holdings.where(organization: organization)
+          .delete
+        ocns_found << cluster.ocns
+      end
+    ocns_found.flatten.uniq
+  end
+
+  class << self
+    attr_reader :ocns_updated
+  end
+
+  class << self
+    attr_writer :ocns_updated
+  end
+
+  def ocns_updated
+    self.class.ocns_updated
+  end
+
 end

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -32,6 +32,25 @@ RSpec.describe Cluster do
   describe "#merge" do
     let(:c1) { described_class.new(ocns: [ocn1]) }
     let(:c2) { described_class.new(ocns: [ocn2]) }
+    let(:h1) do
+      { ocns:              [ocn1],
+        organization:      "loc",
+        local_id:          rand(1_000_000).to_s,
+        mono_multi_serial: "mono" }
+    end
+
+    let(:h2) do
+      { ocns:              [ocn1],
+        organization:      "miu",
+        local_id:          rand(1_000_000).to_s,
+        mono_multi_serial: "mono" }
+    end
+    let(:h3) do
+      { ocns:              [ocn2],
+        organization:      "miu",
+        local_id:          rand(1_000_000).to_s,
+        mono_multi_serial: "mono" }
+    end
 
     before(:each) do
       c1.save
@@ -47,9 +66,9 @@ RSpec.describe Cluster do
     end
 
     it "combines holdings but does not dedupe" do
-      c1.holdings.create(organization: "loc")
-      c1.holdings.create(organization: "miu")
-      c2.holdings.create(organization: "miu")
+      c1.holdings.create(h1)
+      c1.holdings.create(h2)
+      c2.holdings.create(h3)
       expect(c1.merge(c2).holdings.count).to eq(3)
     end
 

--- a/spec/holding_spec.rb
+++ b/spec/holding_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "holding"
+require "cluster"
+require "pp"
+RSpec.describe Holding do
+  let(:ocn_rand) { rand(1_000_000).to_i }
+  let(:holding_hash) do
+    { ocns:              [ocn_rand],
+      organization:      "miu",
+      local_id:          "abc",
+      mono_multi_serial: "mono" }
+  end
+  let(:h) { described_class.new(holding_hash) }
+
+  it "can be created" do
+    expect(described_class.new(holding_hash)).to be_a(described_class)
+  end
+
+  it "has at least 1 ocn" do
+    expect(h.ocns.first).to be_a(Integer)
+  end
+
+  it "has an organization" do
+    expect(h.organization).to be_a(String)
+  end
+
+  it "has a local id" do
+    expect(h.local_id).to be_a(String)
+  end
+
+  it "has a mono_multi_serial" do
+    expect(h.mono_multi_serial).to be_a(String)
+  end
+
+  it "requires mono_multi_serial to be one of the values" do
+    h.mono_multi_serial = "recording"
+    expect(h.valid?).to be false
+    h.mono_multi_serial = "multi"
+    expect(h.valid?).to be true
+  end
+
+  describe "#ocns_updated" do
+    it "can track the ocns seen by the class" do
+      described_class.ocns_updated << 5
+      expect(described_class.new.ocns_updated).to include(5)
+    end
+  end
+
+  describe "#self.add" do
+    before(:each) do
+      Cluster.each(&:delete)
+    end
+
+    let(:c) { Cluster.new(ocns: [5, 7, holding_hash[:ocns]].flatten) }
+    let(:c2) { Cluster.new(ocns: [8, 999]) }
+    let(:hold_hash_multi_ocn) do
+      { ocns:              [7, 8],
+        organization:      "miu",
+        local_id:          "abc",
+        mono_multi_serial: "mono" }
+    end
+
+    after(:each) do
+      Cluster.each(&:delete)
+    end
+
+    it "adds a holding with one OCN to the appropriate cluster" do
+      c.save
+      cluster = described_class.add(holding_hash)
+      expect(cluster.holdings.count).to eq(1)
+      expect(cluster.holdings.first.local_id).to eq("abc")
+    end
+
+    it "creates a cluster if no cluster is found" do
+      expect(Cluster.count).to eq(0)
+      described_class.add(holding_hash)
+      expect(Cluster.count).to eq(1)
+      expect(Cluster.first.holdings.first.local_id).to eq("abc")
+    end
+
+    it "adds a holding with multi OCNs to the appropriate cluster" do
+      c.save
+      cluster = described_class.add(hold_hash_multi_ocn)
+      expect(cluster.holdings.count).to eq(1)
+      expect(cluster.holdings.first.local_id).to eq("abc")
+    end
+
+    it "creates a cluster from a holding with multi OCNS using first" do
+      cluster = described_class.add(hold_hash_multi_ocn)
+      expect(cluster.holdings.count).to eq(1)
+      expect(cluster.ocns.count).to eq(1)
+      expect(cluster.holdings.first.local_id).to eq("abc")
+    end
+
+    it "only adds to first cluster it finds if it has multiple OCNS" do
+      c.save
+      c2.save
+      described_class.add(hold_hash_multi_ocn)
+      expect(Cluster.where(_id: c._id).first.holdings.count).to eq(1)
+      expect(Cluster.where(_id: c2._id).first.holdings.count).to eq(0)
+    end
+  end
+
+  describe "#self.update" do
+    let(:c) { Cluster.new(ocns: [ocn_rand]) }
+    let(:h) { holding_hash }
+
+    before(:each) do
+      Cluster.each(&:delete)
+      c.save
+      h[:ocns] = [c.ocns.first]
+      c.holdings.create(h)
+    end
+
+    after(:each) do
+      described_class.ocns_updated = Set.new
+      Cluster.each(&:delete)
+    end
+
+    it "destroys previous holdings if it HAS NOT seen the ocn" do
+      expect(described_class.ocns_updated).not_to include(h[:ocns].first)
+      c = described_class.update(h.clone)
+      expect(c.holdings.count).to eq(1)
+      expect(described_class.ocns_updated).to include(h[:ocns].first)
+    end
+
+    it "adds to the cluster if it HAS seen the ocn" do
+      c = described_class.update(h.clone)
+      expect(c.holdings.count).to eq(1)
+      expect(described_class.ocns_updated).to include(h[:ocns].first)
+      c = described_class.update(h.clone)
+      expect(c.holdings.count).to eq(2)
+    end
+  end
+
+  describe "#self.delete_holdings" do
+    let(:c) { Cluster.new(ocns: [ocn_rand]) }
+    let(:h) { holding_hash }
+
+    before(:each) do
+      c.save
+      c.holdings.create(h)
+    end
+
+    after(:each) do
+      described_class.ocns_updated = Set.new
+      Cluster.each(&:delete)
+    end
+
+    it "destroys all holdings for a particular member/ocn pair" do
+      expect(c.holdings.count).to eq(1)
+      described_class.delete(h[:organization], c.ocns)
+      expect(Cluster.where(_id: c._id).first.holdings.count).to eq(0)
+    end
+
+    it "returns the OCNs in the clusters affected" do
+      expect(described_class.delete(h[:organization], c.ocns)).to eq(c.ocns)
+    end
+  end
+end


### PR DESCRIPTION
Holdings can be added and updated. 

bin/add_holdings.rb accepts a delete flag that deletes all holdings for a member before adding a new set. I don't believe we have decided what to do about deleted records. Do we remove them? Mark them 'WD'? 