### PR TITLE
First attempt at generating holdings overlap reports

### DIFF
--- a/bin/add_ht_items.rb
+++ b/bin/add_ht_items.rb
@@ -18,12 +18,13 @@ Mongoid.load!("mongoid.yml", :test)
 def hathifile_to_record(hathifile_line)
   fields = hathifile_line.split(/\t/)
   {
-    item_id:    fields[0],
-    ocns:       fields[7].split(",").map(&:to_i),
-    ht_bib_key: fields[3].to_i,
-    rights:     fields[2],
-    bib_fmt:    fields[19],
-    enum_chron: fields[4]
+    item_id:               fields[0],
+    ocns:                  fields[7].split(",").map(&:to_i),
+    ht_bib_key:            fields[3].to_i,
+    rights:                fields[2],
+    bib_fmt:               fields[19],
+    enum_chron:            fields[4],
+    content_provider_code: fields[21]
   }
 end
 

--- a/bin/export_overlap_report.rb
+++ b/bin/export_overlap_report.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "dotenv"
+Dotenv.load(".env")
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+require "bundler/setup"
+require "ocn_resolution"
+require "holding"
+require "utils/waypoint"
+require "utils/ppnum"
+require "zinzout"
+require "cluster_overlap"
+
+Mongoid.load!("mongoid.yml", :test)
+
+# Find clusters that match the given org or all
+def matching_clusters(org = nil)
+  if org.nil?
+    Cluster.where("ht_items.0": { "$exists": 1 })
+  else
+    Cluster.where("ht_items.0": { "$exists": 1 },
+              "$or": [{ "holdings.organization": org },
+                      { "ht_items.content_provider_code": org }])
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  BATCH_SIZE = 10_000
+  waypoint = Utils::Waypoint.new(BATCH_SIZE)
+  logger = Logger.new(STDOUT)
+  logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
+
+  org = ARGV.shift
+  matching_clusters(org).each do |c|
+    ClusterOverlap.new(c, organization).each do |overlap|
+      waypoint.incr
+      h = overlap.to_hash
+      puts [h[:cluster_id],
+            h[:volume_id],
+            h[:member_id],
+            h[:copy_count],
+            h[:brt_count],
+            h[:wd_count],
+            h[:lm_count],
+            h[:access_count]].join("\t")
+      waypoint.on_batch {|wp| logger.info wp.batch_line }
+    end
+  end
+  logger.info waypoint.final_line
+end

--- a/lib/cluster_overlap.rb
+++ b/lib/cluster_overlap.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "cluster"
+require "calculate_format"
+
+# Collects overlap records for every ht_item in a cluster
+class ClusterOverlap
+
+  def initialize(cluster, orgs = nil)
+    @cluster = cluster
+    @orgs = orgs.nil? ? organizations_in_cluster : [orgs].flatten
+  end
+
+  def each
+    return enum_for(:each) unless block_given?
+
+    @cluster.ht_items.each do |ht_item|
+      @orgs.each do |org|
+        overlap = overlap_record(ht_item, org)
+        if overlap.copy_count.nonzero?
+          yield overlap
+        end
+      end
+    end
+  end
+
+  def overlap_record(ht_item, org)
+    if CalculateFormat.new(@cluster).cluster_format == "ser"
+      SerialOverlap.new(@cluster, org, ht_item)
+    elsif CalculateFormat.new(@cluster).cluster_format == "spm"
+      SinglePartOverlap.new(@cluster, org, ht_item)
+    elsif CalculateFormat.new(@cluster).cluster_format == "mpm"
+      MultiPartOverlap.new(@cluster, org, ht_item)
+    elsif CalculateFormat.new(@cluster).cluster_format == "ser/spm"
+      SinglePartOverlap.new(@cluster, org, ht_item)
+    end
+  end
+
+  def organizations_in_cluster
+    (@cluster.holdings.pluck(:organization) +
+ @cluster.ht_items.pluck(:content_provider_code)).uniq
+  end
+end

--- a/lib/holding.rb
+++ b/lib/holding.rb
@@ -10,6 +10,8 @@ class Holding
   field :organization, type: String
   field :local_id, type: String
   field :enum_chron, type: String
