### PR TITLE
HT-2454: HTMember with country code & weight

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     volumes:
       - .:/usr/src/app
       - gem_cache:/gems
+    environment:
+      DB_CONNECTION_STRING: "mysql2://ht_repository:ht_repository@mariadb/ht_repository"
 
   mongo_dev:
     image: mongo

--- a/lib/holding.rb
+++ b/lib/holding.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "mongoid"
+require "ht_members"
+require "services"
 
 # A member holding
 class Holding
@@ -17,11 +19,23 @@ class Holding
   field :gov_doc_flag, type: Boolean
   field :mono_multi_serial, type: String
   field :date_received, type: DateTime
+  field :country_code, type: String
+  field :weight, type: Float
 
   embedded_in :cluster
 
   validates_presence_of :ocn, :organization, :mono_multi_serial, :date_received
   validates_inclusion_of :mono_multi_serial, in: ["mono", "multi", "serial"]
+
+  def initialize(params = nil)
+    super
+    set_member_data if organization
+  end
+
+  def organization=(organization)
+    super
+    set_member_data
+  end
 
   # Convert a tsv line from a validated holding file into a record like hash
   #
@@ -67,4 +81,12 @@ class Holding
   def same_as?(other)
     (self == other) && (date_received == other.date_received)
   end
+
+  private
+
+  def set_member_data
+    self.country_code = Services.ht_members[organization].country_code
+    self.weight       = Services.ht_members[organization].weight
+  end
+
 end

--- a/lib/ht_members.rb
+++ b/lib/ht_members.rb
@@ -55,8 +55,16 @@ class HTMembers
     if @members.key?(inst_id)
       @members[inst_id]
     else
-      raise "No member_info data for inst_id:#{inst_id}"
+      raise KeyError, "No member_info data for inst_id:#{inst_id}"
     end
+  end
+
+  # Adds a temporary member to the member data cache for the lifetime of the
+  # object; does not persist it to the database
+  #
+  # @param member The HTMember to add
+  def add_temp(member)
+    @members[member.inst_id] = member
   end
 
 end

--- a/lib/ht_members.rb
+++ b/lib/ht_members.rb
@@ -1,17 +1,62 @@
 # frozen_string_literal: true
 
-# WIP: cache of information about HathiTrust members
+require "mysql2"
+require "services"
+
+# Information about an individual HathiTrust institution
+class HTMember
+  attr_reader :inst_id, :country_code, :weight, :oclc_sym
+
+  def initialize(inst_id:, country_code: nil, weight: nil, oclc_sym: nil)
+    @inst_id = inst_id
+    @country_code = country_code
+    @weight = weight
+    @oclc_sym = oclc_sym
+  end
+end
+
+#
+# Cache of information about HathiTrust members.
+#
+# Usage:
+#
+#   htm = HTMembers.new()
+#   cc = htm["yale"].country_code
+#   wt = htm["harvard"].weight
+#
+# This returns a hash keyed by member id that contains the country code, weight,
+# and OCLC symbol.
+#
+# You can also pass in mock data for development/testing purposes:
+#
+#   htm = HTMembers.new({
+#     "haverford" => HTMember.new(inst_id: "haverford", country_code: "us", weight: 0.67)
+#   })
+#   htm["haverford"].country_code
+#   htm["haverford"].weight
+#
 class HTMembers
 
-  def initialize(*members)
-    @members = members.empty? ? load_from_db : members
+  attr_reader :members
+
+  def initialize(members = load_from_db)
+    @members = members
   end
 
   def load_from_db
-    # do that
+    Services.holdings_db[:ht_institutions]
+      .select(:inst_id, :country_code, :weight, :oclc_sym)
+      .as_hash(:inst_id)
+      .transform_values {|h| HTMember.new(h) }
   end
 
-  def get_list
-    @members
+  # Given a inst_id, returns a hash of data for that member.
+  def [](inst_id)
+    if @members.key?(inst_id)
+      @members[inst_id]
+    else
+      raise "No member_info data for inst_id:#{inst_id}"
+    end
   end
