### PR TITLE
HT-2338 Determine cluster format mpm/spm/ser

### DIFF
--- a/bin/add_ht_items.rb
+++ b/bin/add_ht_items.rb
@@ -17,7 +17,8 @@ def hathifile_to_record(hathifile_line)
     ocns:       fields[7].split(",").map(&:to_i),
     ht_bib_key: fields[3].to_i,
     rights:     fields[2],
-    bib_fmt:    fields[19] }
+    bib_fmt:    fields[19],
+    enum_chron: fields[4] }
 end
 
 File.open(ARGV.shift, "r:UTF-8").each do |line|

--- a/bin/load_print_serials.rb
+++ b/bin/load_print_serials.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+require "bundler/setup"
+require "cluster_serial"
+require "cluster"
+require "pp"
+
+Mongoid.load!("mongoid.yml", :test)
+
+# Convert a tsv line from the print_serials_*.tsv into a hash
+#
+# @param line, a tsv line
+def print_serial_to_record(line)
+  id, ocns, issns, locations = line.chomp.split("\t")
+  { record_id: id.to_i,
+    ocns:      extract_ocns(ocns),
+    issns:     extract_issns(issns),
+    locations: locations }
+end
+
+# Extract ISSNs from issn field
+def extract_issns(i_field)
+  i_field.split(" | ")
+end
+
+# Extract OCNs from OCNs field
+def extract_ocns(o_field)
+  o_field.split(/(?: \| | )/).map {|o| o.gsub(/[^0-9]/, "").to_i }.uniq
+end
+
+if __FILE__ == $PROGRAM_NAME
+  # delete old print serial records
+  Cluster.where("serials.0": { "$exists": 1 }).each do |c|
+    c.serials.each(&:remove)
+  end
+
+  # load new file
+  fin = File.open(ARGV.shift)
+  fin.each do |line|
+    rec = print_serial_to_record(line)
+    s = Serial.new(rec)
+    begin
+      c = ClusterSerial.new(s).cluster
+      c&.save
+    rescue StandardError
+      PP.pp rec
+    end
+  end
+end

--- a/lib/calculate_format.rb
+++ b/lib/calculate_format.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "cluster"
+
+# Calculates the format for HT Items and OCN Clusters
+# Both are dependent upon loading of the print serials file.
+class CalculateFormat
+
+  def initialize(cluster)
+    @cluster = cluster
+  end
+
+  # Calculate format for this particular ht_item in this particular cluster
+  #
+  # @param ht_item, the HT item to calculate the format on.
+  def item_format(ht_item)
+    if matching_serial? ht_item
+      "ser"
+    elsif cluster_has_item_with_enum_chron_and_same_ht_bib_key? ht_item
+      "mpm"
+    else
+      "spm"
+    end
+  end
+
+  # Calculate format for this entire OCN cluster
+  def cluster_format
+    if any_of_format? "mpm"
+      "mpm"
+    elsif any_of_format?("spm") && @cluster.serials.any?
+      "ser/spm"
+    elsif @cluster.serials.any?
+      "ser"
+    else
+      "spm"
+    end
+  end
+
+  private
+
+  def any_of_format?(format)
+    @cluster.ht_items.any? {|ht| item_format(ht) == format }
+  end
+
+  def cluster_has_item_with_enum_chron_and_same_ht_bib_key?(ht_item)
+    @cluster.ht_items.any? do |ht|
+      ht.ht_bib_key == ht_item.ht_bib_key && !ht.enum_chron.empty?
+    end
+  end
+
+  def matching_serial?(ht_item)
+    @cluster.serials.any? {|s| s.record_id == ht_item.ht_bib_key }
+  end
+
+end

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -4,11 +4,13 @@ require "mongoid"
 require "holding"
 require "ht_item"
 require "commitment"
+require "serial"
 
 # A set of identifiers (e.g. OCLC numbers),
 # - ocns
 # - holdings
 # - htitems
+# - serials
 # - commitments
 class Cluster
   include Mongoid::Document
@@ -17,6 +19,7 @@ class Cluster
   embeds_many :holdings, class_name: "Holding"
   embeds_many :ht_items, class_name: "HtItem"
   embeds_many :ocn_resolutions, class_name: "OCNResolution"
+  embeds_many :serials, class_name: "Serial"
   embeds_many :commitments
   index({ ocns: 1 }, unique: true)
   index({ "ht_items.item_id": 1 }, unique: true, sparse: true)
@@ -60,7 +63,7 @@ class Cluster
     c&.save
     c
   end