+  field :n_enum, type: String, default: ""
+  field :n_chron, type: String
   field :status, type: String
   field :condition, type: String
   field :gov_doc_flag, type: Boolean
@@ -35,6 +37,8 @@ class Holding
       condition:         fields[4],
       gov_doc_flag:      !fields[10].to_i.zero?,
       mono_multi_serial: fields[7],
+      n_enum:            fields[8],
+      n_chron:           fields[9],
       date_received:     DateTime.parse(fields[5]) }
   end
 

--- a/lib/ht_item.rb
+++ b/lib/ht_item.rb
@@ -22,6 +22,7 @@ class HtItem
   field :enum_chron, type: String
   field :n_enum, type: String
   field :n_chron, type: String
+  field :content_provider_code, type: String
 
   embedded_in :cluster
   validates :item_id, uniqueness: true

--- a/lib/multi_part_overlap.rb
+++ b/lib/multi_part_overlap.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "overlap"
+
+# Overlap record for items in MPM clusters
+class MultiPartOverlap < Overlap
+
+  def copy_count
+    cc = matching_holdings.count
+    if cc.zero? && (@ht_item.content_provider_code == @org)
+      1
+    else
+      cc
+    end
+  end
+
+  def brt_count
+    matching_holdings.where(condition: "brt").count
+  end
+
+  def wd_count
+    matching_holdings.where(status: "wd").count
+  end
+
+  def lm_count
+    matching_holdings.where(status: "lm").count
+  end
+
+  # Number of holdings with brt or lm
+  def access_count
+    matching_holdings.where("$or": [{ status: "lm" }, { condition: "brt" }]).count
+  end
+
+  def matching_holdings
+    if @ht_item.n_enum.nil? || (@ht_item.n_enum == "")
+      @cluster.holdings.where(organization: @org)
+    else
+      @cluster.holdings.where(organization: @org,
+                              "$or": [{ n_enum: @ht_item.n_enum }, { n_enum: "" }])
+    end
+  end
+
+end

--- a/lib/overlap.rb
+++ b/lib/overlap.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "cluster"
+
+# The most basic overlap record
+# Inherited by SinglePartOverlap and MultiPartOverlap and used for Serials
+class Overlap
+
+  def initialize(cluster, org, ht_item)
+    @cluster = cluster
+    @org = org
+    @ht_item = ht_item
+  end
+
+  # These methods should return an empty string in the most basic case
+  ["copy", "brt", "wd", "lm", "access"].each do |method|
+    define_method "#{method}_count".to_sym do
+      ""
+    end
+  end
+
+  def to_hash
+    {
+      cluster_id:   @cluster._id.to_s,
+      volume_id:    @ht_item.item_id,
+      member_id:    @org,
+      copy_count:   copy_count,
+      brt_count:    brt_count,
+      wd_count:     wd_count,
+      lm_count:     lm_count,
+      access_count: access_count
+    }
+  end
+end

--- a/lib/serial_overlap.rb
+++ b/lib/serial_overlap.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "cluster"
+require "overlap"
+
+# Overlap record for items in Serial clusters
+class SerialOverlap < Overlap
+
+  # These methods should return an empty string in the most basic case
+  def copy_count
+    cc = @cluster.holdings.where(organization: @org).count
+    if !cc.zero? || (@ht_item.content_provider_code == @org)
+      1
+    else
+      0
+    end
+  end
+
+end

--- a/lib/single_part_overlap.rb
+++ b/lib/single_part_overlap.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "overlap"
+
+# Overlap record for items in SPM clusters
+class SinglePartOverlap < Overlap
+
+  def copy_count
+    cc = @cluster.holdings.where(organization: @org).count
+    if cc.zero? && (@ht_item.content_provider_code == @org)
+      1
+    else
+      cc
+    end
+  end
+
+  def brt_count
+    @cluster.holdings.where(organization: @org, condition: "brt").count
+  end
+
+  def wd_count
+    @cluster.holdings.where(organization: @org, status: "wd").count
+  end
+
+  def lm_count
+    @cluster.holdings.where(organization: @org, status: "lm").count
+  end
+
+  # Number of holdings with brt or lm
+  def access_count
+    @cluster.holdings.where(
+      organization: @org, "$or": [{ status: "lm" }, { condition: "brt" }]
+    ).count
+  end
+
+end

