### PR TITLE
HT-2376 update / delete

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "canister"
 gem "dotenv"
 gem "mongo"
 gem "mongoid"
-gem 'zinzout'
+gem "zinzout"
 
 group :development, :test do
   gem "pry"

--- a/bin/add_ocn_resolutions.rb
+++ b/bin/add_ocn_resolutions.rb
@@ -36,4 +36,3 @@ end
 
 waypoint.mark(count)
 logger.info waypoint.final_line
-

--- a/bin/add_print_holdings.rb
+++ b/bin/add_print_holdings.rb
@@ -7,12 +7,11 @@ Dotenv.load(".env")
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "bundler/setup"
 require "cluster_holding"
-require 'ocn_resolution'
+require "ocn_resolution"
 require "holding"
-require 'utils/waypoint'
-require 'utils/ppnum'
-require 'zinzout'
-
+require "utils/waypoint"
+require "utils/ppnum"
+require "zinzout"
 
 Mongoid.load!("mongoid.yml", :test)
 

--- a/lib/ht_item.rb
+++ b/lib/ht_item.rb
@@ -34,7 +34,8 @@ class HtItem
       item_id:    item_id,
       ht_bib_key: ht_bib_key,
       rights:     rights,
-      bib_fmt:    bib_fmt
+      bib_fmt:    bib_fmt,
+      enum_chron: enum_chron
     }
   end
 

--- a/lib/reclusterer.rb
+++ b/lib/reclusterer.rb
@@ -14,7 +14,7 @@ class Reclusterer
   def recluster
     @cluster.delete
 
-    @cluster.ocn_resolutions.each { |r| ClusterOCNResolution.new(r).cluster.save }
+    @cluster.ocn_resolutions.each {|r| ClusterOCNResolution.new(r).cluster.save }
     @cluster.holdings.each {|h| ClusterHolding.new(h).cluster.save }
     @cluster.ht_items.each {|h| ClusterHtItem.new(h).cluster.save }
     @cluster.serials.each {|s| ClusterSerial.new(s).cluster.save }

--- a/lib/utils/waypoint.rb
+++ b/lib/utils/waypoint.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-#
-require_relative 'ppnum'
+
+require_relative "ppnum"
 
 module Utils
   # Naive waypoint class, to keep track of progress over time for long-running
@@ -63,9 +63,9 @@ module Utils
     end
 
     def seconds_to_time_string(sec)
-      hours, leftover =  sec.divmod(3600)
+      hours, leftover = sec.divmod(3600)
       minutes, secs = leftover.divmod(60)
-      format('%02dh %02dm %02ds', hours, minutes, secs)
+      format("%02dh %02dm %02ds", hours, minutes, secs)
     end
 
     def batch_line

--- a/spec/cluster_ht_item_spec.rb
+++ b/spec/cluster_ht_item_spec.rb
@@ -61,4 +61,65 @@ RSpec.describe ClusterHtItem do
       expect(c2.ht_items.to_a.size).to eq(1)
     end
   end
+
+  describe "#delete" do
+    let(:ht2) { build(:ht_item, ocns: ht.ocns) }
+
+    before(:each) do
+      Cluster.each(&:delete)
+      c.save
+    end
+
+    it "removes the cluster if it's only that htitem" do
+      described_class.new(ht).cluster
+      expect(Cluster.each.to_a.size).to eq(1)
+      described_class.new(ht).delete
+      expect(Cluster.each.to_a.size).to eq(0)
+    end
+
+    it "creates a new cluster without the ht_item" do
+      described_class.new(ht).cluster
+      cluster = described_class.new(ht2).cluster
+      expect(cluster.ht_items.to_a.size).to eq(2)
+      described_class.new(ht).delete
+      expect(Cluster.each.to_a.first.ht_items.to_a.size).to eq(1)
+      expect(Cluster.each.to_a.first).not_to eq(cluster)
+    end
+  end
+
+  describe "#update" do
+    context "with HT2 as an update to HT" do
+      let(:ht2) { build(:ht_item, item_id: ht.item_id) }
+
+      before(:each) do
+        Cluster.each(&:delete)
+      end
+
+      it "removes the old cluster" do
+        first = described_class.new(ht).cluster
+        described_class.new(ht2).update
+        expect(Cluster.each.to_a.size).to eq(1)
+        new_cluster = Cluster.each.to_a.first
+        expect(new_cluster).not_to eq(first)
+        expect(new_cluster.ht_items.first).to eq(ht2)
+      end
+    end
+
+    context "with HT2 with the same OCNS as HT" do
+      let(:ht2) { build(:ht_item, item_id: ht.item_id, ocns: ht.ocns) }
+
+      before(:each) do
+        Cluster.each(&:delete)
+      end
+
+      it "only updates the HT Item" do
+        first = described_class.new(ht).cluster
+        updated = described_class.new(ht2).update
+        expect(first).to eq(updated)
+        expect(
+          Cluster.each.to_a.first.ht_items.first.to_hash
+        ).to eq(ht2.to_hash)
+      end
+    end
+  end
 end

--- a/spec/cluster_ocn_resolution_spec.rb
+++ b/spec/cluster_ocn_resolution_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe ClusterOCNResolution do
          resolution.resolved,
          resolution2.deprecated].each do |ocn|
            ClusterHtItem.new(build(:ht_item, ocns: [ocn])).cluster.save
-        end
+         end
       end
 
       it "creates a new cluster with the deprecated OCN from the deleted rule" do
@@ -121,17 +121,18 @@ RSpec.describe ClusterOCNResolution do
         described_class.new(resolution2).delete
 
         cluster_htitem_ocns = Cluster.where(ocns: resolution.resolved)
-          .first.ht_items.map { |h| h.ocns }
+          .first.ht_items.map(&:ocns)
 
         expect(cluster_htitem_ocns).to contain_exactly(
-          [resolution.deprecated],[resolution.resolved])
+          [resolution.deprecated], [resolution.resolved]
+)
       end
 
       it "cluster with deprecated OCN from deleted rule has correct HtItem" do
         described_class.new(resolution2).delete
 
         cluster_htitem_ocns = Cluster.where(ocns: resolution2.deprecated)
-          .first.ht_items.map { |h| h.ocns }
+          .first.ht_items.map(&:ocns)
 
         expect(cluster_htitem_ocns).to contain_exactly([resolution2.deprecated])
       end

--- a/spec/cluster_serial_spec.rb
+++ b/spec/cluster_serial_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "cluster_serial"
-require "pp"
+
 RSpec.describe ClusterSerial do
   let(:s) { build(:serial) }
   let(:c) { create(:cluster, ocns: s.ocns) }


### PR DESCRIPTION
Uses reclusterer. Delete is similar to OCNResolution delete, but searches for item_id instead of OCN. ClusterHTItem.update deletes then clusters updated record. 