### PR TITLE
Let bin/add_ht_items.rb run at all

### DIFF
--- a/bin/add_ht_items.rb
+++ b/bin/add_ht_items.rb
@@ -5,6 +5,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "bundler/setup"
 require "cluster_ht_item"
 require "ht_item"
+require 'ocn_resolution'
 
 Mongoid.load!("mongoid.yml", :test)
 
@@ -24,6 +25,7 @@ end
 File.open(ARGV.shift, "r:UTF-8").each do |line|
   rec = hathifile_to_record(line)
   h = HtItem.new(rec)
+  next if h.ocns.empty?
   c = ClusterHtItem.new(h).cluster
   c.save
 end


### PR DESCRIPTION
  * Add `ocn_resolution` model to requires
  * Skip HT items that don't have any OCNs to avoid
    error "E11000 duplicate key error collection: test.clusters index: ocns_1 dup key: { ocns: undefined } (11000) (on mongo:27017, legacy retry, attempt 1) (on mongo:27017, legacy retry, attempt 1) (Mongo::Error::OperationFailure)"