### PR TITLE
Ht 2428 (n_enum & n_chron for mpms)

### DIFF
--- a/bin/add_ht_items.rb
+++ b/bin/add_ht_items.rb
@@ -17,12 +17,14 @@ Mongoid.load!("mongoid.yml", :test)
 # @param hathifile_line, a tsv line
 def hathifile_to_record(hathifile_line)
   fields = hathifile_line.split(/\t/)
-  {item_id: fields[0],
-   ocns: fields[7].split(",").map(&:to_i),
-   ht_bib_key: fields[3].to_i,
-   rights: fields[2],
-   bib_fmt: fields[19],
-   enum_chron: fields[4]}
+  {
+    item_id:    fields[0],
+    ocns:       fields[7].split(",").map(&:to_i),
+    ht_bib_key: fields[3].to_i,
+    rights:     fields[2],
+    bib_fmt:    fields[19],
+    enum_chron: fields[4]
+  }
 end
 
 
@@ -37,6 +39,13 @@ logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BAT
 
 count = 0
 update = ARGV[0] == "-u"
+clean  = ARGV.include?("--clean")
+
+if clean
+  logger.info "Removing clusters first"
+  Cluster.each(&:delete)
+end
+
 if update
   filename = ARGV[1]
   logger.info "Updating HT Items."

--- a/lib/enum_chron_parser.rb
+++ b/lib/enum_chron_parser.rb
@@ -51,7 +51,8 @@ class EnumChronParser
     @chron = []
   end
 
-  def preprocess(str)
+  def preprocess(str_o)
+    str = str_o.dup
     str.tr! ",", " "
     str.tr! ":", " "
     str.delete! ";"
@@ -63,6 +64,7 @@ class EnumChronParser
     # recover the 'n.s.' pattern
     newstr.sub!("n.s.", "n.s. ")
     newstr.gsub!(/\s\s/, " ")
+    return newstr
   end
 
   def dot_sub(mstr)
@@ -190,7 +192,7 @@ class EnumChronParser
     clear_fields
 
     # preprocess
-    pstr = preprocess(input_str)
+    input_str = preprocess(input_str)
 
     ### classify enum vs chron ###
     begin

--- a/lib/ht_item.rb
+++ b/lib/ht_item.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "mongoid"
+require "enum_chron_parser"
 
 # An HT Item
 # - ocns
@@ -9,6 +10,9 @@ require "mongoid"
 # - rights
 # - bib_fmt
 # - enum_chron
+# - n_enum
+# - n_chron
+
 class HtItem
   include Mongoid::Document
   field :ocns, type: Array, default: []
@@ -17,14 +21,33 @@ class HtItem
   field :rights, type: String
   field :bib_fmt, type: String
   field :enum_chron, type: String
+  field :n_enum, type: String
+  field :n_chron, type: String
 
   embedded_in :cluster
   validates :item_id, uniqueness: true
   validates_presence_of :item_id, :ht_bib_key, :rights, :bib_fmt
+
   validates_each :ocns do |record, attr, value|
     value.each do |ocn|
       record.errors.add attr, "must be an integer" \
         unless (ocn.to_i if /\A[+-]?\d+\Z/.match?(ocn.to_s))
+    end
+  end
+
+  def initialize(params=nil)
+    super
+    normalize_enum_chron
+  end
+
+  def normalize_enum_chron
+    # When created with an enumchron, normalize it into separate
+    # n_enum and n_chron
+    if !enum_chron.nil?
+      ec_parser = EnumChronParser.new
+      ec_parser.parse(enum_chron)
+      self.n_enum  = ec_parser.normalized_enum
+      self.n_chron = ec_parser.normalized_chron
     end
   end
 
@@ -35,8 +58,9 @@ class HtItem
       ht_bib_key: ht_bib_key,
       rights:     rights,
       bib_fmt:    bib_fmt,
-      enum_chron: enum_chron
+      enum_chron: enum_chron,
+      n_enum:     n_enum,
+      n_chron:    n_chron
     }
   end
-
 end

--- a/spec/ht_item_spec.rb
+++ b/spec/ht_item_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-
 require "ht_item"
 require "cluster"
+
 RSpec.describe HtItem do
   let(:ocn_rand) { rand(1_000_000).to_i }
   let(:item_id_rand) { rand(1_000_000).to_s }
@@ -47,4 +47,25 @@ RSpec.describe HtItem do
   it "can have an empty ocns field" do
     expect(build(:ht_item, ocns: []).valid?).to be true
   end
+
+  it "normalizes enum_chron" do
+    cloned = htitem_hash
+    enumchron_input = "v.1 Jul 1999"
+    cloned[:enum_chron] = enumchron_input
+    c.ht_items.create(cloned)
+    expect(c.ht_items.first.enum_chron).to eq(enumchron_input)
+    expect(c.ht_items.first.n_enum).to eq("1")
+    expect(c.ht_items.first.n_chron).to eq("Jul 1999")
+  end
+
+  it "does nothing if given an empty enum_chron" do
+    cloned = htitem_hash
+    enumchron_input = ""
+    cloned[:enum_chron] = enumchron_input
+    c.ht_items.create(cloned)
+    expect(c.ht_items.first.enum_chron).to eq(enumchron_input)
+    expect(c.ht_items.first.n_enum).to eq(nil)
+    expect(c.ht_items.first.n_chron).to eq(nil)
+  end
+
 end


### PR DESCRIPTION
Added n_enum and n_chron to ht_items. They are populated by the enumchronparser (such as it is) when an ht_item is created with a enum_chron value.

Based on the changes in the autoscrub branch (where the enumchronparser first got added) which hasn't been merged to master yet.