--- a/spec/cluster_overlap_spec.rb
+++ b/spec/cluster_overlap_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "cluster_overlap"
+
+RSpec.describe ClusterOverlap do
+  let(:c) { build(:cluster) }
+  let(:spm) { build(:ht_item, ocns: c.ocns, enum_chron: "", content_provider_code: "ucr") }
+  let(:holding) { build(:holding, ocn: c.ocns.first, organization: "umich") }
+  let(:holding2) do
+    build(:holding,
+          ocn: c.ocns.first,
+            organization: "smu",
+            condition: "brt")
+  end
+
+  before(:each) do
+    Cluster.each(&:delete)
+    c.save
+    ClusterHtItem.new(spm).cluster.tap(&:save)
+    ClusterHolding.new(holding).cluster.tap(&:save)
+    ClusterHolding.new(holding2).cluster.tap(&:save)
+  end
+
+  describe "#each" do
+    it "provides an overlap for each ht_item" do
+      overlap = described_class.new(Cluster.first, ["smu", "umich"])
+      expect(overlap.each.count).to eq(2)
+      overlap.each do |rec|
+        expect(rec.to_hash[:volume_id]).to eq(spm.item_id)
+        expect(rec.to_hash[:copy_count]).to eq(1)
+      end
+    end
+
+    it "filters based on org" do
+      overlap = described_class.new(Cluster.first, "smu")
+      expect(overlap.each.count).to eq(1)
+    end
+
+    it "returns everything if we don't give it an org" do
+      overlap = described_class.new(Cluster.first)
+      expect(overlap.each.count).to eq(3)
+    end
+  end
+
+  describe "#organization_in_cluster" do
+    it "collects all of the organizations found in the cluster" do
+      expect(described_class.new(Cluster.first).organizations_in_cluster).to \
+        eq(["umich", "smu", "ucr"])
+    end
+  end
+end

--- a/spec/factories/holding.rb
+++ b/spec/factories/holding.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     local_id { rand(1_000_000).to_s }
     mono_multi_serial { ["mono", "multi", "serial"].sample }
     date_received { Date.today }
+    condition { "" }
   end
 end

--- a/spec/holding_spec.rb
+++ b/spec/holding_spec.rb
@@ -39,4 +39,14 @@ RSpec.describe Holding do
       expect(h.same_as?(h2)).to be(false)
     end
   end
+
+  describe "#new_from_holding_file_line" do
+    it "turns a holdings file line into a new Holding" do
+      line = "100000252\t005556200\tumich\tCH\t\t2019-10-24\t\tmono\t\t\t\t0"
+      rec = described_class.new_from_holding_file_line(line)
+      expect(rec).to be_a(described_class)
+      expect(rec.mono_multi_serial).to eq("mono")
+      expect(rec.n_enum).to eq("")
+    end
+  end
 end

