### PR TITLE
HT-2383 create clusters for HTItems w/o OCNs

### DIFF
--- a/bin/add_ht_items.rb
+++ b/bin/add_ht_items.rb
@@ -48,7 +48,6 @@ Zinzout.zin(filename).each do |line|
   count += 1
   rec = hathifile_to_record(line)
   h = HtItem.new(rec)
-  next if h.ocns.empty?
 
   c = if update
     ClusterHtItem.new(h).update

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -4,6 +4,7 @@ require "mongoid"
 require "holding"
 require "ht_item"
 require "commitment"
+require "ocn_resolution"
 require "serial"
 
 # A set of identifiers (e.g. OCLC numbers),
@@ -21,7 +22,9 @@ class Cluster
   embeds_many :ocn_resolutions, class_name: "OCNResolution"
   embeds_many :serials, class_name: "Serial"
   embeds_many :commitments
-  index({ ocns: 1 }, unique: true)
+  index({ ocns: 1 },
+        unique: true,
+        partial_filter_expression: { "ocns.0": { :$exists => true } })
   index({ "ht_items.item_id": 1 }, unique: true, sparse: true)
   index({ "ocn_resolutions.ocns": 1 }, unique: true, sparse: true)
   scope :for_resolution, lambda {|resolution|

--- a/lib/cluster_ht_item.rb
+++ b/lib/cluster_ht_item.rb
@@ -14,7 +14,8 @@ class ClusterHtItem
 
   # Cluster the HTItem
   def cluster
-    c = (Cluster.merge_many(Cluster.where(ocns: { "$in": @ht_item.ocns })) ||
+    c = (@ht_item.ocns.any? &&
+         Cluster.merge_many(Cluster.where(ocns: { "$in": @ht_item.ocns })) ||
          Cluster.new(ocns: @ht_item.ocns).tap(&:save))
     c.ht_items << @ht_item
     c.ocns = c.ht_items.collect(&:ocns).flatten.uniq

--- a/lib/ht_item.rb
+++ b/lib/ht_item.rb
@@ -11,7 +11,7 @@ require "mongoid"
 # - enum_chron
 class HtItem
   include Mongoid::Document
-  field :ocns, type: Array
+  field :ocns, type: Array, default: []
   field :item_id, type: String
   field :ht_bib_key, type: Integer
   field :rights, type: String
@@ -20,7 +20,7 @@ class HtItem
 
   embedded_in :cluster
   validates :item_id, uniqueness: true
-  validates_presence_of :ocns, :item_id, :ht_bib_key, :rights, :bib_fmt
+  validates_presence_of :item_id, :ht_bib_key, :rights, :bib_fmt
   validates_each :ocns do |record, attr, value|
     value.each do |ocn|
       record.errors.add attr, "must be an integer" \

--- a/spec/cluster_holding_spec.rb
+++ b/spec/cluster_holding_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "cluster_holding"
-require "pp"
 RSpec.describe ClusterHolding do
   let(:h) { build(:holding) }
   let(:c) { create(:cluster, ocns: [h.ocn]) }

--- a/spec/ht_item_spec.rb
+++ b/spec/ht_item_spec.rb
@@ -43,4 +43,8 @@ RSpec.describe HtItem do
     c.ht_items.create(ht_multi_ocns)
     expect(c.ocns.count).to eq(2)
   end
+
+  it "can have an empty ocns field" do
+    expect(build(:ht_item, ocns: []).valid?).to be true
+  end
 end


### PR DESCRIPTION
HT Items without OCNs now create a bare bones Cluster when added. They will not cluster with anything else. Updates to HT Items are keyed on item_id. 

This required changes to the Cluster.ocns index, HTItem.ocns validation, and a minor change to HTItem clustering. 