+
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "canister"
+require "holdings_db"
+require "ht_members"
+
+Services = Canister.new
+
+Services.register(:holdings_db) { HoldingsDB.connection }
+Services.register(:ht_members) { HTMembers.new }

--- a/spec/cost_report_spec.rb
+++ b/spec/cost_report_spec.rb
@@ -190,6 +190,10 @@ RSpec.describe CostReport do
       end
       let(:serial) { build(:serial, ocns: ht_serial.ocns, record_id: ht_serial.ht_bib_key) }
       let(:holding_serial) do
+        Services.ht_members.add_temp(
+          HTMember.new(inst_id: "not_a_cpc", country_code: "xx", weight: 1.0)
+        )
+
         build(:holding,
               ocn: ht_serial.ocns.first,
               enum_chron: "3",

--- a/spec/holding_spec.rb
+++ b/spec/holding_spec.rb
@@ -2,6 +2,8 @@
 
 require "holding"
 require "cluster"
+require "spec_helper"
+
 RSpec.describe Holding do
   let(:c) { create(:cluster) }
   let(:h) { build(:holding) }
@@ -37,6 +39,18 @@ RSpec.describe Holding do
     it "same_as is not true if date_received does not match" do
       h2.date_received = Date.yesterday
       expect(h.same_as?(h2)).to be(false)
+    end
+  end
+
+  describe "#country_code" do
+    it "is automatically set when organization is set" do
+      expect(build(:holding, organization: "ualberta").country_code).to eq("ca")
+    end
+  end
+
+  describe "#weight" do
+    it "is automatically set when organization is set" do
+      expect(build(:holding, organization: "utexas").weight).to eq(3.0)
     end
   end
 

--- a/spec/holdings_db_spec.rb
+++ b/spec/holdings_db_spec.rb
@@ -46,33 +46,40 @@ RSpec.describe HoldingsDB do
       expect(c.tables).to include(:ht_institutions)
     end
 
-    it "connects with ENV connection string" do
-      wipe_env
-      ENV["DB_CONNECTION_STRING"] = connection_string
-      c                           = described_class.connection
-      expect(c.tables).to include(:ht_institutions)
-    end
+    context "with clean environment" do
+      around :each do |example|
+        old_env = ENV.to_h
+        wipe_env
 
-    it "connects with ENV settings" do
-      wipe_env
-      set_env
-      c = described_class.connection
-      expect(c.tables).to include(:ht_institutions)
-    end
+        example.run
 
-    it "fails as expected with bad env" do
-      wipe_env
-      set_env
-      ENV["DB_USER"] = "NO_SUCH_USER"
-      expect { described_class.connection }.to raise_error(Sequel::DatabaseConnectionError)
-    end
+        old_env.each {|k, v| ENV[k] = v }
+      end
 
-    it "allows override of ENV" do
-      wipe_env
-      set_env
-      ENV["DB_USER"] = "NO_SUCH_USER"
-      c = described_class.connection(user: user)
-      expect(c.tables).to include(:ht_institutions)
+      it "connects with ENV connection string" do
+        ENV["DB_CONNECTION_STRING"] = connection_string
+        c                           = described_class.connection
+        expect(c.tables).to include(:ht_institutions)
+      end
+
+      it "connects with ENV settings" do
+        set_env
+        c = described_class.connection
+        expect(c.tables).to include(:ht_institutions)
+      end
+
+      it "fails as expected with bad env" do
+        set_env
+        ENV["DB_USER"] = "NO_SUCH_USER"
+        expect { described_class.connection }.to raise_error(Sequel::DatabaseConnectionError)
+      end
+
+      it "allows override of ENV" do
+        set_env
+        ENV["DB_USER"] = "NO_SUCH_USER"
+        c = described_class.connection(user: user)
+        expect(c.tables).to include(:ht_institutions)
+      end
     end
   end
 

--- a/spec/ht_members_spec.rb
+++ b/spec/ht_members_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "ht_members"
+require "dotenv"
+
+RSpec.describe HTMembers do
+  let(:mock_data) do
+    {
+      "example" => HTMember.new(inst_id: "example", country_code: "xx",
+                                weight: 3.5, oclc_sym: "ZZZ")
+    }
+  end
+
+  describe "mocking" do
+    it "can accept mocked data" do
+      htm = described_class.new(mock_data)
+      expect(htm["example"].country_code).to eq("xx")
+      expect(htm["example"].weight).to eq(3.5)
+      expect(htm["example"].oclc_sym).to eq("ZZZ")
+    end
+  end
+
+  describe "db connection" do
+    it "can fetch data from the database" do
+      htm = described_class.new
+      expect(htm["umich"].country_code).to eq("us")
+      expect(htm["umich"].weight).to eq(1.33)
+      expect(htm["umich"].oclc_sym).to eq("EYM")
+    end
+
+    it "can fetch the full hash" do
+      htm = described_class.new
+      expect(htm.members.size).to be > 0
+    end
+  end
+end

--- a/spec/ht_members_spec.rb
+++ b/spec/ht_members_spec.rb
@@ -11,26 +11,61 @@ RSpec.describe HTMembers do
     }
   end
 
