### PR TITLE
Don't drop OCNs from cluster when adding HTItem

### DIFF
--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -67,11 +67,10 @@ class Cluster
     c
   end
 
-  # Collects OCNs from embedded documents
+  # Collects OCNs from OCN resolutions and HT items
   def collect_ocns
     (ocn_resolutions.collect(&:ocns).flatten +
-    ht_items.collect(&:ocns).flatten +
-    holdings.collect(&:ocn).flatten).uniq
+     ht_items.collect(&:ocns).flatten).uniq
   end
 
   private

--- a/lib/cluster_ht_item.rb
+++ b/lib/cluster_ht_item.rb
@@ -18,7 +18,7 @@ class ClusterHtItem
          Cluster.merge_many(Cluster.where(ocns: { "$in": @ht_item.ocns })) ||
          Cluster.new(ocns: @ht_item.ocns).tap(&:save))
     c.ht_items << @ht_item
-    c.ocns = c.ht_items.collect(&:ocns).flatten.uniq
+    c.ocns = c.collect_ocns
     c
   end
 

--- a/spec/cluster_ht_item_spec.rb
+++ b/spec/cluster_ht_item_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "spec_helper"
 require "cluster_ht_item"
 RSpec.describe ClusterHtItem do
   let(:ht) { build(:ht_item) }
@@ -146,6 +147,14 @@ RSpec.describe ClusterHtItem do
       updated_ht = build(:ht_item, item_id: no_ocn.item_id, ocns: c.ocns)
       described_class.new(updated_ht).update
       expect(Cluster.each.to_a.size).to eq(1)
+    end
+
+    it "can add an HTItem to a cluster with a concordance rule" do
+      resolution = build(:ocn_resolution)
+      htitem = build(:ht_item, ocns: [resolution.deprecated])
+      create(:cluster, ocns: resolution.ocns, ocn_resolutions: [resolution])
+      c = described_class.new(htitem).cluster
+      expect(c.valid?).to be true
     end
   end
 end

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -92,21 +92,24 @@ RSpec.describe Cluster do
   end
 
   describe "#collect_ocns" do
-    let(:ht) { build(:ht_item) }
+    let(:ht_item) { build(:ht_item) }
     let(:holding) { build(:holding) }
     let(:resolution) { build(:ocn_resolution) }
     let(:cluster) { create(:cluster) }
 
     before(:each) do
-      cluster.ht_items << ht
+      cluster.ht_items << ht_item
       cluster.holdings << holding
       cluster.ocn_resolutions << resolution
     end
 
-    it "gathers all of the OCNs from it's embedded documents" do
-      expect(cluster.collect_ocns).to include(*ht.ocns)
-      expect(cluster.collect_ocns).to include(*holding.ocn)
+    it "gathers all of the OCNs from its embedded resolution and HTitem" do
+      expect(cluster.collect_ocns).to include(*ht_item.ocns)
       expect(cluster.collect_ocns).to include(*resolution.ocns)
+    end
+
+    it "does not gather OCNs from holdings" do
+      expect(cluster.collect_ocns).not_to include(*holding.ocn)
     end
   end
 


### PR DESCRIPTION
Also, don't collect OCNs from holdings - holdings only have one OCN, and
that OCN should be in the list of clsuter OCNs prior to adding the
holding anyway