### PR TITLE
Update holdings records, delete old holdings

### DIFF
--- a/lib/cluster_holding.rb
+++ b/lib/cluster_holding.rb
@@ -24,4 +24,39 @@ class ClusterHolding
     end
   end
 
+  # Updates a matching holding or adds it
+  def update
+    c = Cluster.find_by(ocns: @holding.ocn)
+    return cluster unless c
+
+    old_holding = c.holdings.to_a.find do |h|
+      h == @holding && h.date_received != @holding.date_received
+    end
+    if old_holding
+      old_holding.update_attributes(date_received: @holding.date_received)
+    else
+      c = cluster
+    end
+    c
+  end
+
+  def delete
+    c = Cluster.find_by(ocns: @holding.ocn)
+    @holding.delete
+    c.save
+    c.reload
+    c.delete unless c._children.any?
+  end
+
+  def self.delete_old_holdings(org, date)
+    Cluster.where(
+      "holdings.organization": org,
+      "holdings.date_received": { "$lt": date }
+    ).each do |c|
+      c.holdings.select do |h|
+        h.organization == org && h.date_received < date
+      end.map {|h| ClusterHolding.new(h).delete }
+    end
+  end
+
 end

--- a/lib/holding.rb
+++ b/lib/holding.rb
@@ -5,6 +5,7 @@ require "mongoid"
 # A member holding
 class Holding
   include Mongoid::Document
+  # Changes to the field list must be reflected in `==` and `same_as`
   field :ocn, type: Integer
   field :organization, type: String
   field :local_id, type: String
@@ -19,7 +20,6 @@ class Holding
 
   validates_presence_of :ocn, :organization, :mono_multi_serial, :date_received
   validates_inclusion_of :mono_multi_serial, in: ["mono", "multi", "serial"]
-
 
   # Convert a tsv line from a validated holding file into a record like hash
   #
@@ -40,7 +40,27 @@ class Holding
 
   def self.new_from_holding_file_line(line)
     rec = holding_to_record(line.chomp)
-    self.new(rec)
+    new(rec)
   end
 
+  # Is false when any field other than date_received is not the same
+  #
+  # @param other, another holding
+  def ==(other)
+    ocn == other.ocn &&
+      organization == other.organization &&
+      local_id == other.local_id &&
+      enum_chron == other.enum_chron &&
+      status == other.status &&
+      condition == other.condition &&
+      gov_doc_flag == other.gov_doc_flag &&
+      mono_multi_serial == other.mono_multi_serial
+  end
+
+  # Is true when all fields match
+  #
+  # @param other, another holding
+  def same_as?(other)
+    (self == other) && (date_received == other.date_received)
+  end
 end

--- a/spec/cluster_holding_spec.rb
+++ b/spec/cluster_holding_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe ClusterHolding do
     it "adds a holding to an existing cluster" do
       cluster = described_class.new(h).cluster
       expect(cluster.holdings.first._parent.id).to eq(c.id)
-      expect(cluster.holdings.to_a.size).to eq(1)
-      expect(Cluster.each.to_a.size).to eq(1)
+      expect(cluster.holdings.count).to eq(1)
+      expect(Cluster.count).to eq(1)
     end
 
     it "creates a new cluster if no match is found" do
       expect(described_class.new(build(:holding)).cluster.id).not_to eq(c.id)
-      expect(Cluster.each.to_a.size).to eq(2)
+      expect(Cluster.count).to eq(2)
     end
   end
 
@@ -36,10 +36,140 @@ RSpec.describe ClusterHolding do
 
     it "moves a holding from one cluster to another" do
       cluster = described_class.new(h).cluster
-      expect(cluster.holdings.to_a.size).to eq(1)
+      expect(cluster.holdings.count).to eq(1)
       described_class.new(h).move(c2)