-  
+
   # Collects OCNs from embedded documents
   def collect_ocns
     (ocn_resolutions.collect(&:ocns).flatten +
@@ -78,6 +81,5 @@ class Cluster
     other.ht_items.each {|ht| ClusterHtItem.new(ht).move(self) }
     other.commitments.each {|c| c.move(self) }
   end
-
 
 end

--- a/lib/cluster_serial.rb
+++ b/lib/cluster_serial.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "cluster"
+
+# Services for clustering Print Serials records
+class ClusterSerial
+  def initialize(serial)
+    @serial = serial
+  end
+
+  def cluster
+    c = Cluster.find_by(ocns: @serial[:ocns])
+    if c
+      c.serials << @serial
+      c
+    end
+  end
+
+  def move(new_cluster)
+    unless new_cluster.id == @serial._parent.id
+      duped_s = @serial.dup
+      new_cluster.serials << duped_s
+      @serial.delete
+      @serial = duped_s
+    end
+  end
+
+end

--- a/lib/ht_item.rb
+++ b/lib/ht_item.rb
@@ -8,6 +8,7 @@ require "mongoid"
 # - ht_bib_key
 # - rights
 # - bib_fmt
+# - enum_chron
 class HtItem
   include Mongoid::Document
   field :ocns, type: Array
@@ -15,6 +16,7 @@ class HtItem
   field :ht_bib_key, type: Integer
   field :rights, type: String
   field :bib_fmt, type: String
+  field :enum_chron, type: String
 
   embedded_in :cluster
   validates :item_id, uniqueness: true

--- a/lib/serial.rb
+++ b/lib/serial.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "mongoid"
+
+# A print serial record
+# Used in the process to determine item type
+class Serial
+  include Mongoid::Document
+  field :record_id, type: Integer
+  field :ocns, type: Array
+  field :issns, type: Array
+  field :locations, type: String
+
+  embedded_in :cluster
+
+  validates_presence_of :ocns, :record_id
+
+end

--- a/spec/calculate_format_spec.rb
+++ b/spec/calculate_format_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "calculate_format"
+
+RSpec.describe CalculateFormat do
+  let(:ht_spm) { build(:ht_item, enum_chron: "") }
+  let(:ht_mpm) { build(:ht_item, enum_chron: "V.1") }
+  let(:ht_ser) { build(:ht_item, enum_chron: "V.1") }
+  let(:c) { create(:cluster, ocns: ht_spm.ocns) }
+  let(:s) { build(:serial, record_id: ht_ser.ht_bib_key, ocns: ht_ser.ocns) }
+
+  describe "#item_format" do
+    it "defaults to SPM" do
+      expect(described_class.new(c).item_format(ht_spm)).to eq("spm")
+    end
+
+    it "is a MPM if it or another item has enum_chron" do
+      c_mpm = ClusterHtItem.new(ht_mpm).cluster
+      expect(
+        described_class.new(c_mpm).item_format(ht_mpm)
+      ).to eq("mpm")
+    end
+
+    it "is a MPM if another ht item on this record has enum_chron" do
+      ht_spm.ht_bib_key = ht_mpm.ht_bib_key
+      c.ht_items << ht_mpm
+      c.ht_items << ht_spm
+      expect(described_class.new(c).item_format(ht_mpm)).to eq("mpm")
+    end
+
+    it "is a SER if it is found in the serials file" do
+      c.serials << s
+      expect(described_class.new(c).item_format(ht_ser)).to eq("ser")
+      c.ht_items << ht_ser
+      expect(
+        described_class.new(c).item_format(c.ht_items.first)
+      ).to eq("ser")
+    end
+
+    it "MPM's don't clobber Serials just yet" do
+      c.ht_items << ht_ser
+      c.ht_items << ht_mpm
+      c.serials << s
+      expect(
+        described_class.new(c).item_format(c.ht_items.first)
+      ).to eq("ser")
+      expect(
+        described_class.new(c).item_format(c.ht_items.last)
+      ).to eq("mpm")
+    end
+  end
+
+  describe "#cluster_format" do
+    it "is a MPM if any items are MPM" do
+      c.ht_items << ht_mpm
+      c.ht_items << ht_spm
+      c.ht_items << ht_ser
+      c.serials << s
+      expect(described_class.new(c).cluster_format).to eq("mpm")
+    end
+
+    it "is a SPM if all items are SPM" do
+      c.ht_items << ht_spm
+      expect(described_class.new(c).cluster_format).to eq("spm")
+    end
+
+    it "is a SER if all items are SER" do
+      c.serials << s
+      c.ht_items << ht_ser
+      expect(described_class.new(c).cluster_format).to eq("ser")
+    end
+
+    it "is a SER/SPM if some items are SER and some are SPM" do
+      c.ht_items << ht_spm
+      c.ht_items << ht_ser
+      c.serials << s
+      expect(described_class.new(c).cluster_format).to eq("ser/spm")
+    end
+  end
+end

--- a/spec/cluster_serial_spec.rb
+++ b/spec/cluster_serial_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "cluster_serial"
+require "pp"
+RSpec.describe ClusterSerial do
+  let(:s) { build(:serial) }
+  let(:c) { create(:cluster, ocns: s.ocns) }
+
+  describe "#cluster" do
+    before(:each) do
+      Cluster.each(&:delete)
+      c.save
+    end
+
+    it "adds a serial to an existing cluster" do
+      cluster = described_class.new(s).cluster
+      expect(cluster.serials.first._parent.id).to eq(c.id)
+      expect(cluster.serials.to_a.size).to eq(1)
+      expect(Cluster.each.to_a.size).to eq(1)
+    end
+
+    # This should never actually happen as all Serial Records are for exiting
+    # HT materials
+    it "does not create a new cluster if no match is found" do
+      expect(described_class.new(build(:serial)).cluster).to be_nil
+      expect(Cluster.each.to_a.size).to eq(1)
+    end
+  end
+
+  describe "#move" do
+    let(:c2) { create(:cluster) }
+
+    before(:each) do
+      Cluster.each(&:delete)
+      c.save
+    end
+
+    it "moves a serial from one cluster to another" do
+      cluster = described_class.new(s).cluster
+      expect(cluster.serials.to_a.size).to eq(1)
+      described_class.new(s).move(c2)
+      expect(cluster.serials.to_a.size).to eq(0)
+      expect(c2.serials.to_a.size).to eq(1)
+    end
+  end
+end

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -96,12 +96,13 @@ RSpec.describe Cluster do
     let(:holding) { build(:holding) }
     let(:resolution) { build(:ocn_resolution) }
     let(:cluster) { create(:cluster) }
+
     before(:each) do
       cluster.ht_items << ht
       cluster.holdings << holding
       cluster.ocn_resolutions << resolution
     end
- 
+
     it "gathers all of the OCNs from it's embedded documents" do
       expect(cluster.collect_ocns).to include(*ht.ocns)
       expect(cluster.collect_ocns).to include(*holding.ocn)

--- a/spec/factories/ht_item.rb
+++ b/spec/factories/ht_item.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     ht_bib_key { rand(1_000_000) }
     rights { ["pd", "ic", "icus", "cc", "pdus"].sample }
     bib_fmt { ["m", "s", "r"].sample }
+    enum_chron { ["", "V.1"].sample }
   end
 end

--- a/spec/factories/serial.rb
+++ b/spec/factories/serial.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :serial do
+    record_id { rand(1_000_000) }
+    ocns { [rand(1_000_000)] }
+    issns { [rand(1_000_000).to_s] }
+    locations { ["BUHR", "HATCH", "SCI"].sample }
+  end
+end

--- a/spec/serial_record_spec.rb
+++ b/spec/serial_record_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "../bin/load_print_serials"
+
+RSpec.describe "load_print_serials" do
+  describe "#extract_issns" do
+    let(:i_field) { "2326-4810 | 2326-4845 (online)" }
+
+    it "splits an issn field" do
+      expect(extract_issns(i_field).first).to eq("2326-4810")
+      expect(extract_issns(i_field).last).to eq("2326-4845 (online)")
+    end
+  end
+
+  describe "#print_serial_to_record" do
+    let(:line) do
+      "000011035\t(OCoLC)ocm00754262 | (OCoLC)861791462 | "\
+      "(OCoLC)ocn861791462\t\tBUHR GRAD"
+    end
+
+    it "parses a tsv line" do
+      expect(print_serial_to_record(line)).to eq(
+        record_id: 11_035,
+        ocns: [754_262, 861_791_462],
+        issns: [],
+        locations: "BUHR GRAD"
+      )
+    end
+  end
+
+  describe "#extract_ocns" do
+    let(:o_field) { "(OCoLC)ocm023536349" }
+    let(:o_multi_field) { "(OCoLC)ocm00754262 | (OCoLC)861791462" }
+    let(:o_multi2) { "OCoLC)1755762 (OCoLC)24527036" }
+
+    it "filters out text from an OCN" do
+      expect(extract_ocns(o_field).first).to eq(23_536_349)
+    end
+
+    it "handles multiple ocns" do
+      expect(extract_ocns(o_multi_field).first).to eq(754_262)
+      expect(extract_ocns(o_multi_field).last).to eq(861_791_462)
+    end
+
+    it "handles multiple ocns without |" do
+      expect(extract_ocns(o_multi2).first).to eq(1_755_762)
+    end
+  end
+end

--- a/spec/serial_spec.rb
+++ b/spec/serial_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "serial"
+require "cluster"
+RSpec.describe Serial do
+  let(:c) { create(:cluster) }
+
+  it "does not have a parent" do
+    expect(build(:serial)._parent).to be_nil
+  end
+
+  it "has a parent" do
+    c.serials << build(:serial)
+    expect(c.serials.first._parent).to be(c)
+  end
+end


### PR DESCRIPTION
Adds the enum_chron field to ht_item which we need regardless.

This attempts to recreate existing behavior, https://tools.lib.umich.edu/confluence/pages/viewpage.action?pageId=84936606

Cluster format depends upon the print_serials file that is produced by Margaret on a monthly basis. These records are put into Cluster.new.serials with ClusterSerial which is essentially the same as all the other clustering services. 

CalculateFormat calculates the format for individual ht_items with calculate_item_format(ht_item) which depends on the format for other items in the cluster. It also calculates the format for the entire cluster with calculate_cluster_format which depends on the formats for individual ht items. 

Most of this should go away after we replicate the existing system. Bib format is already provided in the Hathifiles, and while it's not a perfect match to spm/mpm/ser it would be much simpler to map them. Also, Zephir clustering with the OCLC resolution table should eliminate instances of intra-cluster Bib format contradictions. 