### PR TITLE
run travis tests via docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,12 @@
-# This is an example travis-ci config. It contains more than you need.
-# See the readme for how to enable travis-ci builds.
+language: minimal
 
-sudo: false
-language: ruby
-rvm:
-  - 2.5
-  - 2.6
+services:
+  - docker
 
-branches:
-  only:
-    - master
-    - develop
-
-before_install: gem install bundler
+before_install:
+  - docker-compose build
+  - docker-compose run --rm dev bundle install
+  - docker-compose up -d mongo_test
 
 script:
-  - bundle exec rspec
-
-# This adds an additional 'build' that is just the rubocop run
-matrix:
-  include:
-    - rvm: ruby-head
-      script: bin/rubocop
+  - docker-compose run --rm dev bundle exec rspec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,14 @@ services:
       - .:/usr/src/app
       - gem_cache:/gems
 
-  mongo:
+  mongo_dev:
     image: mongo
-    ports:
-      - '27017:27017'
     volumes:
       - data_db:/data/db
+
+  mongo_test:
+    image: mongo
+
 
 volumes:
   gem_cache:

--- a/mongoid.yml
+++ b/mongoid.yml
@@ -3,7 +3,7 @@ development:
     default:
       database: development
       hosts:
-        - mongo:27017
+        - mongo_dev:27017
   options:
     raise_not_found_error: false
 
@@ -12,6 +12,6 @@ test:
     default:
       database: test
       hosts:
-        - mongo:27017
+        - mongo_test:27017
   options:
     raise_not_found_error: false


### PR DESCRIPTION
Configures travis & adds mongo_test container separate from mongo_dev so that dev work doesn't stomp on test work.