### PR TITLE
HT-2570 Generate ETAS overlap reports

### DIFF
--- a/bin/export_etas_overlap_report.rb
+++ b/bin/export_etas_overlap_report.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "dotenv"
+Dotenv.load(".env")
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+require "bundler/setup"
+require "ocn_resolution"
+require "holding"
+require "utils/waypoint"
+require "utils/ppnum"
+require "zinzout"
+require "cluster_overlap"
+
+Mongoid.load!("mongoid.yml", :development)
+
+# Find clusters that match the given org
+def matching_clusters(org = nil)
+  if org.nil?
+    Cluster.where("ht_items.0": { "$exists": 1 },
+                  "holdings.0": { "$exists": 1 })
+  else
+    Cluster.where("ht_items.0": { "$exists": 1 },
+                  "holdings.organization": org)
+  end
+end
+
+def open_report(org, date, path)
+  File.open("#{path}/#{org}_#{date}.tsv", "w")
+end
+
+if __FILE__ == $PROGRAM_NAME
+  date_of_report = Time.now.strftime("%Y-%m-%d")
+  report_path = ENV["path_to_etas_overlap_reports"]
+  Dir.mkdir(report_path) unless File.exist?(report_path)
+  reports = {}
+
+  BATCH_SIZE = 10_000
+  waypoint = Utils::Waypoint.new(BATCH_SIZE)
+  logger = Logger.new(STDERR)
+  logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
+
+  org = ARGV.shift
+  matching_clusters(org).each do |c|
+    ClusterOverlap.new(c, org).each do |overlap|
+      waypoint.incr
+      overlap.matching_holdings.each do |holding|
+        unless reports.key?(holding[:organization])
+          reports[holding[:organization]] = open_report(holding[:organization],
+                                                        date_of_report,
+                                                        report_path)
+        end
+        reports[holding[:organization]].puts [holding[:ocn],
+                                              holding[:local_id],
+                                              CalculateFormat.new(c).cluster_format,
+                                              overlap.ht_item.access,
+                                              overlap.ht_item.rights].join("\t")
+      end
+      waypoint.on_batch {|wp| logger.info wp.batch_line }
+    end
+  end
+  logger.info waypoint.final_line
+end

--- a/lib/overlap.rb
+++ b/lib/overlap.rb
@@ -6,6 +6,7 @@ require "cluster"
 # Inherited by SinglePartOverlap, MultiPartOverlap, and SerialOverlap
 class Overlap
   attr_accessor :org
+  attr_accessor :ht_item
 
   def initialize(cluster, org, ht_item)
     @cluster = cluster
@@ -18,6 +19,10 @@ class Overlap
     define_method "#{method}_count".to_sym do
       ""
     end
+  end
+
+  def matching_holdings
+    @cluster.holdings.where(organization: @org)
   end
 
   # Members that provided matching ht_items

--- a/spec/overlap_spec.rb
+++ b/spec/overlap_spec.rb
@@ -45,4 +45,11 @@ RSpec.describe Overlap do
       expect(overlap.members_with_matching_ht_items).to eq([ht.billing_entity])
     end
   end
+
+  describe "#matching_holdings" do
+    it "finds all matching holdings for an org" do
+      overlap = described_class.new(c, "umich", ht)
+      expect(overlap.matching_holdings.pluck(:organization)).to eq(["umich", "umich"])
+    end
+  end
 end


### PR DESCRIPTION
 * use existing overlap classes
 * write to files at .env defined path

Bit kludgier than I would like. Generates files: <.env path>/<member_id>_Y-m-d.tsv