### PR TITLE
Move HTItem clustering logic into ClusterHtItem

### DIFF
--- a/bin/add_ht_items.rb
+++ b/bin/add_ht_items.rb
@@ -3,10 +3,10 @@
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "bundler/setup"
-require "cluster"
+require "cluster_ht_item"
 require "ht_item"
-require "json"
-require "optparse"
+
+Mongoid.load!("mongoid.yml", :test)
 
 # Convert a tsv line from the hathifile into a record like hash
 #
@@ -20,7 +20,9 @@ def hathifile_to_record(hathifile_line)
     bib_fmt:    fields[19] }
 end
 
-File.open(ARGV.shift) do |line|
+File.open(ARGV.shift, "r:UTF-8").each do |line|
   rec = hathifile_to_record(line)
-  HtItem.add(rec)
+  h = HtItem.new(rec)
+  c = ClusterHtItem.new(h).cluster
+  c.save
 end

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -60,9 +60,12 @@ class Cluster
 
   private
 
+  # Moves embedded documents from another cluster to itself
+  #
+  # @param other - the other cluster
   def move_members_to_self(other)
     other.holdings.each {|h| h.move(self) }
-    other.ht_items.each {|ht| ht.move(self) }
+    other.ht_items.each {|ht| ClusterHtItem.new(ht).move(self) }
     other.commitments.each {|c| c.move(self) }
   end
 

--- a/lib/cluster_ht_item.rb
+++ b/lib/cluster_ht_item.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "cluster"
+
+# Services for clustering HT Items
+class ClusterHtItem
+  # Creates a ClusterHTItem
+  #
+  # @param HTItem that needs clustering
+  def initialize(ht_item)
+    @ht_item = ht_item
+  end
+
+  # Cluster the HTItem
+  def cluster
+    c = (Cluster.merge_many(Cluster.where(ocns: { "$in": @ht_item.ocns })) ||
+         Cluster.new(ocns: @ht_item.ocns).tap(&:save))
+    c.ht_items << @ht_item
+    c.ocns = c.ht_items.collect(&:ocns).flatten.uniq
+    c
+  end
+
+  # Move an HTItem from one cluster to another
+  #
+  # @param new_cluster - the cluster to move to
+  def move(new_cluster)
+    unless new_cluster.id == @ht_item._parent.id
+      duped_htitem = @ht_item.dup
+      @ht_item.delete
+      new_cluster.ht_items << duped_htitem
+      @ht_item = duped_htitem
+    end
+  end
+
+end

--- a/lib/ht_item.rb
+++ b/lib/ht_item.rb
@@ -26,35 +26,6 @@ class HtItem
     end
   end
 