-      expect(cluster.holdings.to_a.size).to eq(0)
-      expect(c2.holdings.to_a.size).to eq(1)
+      expect(cluster.holdings.count).to eq(0)
+      expect(c2.holdings.count).to eq(1)
+    end
+  end
+
+  describe "#update" do
+    let(:h2) { h.clone }
+    let(:h3) { h.clone }
+
+    before(:each) do
+      Cluster.each(&:delete)
+      c.save
+      h.date_received = Date.yesterday
+    end
+
+    it "updates an existing holding" do
+      old_date = h.date_received
+      described_class.new(h).cluster
+      cluster = Cluster.first
+      expect(cluster.holdings.first.date_received).to eq(old_date)
+      h2.date_received = Date.today
+      described_class.new(h2).update
+      cluster = Cluster.first
+      expect(cluster.holdings.first.date_received).not_to eq(old_date)
+      expect(cluster.holdings.first.date_received).to eq(h2.date_received)
+    end
+
+    it "updates only one existing holding" do
+      described_class.new(h).cluster
+      described_class.new(h.clone).cluster
+      h2.date_received = Date.today
+      described_class.new(h2).update
+      cluster = Cluster.first
+      expect(cluster.holdings.first.date_received).to eq(h2.date_received)
+      expect(cluster.holdings.last.date_received).not_to \
+        eq(h2.date_received)
+    end
+
+    it "does not update already updated holding" do
+      described_class.new(h).cluster
+      h2.date_received = Date.today
+      described_class.new(h2).update
+      cluster = Cluster.first
+      expect(cluster.holdings.first.date_received).to eq(h2.date_received)
+      h3.date_received = h2.date_received
+      described_class.new(h3).update
+      cluster = Cluster.first
+      expect(cluster.holdings.count).to eq(2)
+    end
+  end
+
+  describe "#delete" do
+    before(:each) do
+      Cluster.each(&:delete)
+    end
+
+    it "deletes the parent cluster if it has nothing else" do
+      cluster = described_class.new(h).cluster
+      expect(Cluster.count).to eq(1)
+      holding = cluster.holdings.first
+      described_class.new(holding).delete
+      expect(Cluster.count).to eq(0)
+    end
+
+    it "does not delete the parent cluster if it has something else" do
+      described_class.new(h).cluster
+      cluster = described_class.new(h.clone).cluster
+      expect(Cluster.count).to eq(1)
+      holding = cluster.holdings.first
+      described_class.new(holding).delete
+      expect(Cluster.count).to eq(1)
+    end
+  end
+
+  describe "#delete_old_holdings" do
+    let(:past_date) { DateTime.parse("2019-10-24") }
+    let(:current_date) { DateTime.parse("2020-03-25") }
+    let(:old1) do
+      build(:holding,
+            status: "CH",
+            date_received: past_date)
+    end
+    let(:old2) { old1.clone }
+    let(:new1) { old1.clone }
+    let(:new2) { old1.clone }
+    let(:c) { described_class.new(old1).cluster }
+
+    before(:each) do
+      Cluster.each(&:delete)
+    end
+
+    it "deletes old when cluster has new and updated " do
+      c.save
+      described_class.new(old2).cluster
+      new1.date_received = current_date
+      new2.date_received = current_date
+      # replaces first old record
+      described_class.new(new1).update
+      # adds new record
+      new2.status = "WD"
+      described_class.new(new2).update
+      c.save
+      expect(Cluster.first.holdings.size).to eq(3)
+      described_class.delete_old_holdings(old1.organization, new2.date_received)
+      clust = Cluster.first
+      expect(clust.holdings.size).to eq(2)
+      expect(clust.holdings.pluck(:date_received)).to \
+        eq([current_date, current_date])
+    end
+
+    it "deletes all old records from a cluster" do
+      old_date = DateTime.parse("2019-10-24")
+      new_date = DateTime.parse("2020-03-25")
+      h = build(:holding, date_received: old_date)
+      c = described_class.new(h).cluster
+      c.save
+      c = described_class.new(h.clone).cluster
+      c.save
+      c = described_class.new(h.clone).cluster
+      c.save
+      new_copy = h.clone
+      new_copy.date_received = new_date
+      c = described_class.new(new_copy).update
+      c.save
+      clust = Cluster.first
+      expect(clust.holdings.pluck(:date_received)).to \
+        eq([new_date, old_date, old_date])
+      described_class.delete_old_holdings(h.organization,
+                                          new_copy.date_received)
+      clust = Cluster.first
+      expect(clust.holdings.pluck(:date_received)).to \
+        eq([new_date])
     end
   end
 end

--- a/spec/factories/holding.rb
+++ b/spec/factories/holding.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     organization { ["umich", "carleton", "smu"].sample }
     local_id { rand(1_000_000).to_s }
     mono_multi_serial { ["mono", "multi", "serial"].sample }
-    date_received { DateTime.now }
+    date_received { Date.today }
   end
 end

--- a/spec/holding_spec.rb
+++ b/spec/holding_spec.rb
@@ -4,6 +4,8 @@ require "holding"
 require "cluster"
 RSpec.describe Holding do
   let(:c) { create(:cluster) }
+  let(:h) { build(:holding) }
+  let(:h2) { h.clone }
 
   it "does not have a parent" do
     expect(build(:holding)._parent).to be_nil
@@ -12,5 +14,29 @@ RSpec.describe Holding do
   it "has a parent" do
     c.holdings << build(:holding)
     expect(c.holdings.first._parent).to be(c)
+  end
+
+  describe "#==" do
+    it "== is true if all fields match except date_received" do
+      h2.date_received = Date.yesterday
+      expect(h == h2).to be(true)
+    end
+
+    it "== is true if all fields match including date_received" do
+      expect(h == h2).to be(true)
+    end
+  end
+
+  describe "#same_as?" do
+    let(:h2) { h.clone }
+
+    it "same_as is true if all fields match" do
+      expect(h.same_as?(h2)).to be(true)
+    end
+
+    it "same_as is not true if date_received does not match" do
+      h2.date_received = Date.yesterday
+      expect(h.same_as?(h2)).to be(false)
+    end
   end
 end


### PR DESCRIPTION
Adds the option to update holdings with bin/add_print_holdings.rb

ClusterHolding.new(h).update finds a matching holdings record and updates its received_date, or adds it if none can be found. For our purposes matching means all fields are identical except date_received. This overrides Holding's == method. 

After updating holdings records, bin/add_print_holdings.rb deletes any remaining holdings from the particular organization and an older date_received. 

While testing it was discovered the Cluster.ocns index was not being used resulting in full column scans. The partial filter has been changed from "ocns.0" : {$exists:1} to ocns :{$gt:1}