### PR TITLE
Fix Cluster ocns index to prevent collscans

### DIFF
--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -24,7 +24,7 @@ class Cluster
   embeds_many :commitments
   index({ ocns: 1 },
         unique: true,
-        partial_filter_expression: { "ocns.0": { :$exists => true } })
+        partial_filter_expression: { ocns: { :$gt => 0 } })
   index({ "ht_items.item_id": 1 }, unique: true, sparse: true)
   index({ "ocn_resolutions.ocns": 1 }, unique: true, sparse: true)
   scope :for_resolution, lambda {|resolution|


### PR DESCRIPTION
One line change to the ocns index for clusters. "ocns.0" prevents usage for general ocn queries. Ocns $gt > 0 ensures non-existent OCNs aren't indexed and the resulting duplicate key error, while still being used for queries. 

This was claimed in PR 28 (HT-2378), but was omitted accidentally during some ham-fisted git operations. It didn't have any particular relationship to said ticket anyway. 