-  # Attach this embedded document to another parent
-  #
-  # @param new_parent, the parent cluster to attach to
-  def move(new_parent)
-    unless new_parent.id == _parent.id
-      h = to_hash
-      delete
-      new_parent.ht_items.create(h)
-    end
-  end
-
-  # Add htitem to the clusters, merging if necessary
-  #
-  # @param record
-  def self.add(record)
-    c = Cluster.merge_many(Cluster.where(ocns: { "$in": record[:ocns] }))
-    if c.nil?
-      c = Cluster.new(ocns: record[:ocns])
-      c.save
-    end
-    c.ht_items.create(record)
-  end
-
-  # Adds its own OCNs to its parent's
-  def save
-    _parent.ocns = (_parent.ocns + ocns).uniq
-    super
-  end
-
   def to_hash
     {
       ocns:       ocns,

--- a/spec/cluster_ht_item_spec.rb
+++ b/spec/cluster_ht_item_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "cluster_ht_item"
+RSpec.describe ClusterHtItem do
+  let(:ht) { build(:ht_item) }
+  let(:c) { create(:cluster, ocns: ht.ocns) }
+
+  describe "#cluster" do
+    before(:each) do
+      Cluster.each(&:delete)
+    end
+
+    it "adds an HT Item to an existing cluster" do
+      c.save
+      cluster = described_class.new(ht).cluster
+      expect(cluster.ht_items.first._parent.id).to eq(c.id)
+      expect(cluster.ht_items.to_a.size).to eq(1)
+      expect(Cluster.each.to_a.size).to eq(1)
+    end
+
+    it "creates a new cluster if no match is found" do
+      c.save
+      new_cluster = described_class.new(build(:ht_item)).cluster
+      expect(new_cluster.id).not_to eq(c.id)
+      expect(Cluster.each.to_a.size).to eq(2)
+    end
+
+    it "merges two or more clusters" do
+      # first cluster with ht's ocns
+      c = described_class.new(ht).cluster
+      # a second cluster with different ocns
+      second_c = described_class.new(build(:ht_item)).cluster
+      # ht with ocns overlapping both
+      overlapping_ht = build(:ht_item, ocns: c.ocns+second_c.ocns)
+      cluster = described_class.new(overlapping_ht).cluster
+      expect(Cluster.each.to_a.size).to eq(1)
+      expect(cluster.ht_items.to_a.size).to eq(3)
+    end
+
+    it "cluster has it's embed's ocns" do
+      c.save
+      ht.ocns << rand(1_000_000)
+      cluster = described_class.new(ht).cluster
+      expect(cluster.ocns).to eq(ht.ocns)
+    end
+  end
+
+  describe "#move" do
+    let(:c2) { create(:cluster) }
+
+    before(:each) do
+      Cluster.each(&:delete)
+      c.save
+    end
+
+    it "moves an HT Item from one cluster to another" do
+      cluster = described_class.new(ht).cluster
+      expect(cluster.ht_items.to_a.size).to eq(1)
+      described_class.new(ht).move(c2)
+      expect(cluster.ht_items.to_a.size).to eq(0)
+      expect(c2.ht_items.to_a.size).to eq(1)
+    end
+  end
+end

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe Cluster do
   let(:ht) { build(:ht_item).to_hash }
 
   before(:each) do
-    described_class.remove_indexes
-    described_class.create_indexes
     described_class.collection.find.delete_many
   end
 

--- a/spec/ht_item_spec.rb
+++ b/spec/ht_item_spec.rb
@@ -10,9 +10,6 @@ RSpec.describe HtItem do
   let(:c) { create(:cluster, ocns: htitem_hash[:ocns]) }
 
   before(:each) do
-    described_class.remove_indexes
-    described_class.create_indexes
-    Cluster.create_indexes
     described_class.collection.find.delete_many
     Cluster.collection.find.delete_many
   end
@@ -43,32 +40,5 @@ RSpec.describe HtItem do
     ht_multi_ocns[:ocns] << rand(1_000_000).to_i
     c.ht_items.create(ht_multi_ocns)
     expect(c.ocns.count).to eq(2)
-  end
-
-  describe "#add" do
-    let(:htitem2) do
-      { ocns:       [rand(1_000_000).to_i, htitem_hash[:ocns]].flatten,
-        item_id:    item_id_rand,
-        ht_bib_key: ht_bib_key_rand,
-        rights:     rand(10).to_s,
-        bib_fmt:    rand(10).to_s }
-    end
-    let(:c2) { create(:cluster, ocns: [htitem2[:ocns].first]) }
-
-    it "creates a cluster if it doesn't exist" do
-      expect(Cluster.count).to eq(0)
-      described_class.add(htitem2)
-      expect(Cluster.count).to eq(1)
-      expect(Cluster.first.ht_items.first.item_id).to eq(htitem2[:item_id])
-    end
-
-    it "merges 2 clusters based on ocns" do
-      c
-      c2
-      expect(Cluster.count).to eq(2)
-      described_class.add(htitem2)
-      expect(Cluster.count).to eq(1)
-      expect(Cluster.first.ht_items.first.item_id).to eq(htitem2[:item_id])
-    end
   end
 end


### PR DESCRIPTION
Simplifying the HTItem model, moving the necessary clustering bits into ClusterHtItem. ClusterHtItem and ClusterHolding are nearly identical. 