--- a/spec/multi_part_overlap_spec.rb
+++ b/spec/multi_part_overlap_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "multi_part_overlap"
+
+RSpec.describe MultiPartOverlap do
+  let(:c) { build(:cluster) }
+  let(:ht_w_ec) { build(:ht_item, ocns: c.ocns, bib_fmt: "mpm", n_enum: "1") }
+  let(:ht_wo_ec) { build(:ht_item, ocns: c.ocns, bib_fmt: "mpm", n_enum: "") }
+  let(:h_w_ec) { build(:holding, ocn: c.ocns.first, n_enum: "1") }
+  let(:h_wo_ec) { build(:holding, ocn: c.ocns.first, n_enum: "") }
+  let(:h_wrong_ec) { build(:holding, ocn: c.ocns.first, n_enum: "2") }
+  let(:h_lm) do
+    build(:holding,
+          ocn: c.ocns.first,
+            organization: h_w_ec.organization,
+            n_enum: "1",
+            status: "lm")
+  end
+
+  let(:h_brt_wd) do
+    build(:holding,
+          ocn: c.ocns.first,
+            organization: h_w_ec.organization,
+            n_enum: "1",
+            condition: "brt",
+            status: "wd")
+  end
+
+  before(:each) do
+    Cluster.each(&:delete)
+    c.save
+    ClusterHtItem.new(ht_w_ec).cluster.tap(&:save)
+  end
+
+  describe "#matching_holdings" do
+    it "finds holdings that match on enum chron" do
+      cluster = ClusterHolding.new(h_w_ec).cluster.tap(&:save)
+      overlap = described_class.new(cluster, h_w_ec.organization, ht_w_ec)
+      expect(overlap.matching_holdings).to be_a(Enumerable)
+      expect(overlap.matching_holdings.count).to eq(1)
+    end
+
+    it "finds holdings with no enum chron" do
+      cluster = ClusterHolding.new(h_wo_ec).cluster.tap(&:save)
+      overlap = described_class.new(cluster, h_wo_ec.organization, ht_w_ec)
+      expect(overlap.matching_holdings).to be_a(Enumerable)
+      expect(overlap.matching_holdings.count).to eq(1)
+    end
+
+    it "finds holdings when ht item has no enum chron" do
+      ht_w_ec.update_attributes(n_enum: "")
+      cluster = ClusterHolding.new(h_w_ec).cluster.tap(&:save)
+      overlap = described_class.new(cluster, h_w_ec.organization, ht_w_ec)
+      expect(overlap.matching_holdings).to be_a(Enumerable)
+      expect(overlap.matching_holdings.count).to eq(1)
+    end
+
+    it "does not find holdings with the wrong enum chron" do
+      cluster = ClusterHolding.new(h_wrong_ec).cluster.tap(&:save)
+      overlap = described_class.new(cluster, h_wrong_ec.organization, ht_w_ec)
+      expect(overlap.matching_holdings).to be_a(Enumerable)
+      expect(overlap.matching_holdings.count).to eq(0)
+    end
+
+    it "does not find holdings if they have the wrong organization" do
+      cluster = ClusterHolding.new(h_w_ec).cluster.tap(&:save)
+      overlap = described_class.new(cluster, "not_an_org", ht_w_ec)
+      expect(overlap.matching_holdings.count).to eq(0)
+    end
+  end
+
+  describe "#copy_count" do
+    it "provides the correct copy count" do
+      ClusterHolding.new(h_w_ec).cluster.tap(&:save)
+      cluster = ClusterHolding.new(h_lm).cluster.tap(&:save)
+      mpo = described_class.new(cluster, h_w_ec.organization, ht_w_ec)
+      expect(mpo.copy_count).to eq(2)
+    end
+
+    it "returns 0 copies if wrong organization" do
+      cluster = ClusterHolding.new(h_w_ec).cluster.tap(&:save)
+      mpo = described_class.new(cluster, "not_an_org", ht_w_ec)
+      expect(mpo.copy_count).to be(0)
+    end
+
+    it "returns 1 copy if content_provider_code matches" do
+      ht_w_ec.update_attributes(content_provider_code: "different_org")
+      mpo = described_class.new(c, "different_org", ht_w_ec)
+      expect(mpo.copy_count).to be(1)
+    end
+  end
+
+  describe "#brt_count" do
+    it "provides the correct brt count" do
+      cluster = ClusterHolding.new(h_brt_wd).cluster.tap(&:save)
+      mpo = described_class.new(cluster, h_brt_wd.organization, ht_w_ec)
+      expect(mpo.brt_count).to eq(1)
+    end
+  end
+
+  describe "#wd_count" do
+    it "provides the correct wd count" do
+      cluster = ClusterHolding.new(h_brt_wd).cluster.tap(&:save)
+      mpo = described_class.new(cluster, h_brt_wd.organization, ht_w_ec)
+      expect(mpo.wd_count).to eq(1)
+    end
+  end
+
+  describe "#lm_count" do
+    it "provides the correct lm count" do
+      cluster = ClusterHolding.new(h_lm).cluster.tap(&:save)
+      mpo = described_class.new(cluster, h_lm.organization, ht_w_ec)
+      expect(mpo.lm_count).to eq(1)
+    end
+  end
+
+  describe "#access_count" do
+    it "provides the correct access count" do
+      ClusterHolding.new(h_lm).cluster.tap(&:save)
+      cluster = ClusterHolding.new(h_brt_wd).cluster.tap(&:save)
+      mpo = described_class.new(cluster, h_brt_wd.organization, ht_w_ec)
+      expect(mpo.access_count).to eq(2)
+    end
+  end
+end