-  describe "mocking" do
-    it "can accept mocked data" do
-      htm = described_class.new(mock_data)
-      expect(htm["example"].country_code).to eq("xx")
-      expect(htm["example"].weight).to eq(3.5)
-      expect(htm["example"].oclc_sym).to eq("ZZZ")
+  let(:ht_members) { described_class.new(mock_data) }
+
+  describe "#[]" do
+    it "can fetch an institution" do
+      expect(ht_members["example"].country_code).to eq("xx")
+      expect(ht_members["example"].weight).to eq(3.5)
+      expect(ht_members["example"].oclc_sym).to eq("ZZZ")
+    end
+
+    it "raises a KeyError when institution has no data" do
+      expect { ht_members["nonexistent"] }.to raise_exception(KeyError)
     end
   end
 
-  describe "db connection" do
-    it "can fetch data from the database" do
-      htm = described_class.new
-      expect(htm["umich"].country_code).to eq("us")
-      expect(htm["umich"].weight).to eq(1.33)
-      expect(htm["umich"].oclc_sym).to eq("EYM")
+  describe "#members" do
+    it "returns all members as a hash" do
+      expect(ht_members.members.keys).to contain_exactly("example")
+    end
+  end
+
+  describe "#add_temp" do
+    let(:temp_member) do
+      HTMember.new(inst_id: "temp", country_code: "zz", weight: 1.0)
     end
 
-    it "can fetch the full hash" do
-      htm = described_class.new
-      expect(htm.members.size).to be > 0
+    it "can add a temporary institution" do
+      expect(described_class.new(mock_data)
+        .add_temp(temp_member)).not_to be(nil)
+    end
+
+    it "can fetch a temporary institution" do
+      ht_members = described_class.new(mock_data)
+      ht_members.add_temp(temp_member)
+
+      expect(ht_members["temp"].country_code).to eq("zz")
+    end
+
+    describe "db connection" do
+      let(:ht_members) { described_class.new }
+
+      it "can fetch data from the database" do
+        expect(ht_members["umich"].country_code).to eq("us")
+        expect(ht_members["umich"].weight).to eq(1.33)
+        expect(ht_members["umich"].oclc_sym).to eq("EYM")
+      end
+
+      it "can fetch the full set of members" do
+        expect(ht_members.members.size).to be > 10
+      end
+
+      it "does not persist temp members to the database/across instances" do
+        ht_members.add_temp(temp_member)
+
+        expect(described_class.new.members.key?("temp")).to be false
+      end
     end
   end
 end


### PR DESCRIPTION
- Uses canister for holdings DB & global cache of member info

- Auto-sets organization & country code when constructing holding

Supercedes #37 