### PR TITLE
HT-2365 Load concordance file, hathifiles, some amount of holdings data

### DIFF
--- a/bin/add_ht_items.rb
+++ b/bin/add_ht_items.rb
@@ -6,8 +6,13 @@ require "bundler/setup"
 require "cluster_ht_item"
 require "ht_item"
 require 'ocn_resolution'
+require 'zinzout'
+require 'utils/ppnum'
+require 'utils/waypoint'
 
 Mongoid.load!("mongoid.yml", :test)
+
+
 
 # Convert a tsv line from the hathifile into a record like hash
 #
@@ -22,10 +27,30 @@ def hathifile_to_record(hathifile_line)
     enum_chron: fields[4] }
 end
 
-File.open(ARGV.shift, "r:UTF-8").each do |line|
+logger = Logger.new(STDOUT)
+waypoint = Utils::Waypoint.new
+
+BATCH_SIZE = 10_000
+
+# rubocop:disable Layout/LineLength
+logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
+# rubocop:enable Layout/LineLength
+
+count = 0
+Zinzout.zin(ARGV.shift).each do |line|
+  count += 1
   rec = hathifile_to_record(line)
   h = HtItem.new(rec)
   next if h.ocns.empty?
   c = ClusterHtItem.new(h).cluster
   c.save
+
+  if (count % BATCH_SIZE).zero? && !count.zero?
+    waypoint.mark(count)
+    logger.info waypoint.batch_line
+  end
+
 end
+
+waypoint.mark(count)
+logger.info waypoint.final_line

--- a/bin/add_ocn_resolutions.rb
+++ b/bin/add_ocn_resolutions.rb
@@ -20,7 +20,9 @@ waypoint = Utils::Waypoint.new
 logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
 # rubocop:enable Layout/LineLength
 
-Zinzout.zin(ARGV.shift).each_with_index do |line, count|
+count = 0
+Zinzout.zin(ARGV.shift).each do |line|
+  count += 1
   (deprecated, resolved) = line.split.map(&:to_i)
   r = OCNResolution.new(deprecated: deprecated, resolved: resolved)
   c = ClusterOCNResolution.new(r).cluster
@@ -28,8 +30,10 @@ Zinzout.zin(ARGV.shift).each_with_index do |line, count|
 
   if (count % BATCH_SIZE).zero? && !count.zero?
     waypoint.mark(count)
-    # rubocop:disable Layout/LineLength
-    logger.info "#{ppnum(count, 10)}. This batch #{ppnum(waypoint.batch_records, 5)} in #{ppnum(waypoint.batch_seconds, 4, 1)}s (#{waypoint.batch_rate_str} r/s). Overall #{waypoint.total_rate_str} r/s."
-    # rubocop:enable Layout/LineLength
+    logger.info waypoint.batch_line
   end
 end
+
+waypoint.mark(count)
+logger.info waypoint.final_line
+

--- a/bin/add_print_holdings.rb
+++ b/bin/add_print_holdings.rb
@@ -7,10 +7,16 @@ Dotenv.load(".env")
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "bundler/setup"
 require "cluster_holding"
+require 'ocn_resolution'
 require "holding"
-require "pp"
+require 'utils/waypoint'
+require 'utils/ppnum'
+require 'zinzout'
+
 
 Mongoid.load!("mongoid.yml", :test)
+
+BATCH_SIZE=100
 
 # Convert a tsv line from a validated holding file into a record like hash
 #
@@ -29,11 +35,28 @@ def holding_to_record(holding_line)
     date_received:     DateTime.parse(fields[5]) }
 end
 
-File.open(ARGV.shift).each do |line|
+waypoint = Utils::Waypoint.new
+logger = Logger.new(STDOUT)
+
+# rubocop:disable Layout/LineLength
+logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
+# rubocop:enable Layout/LineLength
+
+count = 0
+Zinzout.zin(ARGV.shift).each do |line|
   next if /^OCN\tBIB/.match?(line)
 
+  count += 1
   rec = holding_to_record(line.chomp)
   h = Holding.new(rec)
   c = ClusterHolding.new(h).cluster
   c.save
+
+  if (count % BATCH_SIZE).zero? && !count.zero?
+    waypoint.mark(count)
+    logger.info waypoint.batch_line
+  end
 end
+
+waypoint.mark(count)
+logger.info waypoint.final_line

--- a/lib/utils/waypoint.rb
+++ b/lib/utils/waypoint.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+#
+require_relative 'ppnum'
 
 module Utils
   # Naive waypoint class, to keep track of progress over time for long-running
@@ -58,6 +60,24 @@ module Utils
       return "0" if @total_records.zero?
 
       format "%5.#{decimals}f", (@total_records / total_seconds)
+    end
+
+    def seconds_to_time_string(sec)
+      hours, leftover =  sec.divmod(3600)
+      minutes, secs = leftover.divmod(60)
+      format('%02dh %02dm %02ds', hours, minutes, secs)
+    end
+
+    def batch_line
+      # rubocop:disable Layout/LineLength
+      "#{ppnum(total_records, 10)}. This batch #{ppnum(batch_records, 5)} in #{ppnum(batch_seconds, 4, 1)}s (#{batch_rate_str} r/s). Overall #{total_rate_str} r/s."
+      # rubocop:enable Layout/LineLength
+    end
+
+    def final_line
+      # rubocop:disable Layout/LineLength
+      "Finished. #{ppnum(total_records, 10)} total records in #{seconds_to_time_string(total_seconds)}. Overall #{total_rate_str} r/s."
+      # rubocop:enable Layout/LineLength
     end
   end
 end


### PR DESCRIPTION
Finished sanity checks on all bin/add_* scripts

  * require 'ocn_resoultion' in `add_print_holdings`
  * update and make consistent logging across scripts

This marks the point at which the scripts at least tell me they've loaded from the
OCLC resolution, ht_items, and a holdings file, and spot checks seem to confirm. 

Should close out HT-2365 upon approval.