--- a/spec/overlap_report_spec.rb
+++ b/spec/overlap_report_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "cluster_ht_item"
+require_relative "../bin/export_overlap_report"
+
+RSpec.describe "overlap_report" do
+  let(:h) { build(:holding) }
+  let(:ht) { build(:ht_item, ocns: [h.ocn], content_provider_code: "not_same_as_holding") }
+  let(:ht2) { build(:ht_item, content_provider_code: "not_same_as_holding") }
+
+  before(:each) do
+    Cluster.each(&:delete)
+    ClusterHolding.new(h).cluster.tap(&:save)
+    ClusterHtItem.new(ht).cluster.tap(&:save)
+    ClusterHtItem.new(ht2).cluster.tap(&:save)
+  end
+
+  describe "matching_clusters" do
+    it "finds them all if org is nil" do
+      expect(matching_clusters.count).to eq(2)
+    end
+
+    it "finds by holding" do
+      expect(matching_clusters(h.organization).count).to eq(1)
+    end
+
+    it "finds by ht_item" do
+      expect(matching_clusters(ht.content_provider_code).count).to eq(2)
+    end
+  end
+end

--- a/spec/overlap_spec.rb
+++ b/spec/overlap_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "overlap"
+
+RSpec.describe Overlap do
+  let(:c) { build(:cluster) }
+  let(:ht) { build(:ht_item, ocns: c.ocns, bib_fmt: "ser", enum_chron: "") }
+  let(:h) { build(:holding, ocn: c.ocns.first, organization: "umich", status: "lm") }
+  let(:h2) do
+    build(:holding,
+          ocn: c.ocns.first,
+            organization: "umich",
+            condition: "brt",
+            enum_chron: "V.1")
+  end
+  let(:h3) { build(:holding, ocn: c.ocns.first, organization: "smu") }
+
+  before(:each) do
+    Cluster.each(&:delete)
+    c.save
+    ClusterHtItem.new(ht).cluster.tap(&:save)
+    ClusterHolding.new(h).cluster.tap(&:save)
+    ClusterHolding.new(h2).cluster.tap(&:save)
+    ClusterHolding.new(h3).cluster.tap(&:save)
+  end
+
+  describe "#to_hash" do
+    it "returns a mostly empty hash" do
+      overlap_hash = described_class.new(c, h.organization, ht).to_hash
+      expect(overlap_hash).to eq(cluster_id: c._id.to_s,
+          volume_id: ht.item_id,
+          member_id: h.organization,
+          copy_count: "",
+          brt_count: "",
+          wd_count: "",
+          lm_count: "",
+          access_count: "")
+    end
+  end
+end

--- a/spec/serial_overlap_spec.rb
+++ b/spec/serial_overlap_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "serial_overlap"
+
+RSpec.describe SerialOverlap do
+  let(:c) { build(:cluster) }
+  let(:ht) { build(:ht_item, ocns: c.ocns, bib_fmt: "ser", enum_chron: "") }
+  let(:h) { build(:holding, ocn: c.ocns.first, organization: "umich", status: "lm") }
+  let(:h2) do
+    build(:holding,
+          ocn: c.ocns.first,
+            organization: "umich",
+            condition: "brt",
+            enum_chron: "V.1")
+  end
+  let(:h3) { build(:holding, ocn: c.ocns.first, organization: "smu") }
+
+  before(:each) do
+    Cluster.each(&:delete)
+    c.save
+    ClusterHtItem.new(ht).cluster.tap(&:save)
+    ClusterHolding.new(h).cluster.tap(&:save)
+    ClusterHolding.new(h2).cluster.tap(&:save)
+    ClusterHolding.new(h3).cluster.tap(&:save)
+  end
+
+  describe "#copy_count" do
+    it "returns 1 if there is any match" do
+      c = Cluster.first
+      expect(described_class.new(c, h.organization, ht).copy_count).to eq(1)
+    end
+
+    it "returns 1 if content_provider_code matches" do
+      c = Cluster.first
+      ht.update_attributes(content_provider_code: "different_org")
+      expect(described_class.new(c, "different_org", ht).copy_count).to eq(1)
+    end
+  end
+end

