### PR TITLE
HT-2475 load overlap export into db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ config/environments/*.local.yml
 /docs/_build/
 /docs/_yard/
 *.iml
+/testdata

--- a/bin/export_overlap_report.rb
+++ b/bin/export_overlap_report.rb
@@ -26,6 +26,17 @@ def matching_clusters(org = nil)
   end
 end
 
+def overlap_line(overlap_hash)
+  [overlap_hash[:cluster_id],
+   overlap_hash[:volume_id],
+   overlap_hash[:member_id],
+   overlap_hash[:copy_count],
+   overlap_hash[:brt_count],
+   overlap_hash[:wd_count],
+   overlap_hash[:lm_count],
+   overlap_hash[:access_count]].join("\t")
+end
+
 if __FILE__ == $PROGRAM_NAME
   BATCH_SIZE = 10_000
   waypoint = Utils::Waypoint.new(BATCH_SIZE)
@@ -36,15 +47,7 @@ if __FILE__ == $PROGRAM_NAME
   matching_clusters(org).each do |c|
     ClusterOverlap.new(c, org).each do |overlap|
       waypoint.incr
-      h = overlap.to_hash
-      puts [h[:cluster_id],
-            h[:volume_id],
-            h[:member_id],
-            h[:copy_count],
-            h[:brt_count],
-            h[:wd_count],
-            h[:lm_count],
-            h[:access_count]].join("\t")
+      puts overlap_line(overlap.to_hash)
       waypoint.on_batch {|wp| logger.info wp.batch_line }
     end
   end

--- a/bin/load_overlap_report_to_database.rb
+++ b/bin/load_overlap_report_to_database.rb
@@ -1,0 +1,56 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+TABLENAME = :holdings_htitem_htmember
+
+require "dotenv"
+Dotenv.load(".env")
+
+require "pathname"
+$LOAD_PATH.unshift(Pathname.new(__dir__).parent + "lib")
+
+require "bundler/setup"
+require "logger"
+require "services"
+require "utils/waypoint"
+
+if ARGV.empty? || ARGV.include?("-h")
+  puts "Usage"
+  puts "  #{$PROGRAM_NAME} file_to_load <optional_log_file>"
+  puts "\n  Default is to log to STDERR"
+  exit 1
+end
+
+# @return [HoldingsDB] The holdings_db connection
+def connection
+  Services.holdings_db
+end
+
+def get_logger(logfile = STDERR)
+  Logger.new(logfile)
+end
+
+def validate_database!(connection)
+  unless connection.tables.include? TABLENAME
+    raise "Table #{TABLENAME} is not present (#{connection.tables.join(", ")})"
+  end
+end
+
+def validate_inputfile!(filename)
+  unless File.exist?(filename)
+    raise "File #{filename} not found"
+  end
+end
+
+filename = Pathname.new(ARGV.shift).realpath
+logger = get_logger(ARGV.shift)
+
+validate_database!(connection)
+validate_inputfile!(filename)
+
+# Clear it out
+connection[TABLENAME].delete
+
+# Load the data
+connection.load_tab_delimited_file(filepath: filename, tablename: TABLENAME,
+                                   maxlines: 1_000_000, logger: logger)

--- a/lib/holdings_db.rb
+++ b/lib/holdings_db.rb
@@ -1,19 +1,77 @@
 # frozen_string_literal: true
 
-require "sequel"
-require "mysql2"
 require "dotenv"
-
 Dotenv.load(".env")
+
+require "delegate"
+require "mysql2"
+require "sequel"
+require "services"
+require "tempfile"
 
 # Backend for connection to MySQL database for production information about
 # holdings and institutions
-class HoldingsDB
+class HoldingsDB < SimpleDelegator
 
   attr_reader :rawdb
   attr_accessor :connection_string
 
-  # #create_connection will take
+  def initialize(connection_string = ENV["DB_CONNECTION_STRING"], **kwargs)
+    @rawdb = self.class.connection(connection_string, **kwargs)
+    __setobj__(@rawdb)
+  end
+
+  # Load the given filepath into the table named.
+  # Note that we have to explicitly state that there's isn't an escape character
+  # (hence "ESCAPED BY ''") because some fields may end with a backslash -- the default
+  # escape character.
+  #
+  # Under the hood, we split the input file into files with _maxlines_ lines and load them one
+  # at a time, pausing _pause_in_seconds_ between loads so mysql replication can keep up
+  #
+  # @param [Symbol] tablename
+  # @param [Pathname, String] filepath Path to the tab-delimited file to load
+  # @param [Integer] maxlines How many lines to load at a time. Do not split if maxlines == -1
+  # @param [Integer] pause_in_seconds How long to pause between batches of _maxlines_
+  # @param [Logger] logger A logger
+  # @return [Integer] Total number of lines loaded
+  def load_tab_delimited_file(tablename:, filepath:,
+    maxlines: 1_000_000, pause_in_seconds: 10,
+    logger: Services.logger)
+    waypoint = Utils::Waypoint.new(maxlines)
+    logger.info("Begin load data infile of #{filepath} into #{tablename}")
+    Dir.mktmpdir("#{tablename}_tmp_load", ".") do |dir|
+      split_files = split_out_large_file(dir, filepath, maxlines)
+      split_files.each do |f|
+        load_data_infile(tablename, f)
+        if f == split_files.last
+          waypoint.incr File.open(f).count
+          logger.info(waypoint.final_line)
+        else
+          waypoint.incr maxlines
+          logger.info(waypoint.batch_line + "; sleeping #{pause_in_seconds}")
+          sleep pause_in_seconds
+        end
+      end
+    end
+    waypoint.count
+  end
+
+  def split_out_large_file(dir, filepath, maxlines)
+    if maxlines == -1
+      [filepath]
+    else
+      system("cd #{dir} && split #{filepath} -l #{maxlines}")
+      Pathname.new(dir).children
+    end
+  end
+
+  def load_data_infile(table, file)
+    @rawdb.run("LOAD DATA LOCAL INFILE '#{file}' INTO TABLE #{table}
+                FIELDS TERMINATED BY '\t' ESCAPED BY ''")
+  end
+
+  # #connection will take
   #  * a full connection string (passed here OR in the environment
   #    variable MYSQL_CONNECTION_STRING)
   #  * a set of named arguments, drawn from those passed in and the
@@ -51,6 +109,7 @@ class HoldingsDB
       end
     rescue Sequel::DatabaseConnectionError => e
       puts "Error trying to connect"
+      pp e
       raise e
     end
   end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -3,8 +3,10 @@
 require "canister"
 require "holdings_db"
 require "ht_members"
+require "logger"
 
 Services = Canister.new
 
-Services.register(:holdings_db) { HoldingsDB.connection }
+Services.register(:holdings_db) { HoldingsDB.new }
 Services.register(:ht_members) { HTMembers.new }
+Services.register(:logger) { Logger.new(STDERR) }

--- a/spec/holdings_db_spec.rb
+++ b/spec/holdings_db_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe HoldingsDB do
   let(:database) { "ht_repository" }
   let(:host) { "mariadb" }
   let(:connection) do
-    described_class.connection(user: user,
+    described_class.new(user: user,
                                password: password,
                                database: database,
                                host: host)
@@ -84,10 +84,6 @@ RSpec.describe HoldingsDB do
   end
 
   describe "Data is loaded" do
-    it "finds all the tables" do
-      expect(connection.tables).to match_array([:ht_collections, :ht_institutions])
-    end
-
     it "finds all the institutions" do
       c = described_class.connection(user: user, password: password, database: database, host: host)
       expect(c[:ht_institutions].count).to equal(249)

--- a/spec/overlap_report_mysql_import_spec.rb
+++ b/spec/overlap_report_mysql_import_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "cluster_ht_item"
+require "cluster_holding"
+require "cluster_overlap"
+require "single_part_overlap"
+require "multi_part_overlap"
+require "serial_overlap"
+require_relative "../bin/export_overlap_report"
+require "tempfile"
+
+RSpec.describe "overlap_report_import_to_mysql" do
+  let(:connection_string) { "mysql2://ht_repository:ht_repository@mariadb/ht_repository" }
+  let(:connection) { HoldingsDB.new(connection_string) }
+  let(:load_script) { Pathname.new(__dir__).parent + "bin" + "load_overlap_report_to_database.rb" }
+
+  def tempfilepath
+    "/tmp/tmp_load_test"
+  end
+
+  # Build up a couple items and save them using the export logic from bin/export_overlap_report
+  around(:all) do |spec|
+    h   = build(:holding)
+    ht  = build(:ht_item, ocns: [h.ocn], content_provider_code: "not_same_as_holding")
+    ht2 = build(:ht_item, content_provider_code: "not_same_as_holding")
+    Cluster.each(&:delete)
+    ClusterHolding.new(h).cluster.tap(&:save)
+    ClusterHtItem.new(ht).cluster.tap(&:save)
+    ClusterHtItem.new(ht2).cluster.tap(&:save)
+
+    org = nil # all orgs
+    File.open(tempfilepath, "w:utf-8") do |tmpfile|
+      matching_clusters(org).each do |c|
+        puts "adding #{c}"
+        ClusterOverlap.new(c, org).each do |overlap|
+          tmpfile.puts overlap_line(overlap.to_hash)
+        end
+      end
+    end
+
+    spec.run
+
+    # File.unlink(tempfilepath)
+  end
+
+  describe "Sanity check" do
+    let(:lines) { File.open(tempfilepath).to_a.map {|x| x.split("\t") } }
+
+    it "has 3 lines" do
+      expect(lines.size).to equal(3)
+    end
+
+    it "has lines with 8 columns" do
+      expect(lines.map(&:size)).to all(be == 8)
+    end
+  end
+
+  describe "bulk import" do
+    it "loads a little file via code" do
+      connection[:holdings_htitem_htmember].delete
+      d = connection.load_tab_delimited_file(tablename: "holdings_htitem_htmember",
+                                             filepath: tempfilepath)
+      expect(d).to eq(3)
+      expect(connection[:holdings_htitem_htmember].count).to eq(3)
+      connection[:holdings_htitem_htmember].delete
+    end
+
+    it "loads a little file via the script" do
+      connection[:holdings_htitem_htmember].delete
+      system("bundle exec ruby #{load_script} #{tempfilepath}")
+      expect(connection[:holdings_htitem_htmember].count).to eq(3)
+    end
+  end
+end

--- a/spec/overlap_report_spec.rb
+++ b/spec/overlap_report_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
+require "spec_helper"
 require "cluster_ht_item"
+require "cluster_holding"
 require_relative "../bin/export_overlap_report"
 
 RSpec.describe "overlap_report" do

--- a/sql/003_holdings_htitem_htmember.sql
+++ b/sql/003_holdings_htitem_htmember.sql
@@ -1,0 +1,15 @@
+USE `ht_repository`;
+
+CREATE TABLE IF NOT EXISTS `holdings_htitem_htmember` (
+  `cluster_id` bigint NOT NULL,
+  `volume_id` varchar(50) NOT NULL,
+  `member_id` varchar(20) NOT NULL,
+  `copy_count` int(11) DEFAULT NULL,
+  `lm_count` smallint(6) DEFAULT NULL,
+  `wd_count` smallint(6) DEFAULT NULL,
+  `brt_count` smallint(6) DEFAULT NULL,
+  `access_count` smallint(6) DEFAULT NULL,
+  PRIMARY KEY (`volume_id`, `member_id`),
+  KEY (`member_id`),
+  KEY (`cluster_id`)
+  ) ENGINE=InnoDB DEFAULT CHARSET=latin1;


### PR DESCRIPTION
Provide LOAD DATA INFILE capability to get overlap data into `holdings_htitem_htmember`

* New sql table definition in `/sql` (`holdings_htitem_htmember` with extra `cluster_id` column)
* Make `HoldingsDB` a real class with instances. Instances delegate pretty much everything to the underlying Sequel connection. Change spec to suit.
* Now that it's an object, add `HoldingsDB#load_tab_delimited_file` which takes a table and filename and:
   - uses unix utility _split_ to split the source into (default) one-million-line files in a temporary directory
   - load each file with a pause between (default 10 seconds)
   - clean up after itself
* Create a spec. Most of it is copy-paste from `overlap_spec` to make a few cluster/items and then export them.
* Minor changes to `bin/export_overlap_report.rb` to make it easier to call the code in a spec

## TODO
* check to make sure `split` exists (or maybe just use ruby? Slower, I'm sure.)
* actually make the script in `./bin/` that calls all this
* Have the import drop keys beforehand and then recreate them afterwards, for performance increase
* (?) Implement an upsert method with a signature similar to `#load_tab_delimited_file` (?)