--- a/spec/single_part_overlap_spec.rb
+++ b/spec/single_part_overlap_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "single_part_overlap"
+
+RSpec.describe SinglePartOverlap do
+  let(:c) { build(:cluster) }
+  let(:ht) { build(:ht_item, ocns: c.ocns, bib_fmt: "spm", enum_chron: "") }
+  let(:h) { build(:holding, ocn: c.ocns.first, organization: "umich", status: "lm") }
+  let(:h2) do
+    build(:holding,
+          ocn: c.ocns.first,
+            organization: "umich",
+            condition: "brt")
+  end
+  let(:h3) { build(:holding, ocn: c.ocns.first, organization: "smu") }
+
+  before(:each) do
+    Cluster.each(&:delete)
+    c.save
+    ClusterHtItem.new(ht).cluster.tap(&:save)
+    ClusterHolding.new(h).cluster.tap(&:save)
+    ClusterHolding.new(h2).cluster.tap(&:save)
+    ClusterHolding.new(h3).cluster.tap(&:save)
+  end
+
+  describe "#copy_count" do
+    it "provides the correct copy count" do
+      c = Cluster.first
+      spo = described_class.new(c, h.organization, ht)
+      expect(spo.copy_count).to eq(2)
+    end
+
+    it "returns 1 if only content_provider_code matches" do
+      c = Cluster.first
+      ht.update_attributes(content_provider_code: "different_org")
+      expect(described_class.new(c, "different_org", ht).copy_count).to eq(1)
+    end
+
+    it "returns 0 if nothing matches" do
+      c = Cluster.first
+      expect(described_class.new(c, "not an org", ht).copy_count).to eq(0)
+    end
+  end
+
+  describe "#wd_count" do
+    it "provides the correct wd count" do
+      c = Cluster.first
+      spo = described_class.new(c, h.organization, ht)
+      expect(spo.brt_count).to eq(1)
+    end
+  end
+
+  describe "#brt_count" do
+    it "provides the correct brt count" do
+      c = Cluster.first
+      spo = described_class.new(c, h.organization, ht)
+      expect(spo.brt_count).to eq(1)
+    end
+  end
+
+  describe "#lm_count" do
+    it "provides the correct lm count" do
+      c = Cluster.first
+      spo = described_class.new(c, h.organization, ht)
+      expect(spo.lm_count).to eq(1)
+    end
+  end
+
+  describe "#access_count" do
+    it "provides the correct access count" do
+      c = Cluster.first
+      spo = described_class.new(c, h.organization, ht)
+      expect(spo.access_count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
Adds `condition` to Holdings records.
Adds `content_provider_code` to HTItems

Adds Overlap record class to compute holdings *_counts for a Serial cluster (does almost nothing since we don't really need it)
Adds SinglePartOverlap for SPMs.
Adds MultiPartOverlap for MPMs.

Adds CollectOverlap to iterate over overlapping HTItems.

Adds `bin/export_overlap_report.rb umich` to dump the results from CollectOverlap as tsv

Known issues:
It raises an error when dealing with "ser/spm" clusters. What are we supposed to do with them?

access_count is wrong. I am only seeing documentation for UMich's brittle access program. Is this relevant for ETAS and is it computed differently.

MPMs are likely computed incorrectly or at least differently from existing practice.

Handling of MPMs without enum_chrons is undefined.

Test coverage isn't great, especially inre to corner cases. 

SPO and Overlap.copy_count do not handle missing holdings like MPO.copy_count, i.e. when the content_provider_code matches the member_id. 
