### PR TITLE
HT-2463, HT-2491, HT-2480: Batching and transaction support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/testdata/
+/coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,5 @@ config/environments/*.local.yml
 /docs/_build/
 /docs/_yard/
 *.iml
-/testdata
+/testdata/
+test.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,8 @@ services:
   - docker
 
 before_install:
-  - docker-compose build
-  - docker-compose run --rm dev bundle install
-  - docker-compose up -d mongo_test mariadb
+  - ./bin/setup_test.sh
 
 script:
   - docker-compose run --rm dev bundle exec rubocop
-  - docker-compose run --rm -e MONGOID_ENV=test dev bin/wait-for mongo_test:27017 -- bundle exec ruby lib/tasks/build_database.rb
   - docker-compose run --rm -e MONGOID_ENV=test dev bin/wait-for mariadb:3306 -- bundle exec rspec

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -17,8 +17,3 @@ WORKDIR /usr/src/app
 ENV BUNDLE_PATH /gems
 RUN bundle install
 COPY --chown=$UID:$GID . /usr/src/app
-
-WORKDIR /usr/src/app
-ENV BUNDLE_PATH /gems
-
-COPY . /usr/src/app

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,24 @@
+FROM ruby:2.6
+ARG UNAME=holdings
+ARG UID=1000
+ARG GID=1000
+
+RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
+  nodejs
+
+RUN gem install bundler
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -d /usr/src/app -u $UID -g $GID -o -s /bin/bash $UNAME
+RUN mkdir -p /gems && chown $UID:$GID /gems
+USER $UNAME
+
+COPY --chown=$UID:$GID Gemfile* /usr/src/app/
+WORKDIR /usr/src/app
+ENV BUNDLE_PATH /gems
+RUN bundle install
+COPY --chown=$UID:$GID . /usr/src/app
+
+WORKDIR /usr/src/app
+ENV BUNDLE_PATH /gems
+
+COPY . /usr/src/app

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "zinzout"
 
 group :development, :test do
   gem "pry"
+  gem "pry-byebug"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
       zeitwerk (~> 2.2)
     ast (2.4.0)
     bson (4.7.1)
+    byebug (11.1.3)
     canister (0.9.1)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
@@ -37,6 +38,9 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     rainbow (3.0.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -88,6 +92,7 @@ DEPENDENCIES
   mongoid
   mysql2
   pry
+  pry-byebug
   rspec
   rubocop
   rubocop-performance

--- a/bin/add_ht_items.rb
+++ b/bin/add_ht_items.rb
@@ -3,6 +3,7 @@
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "bundler/setup"
+require "services"
 require "cluster_ht_item"
 require "batch_cluster_ht_item"
 require "ht_item"
@@ -32,7 +33,7 @@ end
 
 MAX_RETRIES = 5
 BATCH_SIZE = 10_000
-logger = Logger.new(STDOUT)
+logger = Services.logger
 waypoint = Utils::Waypoint.new
 STDIN.set_encoding "utf-8"
 logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"

--- a/bin/add_ocn_resolutions.rb
+++ b/bin/add_ocn_resolutions.rb
@@ -13,7 +13,7 @@ require "utils/ppnum"
 Mongoid.load!("mongoid.yml", ENV["MONGOID_ENV"] || :development)
 
 BATCH_SIZE = 10_000
-logger = Logger.new(STDOUT)
+logger = Services.logger
 waypoint = Utils::Waypoint.new(BATCH_SIZE)
 logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
 
@@ -27,10 +27,10 @@ Zinzout.zin(ARGV.shift).each do |line|
     c.save if c.changed?
     waypoint.on_batch {|wp| logger.info wp.batch_line }
   rescue StandardError => e
-    puts "Encountered error while processing line: "
-    puts line
-    puts e.message
-    puts e.backtrace.inspect
+    logger.error "Encountered error while processing line: "
+    logger.error line
+    logger.error e.message
+    logger.error e.backtrace.inspect
     raise e
   end
 end

--- a/bin/add_ocn_resolutions.rb
+++ b/bin/add_ocn_resolutions.rb
@@ -24,7 +24,7 @@ Zinzout.zin(ARGV.shift).each do |line|
     (deprecated, resolved) = line.split.map(&:to_i)
     r = OCNResolution.new(deprecated: deprecated, resolved: resolved)
     c = ClusterOCNResolution.new(r).cluster
-    c.upsert if c.changed?
+    c.save if c.changed?
     waypoint.on_batch {|wp| logger.info wp.batch_line }
   rescue StandardError => e
     puts "Encountered error while processing line: "

--- a/bin/add_ocn_resolutions.rb
+++ b/bin/add_ocn_resolutions.rb
@@ -19,12 +19,20 @@ logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BAT
 
 STDIN.set_encoding "utf-8"
 Zinzout.zin(ARGV.shift).each do |line|
-  waypoint.incr
-  (deprecated, resolved) = line.split.map(&:to_i)
-  r = OCNResolution.new(deprecated: deprecated, resolved: resolved)
-  c = ClusterOCNResolution.new(r).cluster
-  c.save
-  waypoint.on_batch {|wp| logger.info wp.batch_line }
+  begin
+    waypoint.incr
+    (deprecated, resolved) = line.split.map(&:to_i)
+    r = OCNResolution.new(deprecated: deprecated, resolved: resolved)
+    c = ClusterOCNResolution.new(r).cluster
+    c.upsert if c.changed?
+    waypoint.on_batch {|wp| logger.info wp.batch_line }
+  rescue StandardError => e
+    puts "Encountered error while processing line: "
+    puts line
+    puts e.message
+    puts e.backtrace.inspect
+    raise e
+  end
 end
 
 logger.info waypoint.final_line

--- a/bin/add_print_holdings.rb
+++ b/bin/add_print_holdings.rb
@@ -17,7 +17,7 @@ Mongoid.load!("mongoid.yml", ENV["MONGOID_ENV"] || :development)
 
 BATCH_SIZE = 10_000
 waypoint = Utils::Waypoint.new(BATCH_SIZE)
-logger = Logger.new(STDOUT)
+logger = Services.logger
 logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
 
 update = ARGV[0] == "-u"
@@ -47,9 +47,9 @@ Zinzout.zin(filename).each do |line|
     c.save if c.changed?
     waypoint.on_batch {|wp| logger.info wp.batch_line }
   rescue StandardError => e
-    puts "Encountered error while processing line: "
-    puts line
-    puts e.message
+    logger.error "Encountered error while processing line: "
+    logger.error line
+    logger.error e.message
     puts e.backtrace.inspect
     raise e
   end

--- a/bin/add_print_holdings.rb
+++ b/bin/add_print_holdings.rb
@@ -44,7 +44,7 @@ Zinzout.zin(filename).each do |line|
     else
       ClusterHolding.new(h).cluster
     end
-    c.upsert if c.changed?
+    c.save if c.changed?
     waypoint.on_batch {|wp| logger.info wp.batch_line }
   rescue StandardError => e
     puts "Encountered error while processing line: "

--- a/bin/compile_hscores.rb
+++ b/bin/compile_hscores.rb
@@ -16,7 +16,7 @@ Mongoid.load!("mongoid.yml", :development)
 if __FILE__ == $PROGRAM_NAME
   BATCH_SIZE = 10_000
   waypoint = Utils::Waypoint.new(BATCH_SIZE)
-  logger = Logger.new(STDERR)
+  logger = Services.logger
   logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
 
   org = ARGV.shift

--- a/bin/export_overlap_report.rb
+++ b/bin/export_overlap_report.rb
@@ -40,7 +40,7 @@ end
 if __FILE__ == $PROGRAM_NAME
   BATCH_SIZE = 10_000
   waypoint = Utils::Waypoint.new(BATCH_SIZE)
-  logger = Logger.new(STDERR)
+  logger = Services.logger
   logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
 
   org = ARGV.shift

--- a/bin/load_print_serials.rb
+++ b/bin/load_print_serials.rb
@@ -34,7 +34,7 @@ end
 
 BATCH_SIZE = 1_000
 waypoint = Utils::Waypoint.new(BATCH_SIZE)
-logger = Logger.new(STDOUT)
+logger = Services.logger
 
 if __FILE__ == $PROGRAM_NAME
   # delete old print serial records

--- a/bin/rs_initiate.sh
+++ b/bin/rs_initiate.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+MONGO_SERVICE="${MONGO_SERVICE:-$1}"
+
+mongo <<EOT
+  rs.initiate(
+    {
+      _id: "rs0",
+      version: 1,
+      members: [
+        { _id: 0, host: "$MONGO_SERVICE:27017" }
+      ]
+    }
+  )
+EOT

--- a/bin/setup_dev.sh
+++ b/bin/setup_dev.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$(dirname ${BASH_SOURCE[0]})/setup_test.sh
+
+docker-compose up -d mongo_dev
+docker-compose run --rm dev bin/wait-for mongo_dev:27017 -- echo "mongo is ready"
+docker-compose exec mongo_dev bash /tmp/bin/rs_initiate.sh mongo_dev
+docker-compose run --rm -e MONGOID_ENV=development dev bundle exec ruby lib/tasks/build_database.rb
+

--- a/bin/setup_test.sh
+++ b/bin/setup_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+docker-compose build
+docker-compose run --rm dev bundle install
+docker-compose up -d mongo_test mariadb
+docker-compose run --rm -e MONGOID_ENV=test dev bin/wait-for mongo_test:27017 -- echo "mongo is ready"
+docker-compose exec mongo_test bash /tmp/bin/rs_initiate.sh mongo_test
+docker-compose run --rm -e MONGOID_ENV=test dev bundle exec ruby lib/tasks/build_database.rb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,15 @@ services:
     image: mongo
     volumes:
       - data_db:/data/db
+    command: --replSet rs0 --bind_ip localhost,mongo_dev
+    volumes:
+      - ./bin:/tmp/bin
 
   mongo_test:
     image: mongo
+    command: --replSet rs0 --bind_ip localhost,mongo_test
+    volumes:
+      - ./bin:/tmp/bin
 
   mariadb:
     image: mariadb

--- a/lib/autoscrub.rb
+++ b/lib/autoscrub.rb
@@ -91,7 +91,7 @@ class Autoscrub
     session_log_name = "session_#{@member_id}_#{date}"
     @session_log = get_log_file(session_log_name)
     slog("Starting session log for member #{@member_id}")
-    warn "Logging to #{File.expand_path(@session_log.path)}"
+    Services.logger.warn "Logging to #{File.expand_path(@session_log.path)}"
 
     @scrubfields = ScrubFields.new
 
@@ -110,7 +110,7 @@ class Autoscrub
     log_prefix  = "#{time} | .#{caller_meth} |"
 
     if handle.nil?
-      puts "#{log_prefix} #{str}"
+      Services.logger.info "#{log_prefix} #{str}"
     else
       handle.puts("#{log_prefix} #{str}")
     end

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -122,7 +122,7 @@ class Cluster
   # @param other - the other cluster
   def move_members_to_self(other)
     other.holdings.each {|h| ClusterHolding.new(h).move(self) }
-    other.ht_items.each {|ht| ClusterHtItem.new(ht.ocns).move(ht, self) }
+    other.ht_items.each {|ht| ClusterHtItem.new(ht).move(self) }
     other.commitments.each {|c| c.move(self) }
   end
 

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -15,7 +15,7 @@ require "serial"
 # - commitments
 class Cluster
   include Mongoid::Document
-  store_in collection: "clusters", database: "test", client: "default"
+  store_in collection: "clusters"
   field :ocns
   embeds_many :holdings, class_name: "Holding"
   embeds_many :ht_items, class_name: "HtItem"

--- a/lib/cluster_error.rb
+++ b/lib/cluster_error.rb
@@ -1,0 +1,3 @@
+# Indication of a retryable error with clustering
+class ClusterError < RuntimeError
+end

--- a/lib/cluster_error.rb
+++ b/lib/cluster_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Indication of a retryable error with clustering
 class ClusterError < RuntimeError
 end

--- a/lib/cluster_ht_item.rb
+++ b/lib/cluster_ht_item.rb
@@ -13,12 +13,14 @@ class ClusterHtItem
   end
 
   # Cluster the HTItem
-  def cluster
+  def cluster(transaction: true)
     c = (@ht_item.ocns.any? &&
-         Cluster.merge_many(Cluster.where(ocns: { "$in": @ht_item.ocns })) ||
+         Cluster.merge_many(Cluster.where(ocns: { "$in": @ht_item.ocns }),transaction: transaction) ||
          Cluster.new(ocns: @ht_item.ocns).tap(&:save))
     c.ht_items << @ht_item
-    c.ocns = c.collect_ocns
+    @ht_item.ocns.each do |ocn|
+      c.ocns << ocn unless c.ocns.include?(ocn)
+    end
     c
   end
 

--- a/lib/cluster_ht_item.rb
+++ b/lib/cluster_ht_item.rb
@@ -2,28 +2,25 @@
 
 require "cluster"
 require "reclusterer"
+require "cluster_error"
 
 # Services for batch loading HT items
 class ClusterHtItem
 
-  def initialize(ocns = [], transaction: true)
+  MAX_RETRIES=5
+  # Not constantized by mongo ge
+  MONGO_DUPLICATE_KEY_ERROR=11_000
+
+  def initialize(ocns = [])
     @ocns = ocns
-    @transaction = transaction
   end
 
-  # Cluster the HTItem
-  def cluster(batch)
-    cluster_for_ocns.tap do |c|
-      to_append = []
-      batch.each do |item|
-        if (existing_item = c.ht_item(item.item_id))
-          existing_item.update_attributes(item.to_hash)
-        else
-          remove_old_ht_item(item)
-          to_append << item
-        end
+  def cluster(htitems)
+    retry_operation do
+      cluster_for_ocns.tap do |cluster|
+        puts "adding htitems #{htitems.inspect} with ocns #{@ocns} to cluster #{cluster.inspect}"
+        update_or_add_htitems(cluster,htitems)
       end
-      c.ht_items.concat(to_append)
     end
   end
 
@@ -32,47 +29,108 @@ class ClusterHtItem
   # @param new_cluster - the cluster to move to
   def move(ht_item, new_cluster)
     unless new_cluster.id == ht_item._parent.id
-      duped_htitem = ht_item.dup
-      ht_item.delete
-      new_cluster.ht_items << duped_htitem
-      ht_item = duped_htitem
+      Cluster.with_transaction do
+        duped_htitem = ht_item.dup
+        ht_item.delete
+        new_cluster.ht_items << duped_htitem
+      end
     end
   end
 
   # Removes an HTItem
   def delete(ht_item)
-    Cluster.where("ht_items.item_id": ht_item.item_id).each do |c|
-      c.ht_items.delete_if {|h| h.item_id == ht_item.item_id }
-      Reclusterer.new(c).recluster
+    # Don't start a transaction until we know there's something we need to
+    # delete, but if we do need to delete the thing then we need to re-fetch it
+    # so we can acquire the correct lock
+    retry_operation do
+      return unless Cluster.with_ht_item(ht_item).first
+
+      Cluster.with_transaction do
+        if (cluster = Cluster.with_ht_item(ht_item).first)
+          delete_htitem_and_recluster(cluster,ht_item)
+        end
+      end
     end
   end
 
   private
 
-  def remove_old_ht_item(ht_item)
-    if (cluster = Cluster.with_ht_item(ht_item).first)
-      cluster.ht_item(ht_item.item_id).delete
+  def delete_htitem_and_recluster(cluster,ht_item)
+    puts "removing old htitem #{ht_item.item_id}"
+    cluster.ht_item(ht_item.item_id).delete
 
-      # Note that technically we only need to do this if there were multiple
-      # OCNs for that HT item and nothing else binds the cluster together.
-      # It may be worth optimizing not to do this if the htitem has only one
-      # OCN, since that will be the common case. Probably not worth checking
-      # that nothing else binds the cluster together?
-      Reclusterer.new(cluster).recluster
-    end
+    # Note that technically we only need to do this if there were multiple
+    # OCNs for that HT item and nothing else binds the cluster together.
+    # It may be worth optimizing not to do this if the htitem has only one
+    # OCN, since that will be the common case. Probably not worth checking
+    # that nothing else binds the cluster together?
+    Reclusterer.new(cluster).recluster
   end
 
   def cluster_for_ocns
-    existing_cluster_with_ocns || Cluster.create(ocns: @ocns)
+    existing_cluster_with_ocns.tap { |c| puts "Got existing cluster #{c.inspect}" if c} || Cluster.create(ocns: @ocns).tap { |c| puts "Created cluster #{c.inspect}" }
   end
 
   def existing_cluster_with_ocns
     return unless @ocns.any?
 
-    Cluster.merge_many(Cluster.for_ocns(@ocns),
-                       transaction: @transaction).tap do |c|
-                         c&.add_to_set(ocns: @ocns)
-                       end
+    Cluster.merge_many(Cluster.for_ocns(@ocns)).tap do |c|
+      c&.add_to_set(ocns: @ocns)
+    end
+  end
+
+  def update_or_add_htitems(cluster,htitems)
+    puts "Cluster #{cluster.inspect}: adding htitems #{htitems.inspect} with ocns #{@ocns}"
+    to_append = []
+    htitems.each do |item|
+      if (existing_item = cluster.ht_item(item.item_id))
+        puts "updating existing item with id #{item.item_id}"
+        existing_item.update_attributes(item.to_hash)
+      else
+        delete(item)
+        to_append << item
+      end
+    end
+
+    if(to_append.length > 0)
+      docs = to_append.map(&:as_document)
+      result = cluster.collection.update_one( { _id: cluster._id }, { "$push" => { :ht_items => { "$each" => docs } } }, session: Cluster.session )
+      raise ClusterError, "#{cluster.inspect} deleted before update" unless result.modified_count > 0
+
+      to_append.each do |item|
+        item.parentize(cluster)
+        item._association = cluster.ht_items._association
+        item.cluster=cluster
+      end
+      cluster.reload
+    end
+  end
+
+  def retry_operation
+    tries = 0
+
+    begin
+      tries += 1
+      yield
+    rescue Mongo::Error::OperationFailure => e
+      handle_batch_error?(e, tries, retryable_error?(e)) && retry || raise
+    rescue ClusterError => e
+      handle_batch_error?(e, tries) && retry || raise
+    end
+  end
+
+  def retryable_error?(error)
+    error.code == MONGO_DUPLICATE_KEY_ERROR || error.code_name == "WriteConflict" 
+#    error.code == MONGO_DUPLICATE_KEY_ERROR
+  end
+
+  def handle_batch_error?(exception, tries, condition=true)
+    if condition && tries < MAX_RETRIES
+      warn "Got #{exception} while processing #{@ocns}, retrying (try #{tries+1})"
+      true
+    else
+      false
+    end
   end
 
 end

--- a/lib/cluster_ht_item.rb
+++ b/lib/cluster_ht_item.rb
@@ -5,6 +5,11 @@ require "reclusterer"
 require "cluster_error"
 
 # Services for batch loading HT items
+#
+# rubocop:disable Metrics/ClassLength
+# Much of this esp. around transactions and retry should be extracted to common
+# functionality shared by the other Cluster classes; remove this disabled cop
+# after doing so.
 class ClusterHtItem
 
   MAX_RETRIES=5
@@ -27,7 +32,8 @@ class ClusterHtItem
   def cluster
     retry_operation do
       cluster_for_ocns.tap do |cluster|
-        Services.logger.debug "adding htitems #{htitems.inspect} with ocns #{@ocns} to cluster #{cluster.inspect}"
+        Services.logger.debug "adding htitems #{htitems.inspect} " \
+          " with ocns #{@ocns} to cluster #{cluster.inspect}"
         update_or_add_htitems(cluster, htitems)
       end
     end
@@ -104,7 +110,8 @@ class ClusterHtItem
   end
 
   def update_or_add_htitems(cluster, htitems)
-    Services.logger.debug "Cluster #{cluster.inspect}: adding htitems #{htitems.inspect} with ocns #{@ocns}"
+    Services.logger.debug "Cluster #{cluster.inspect}: " \
+      "adding htitems #{htitems.inspect} with ocns #{@ocns}"
     to_append = []
     htitems.each do |item|
       if (existing_item = cluster.ht_item(item.item_id))
@@ -136,7 +143,6 @@ class ClusterHtItem
 
   def retryable_error?(error)
     error.code == MONGO_DUPLICATE_KEY_ERROR || error.code_name == "WriteConflict"
-    #    error.code == MONGO_DUPLICATE_KEY_ERROR
   end
 
   def handle_batch_error?(exception, tries, condition = true)
@@ -149,3 +155,4 @@ class ClusterHtItem
   end
 
 end
+# rubocop:enable Metrics/ClassLength

--- a/lib/cluster_ht_item.rb
+++ b/lib/cluster_ht_item.rb
@@ -11,11 +11,21 @@ class ClusterHtItem
   # Not constantized by mongo ge
   MONGO_DUPLICATE_KEY_ERROR=11_000
 
-  def initialize(ocns = [])
-    @ocns = ocns
+  def initialize(*htitems)
+    @htitems = htitems.flatten
+    @ocns = @htitems.first.ocns
+
+    if @htitems.find { |h| h.ocns != @ocns }
+      raise ArgumentError, "OCNs for each HTItem in batch must match"
+    end
+
+    if (@ocns.nil? || @ocns.empty?) && @htitems.length > 1
+      raise ArgumentError, "Cannot cluster multiple OCN-less HTItems"
+    end
+
   end
 
-  def cluster(htitems)
+  def cluster()
     retry_operation do
       cluster_for_ocns.tap do |cluster|
         puts "adding htitems #{htitems.inspect} with ocns #{@ocns} to cluster #{cluster.inspect}"
@@ -24,11 +34,16 @@ class ClusterHtItem
     end
   end
 
-  # Move an HTItem from one cluster to another
+  # Move HTItem from one cluster to another
   #
   # @param new_cluster - the cluster to move to
-  def move(ht_item, new_cluster)
-    unless new_cluster.id == ht_item._parent.id
+  def move(new_cluster)
+    raise ArgumentError, "Can only move one HTItem at a time" unless htitems.length == 1
+    ht_item = htitems.first
+
+    retry_operation do
+      return if new_cluster.id == ht_item._parent.id
+
       Cluster.with_transaction do
         duped_htitem = ht_item.dup
         ht_item.delete
@@ -38,16 +53,31 @@ class ClusterHtItem
   end
 
   # Removes an HTItem
-  def delete(ht_item)
+  def delete
+    raise ArgumentError, "Can only delete one HTItem at a time" unless htitems.length == 1
+
+    ht_item = htitems.first
+
     # Don't start a transaction until we know there's something we need to
-    # delete, but if we do need to delete the thing then we need to re-fetch it
-    # so we can acquire the correct lock
+    # delete. If we do need to delete the thing, then we need to re-fetch it so
+    # we can acquire the correct lock
     retry_operation do
-      return unless Cluster.with_ht_item(ht_item).first
+      return unless cluster_with_htitem(ht_item)
 
       Cluster.with_transaction do
-        if (cluster = Cluster.with_ht_item(ht_item).first)
-          delete_htitem_and_recluster(cluster,ht_item)
+        if (cluster = cluster_with_htitem(ht_item))
+          puts "removing old htitem #{ht_item.item_id}"
+          cluster.ht_item(ht_item.item_id).delete
+
+          # Note that technically we only need to do this if there were multiple
+          # OCNs for that HT item and nothing else binds the cluster together.
+          # It may be worth optimizing not to do this if the htitem has only
+          # one OCN, since that will be the common case. Not sure if it's worth
+          # optimizing away if there are multiple OCNs (i.e. doing the check to
+          # see if anything else binds the cluster together). In general the
+          # operation is probably rare enough that we don't need to worry about
+          # this for the time being.
+          Reclusterer.new(cluster).recluster
         end
       end
     end
@@ -55,16 +85,10 @@ class ClusterHtItem
 
   private
 
-  def delete_htitem_and_recluster(cluster,ht_item)
-    puts "removing old htitem #{ht_item.item_id}"
-    cluster.ht_item(ht_item.item_id).delete
+  attr_reader :htitems, :ocns
 
-    # Note that technically we only need to do this if there were multiple
-    # OCNs for that HT item and nothing else binds the cluster together.
-    # It may be worth optimizing not to do this if the htitem has only one
-    # OCN, since that will be the common case. Probably not worth checking
-    # that nothing else binds the cluster together?
-    Reclusterer.new(cluster).recluster
+  def cluster_with_htitem(htitem)
+    Cluster.with_ht_item(htitem).first
   end
 
   def cluster_for_ocns
@@ -87,7 +111,7 @@ class ClusterHtItem
         puts "updating existing item with id #{item.item_id}"
         existing_item.update_attributes(item.to_hash)
       else
-        delete(item)
+        ClusterHtItem.new(item).delete
         to_append << item
       end
     end

--- a/lib/cluster_ht_item.rb
+++ b/lib/cluster_ht_item.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cluster"
@@ -7,7 +6,7 @@ require "reclusterer"
 # Services for batch loading HT items
 class ClusterHtItem
 
-  def initialize(ocns=[],transaction: true)
+  def initialize(ocns = [], transaction: true)
     @ocns = ocns
     @transaction = transaction
   end
@@ -17,8 +16,7 @@ class ClusterHtItem
     cluster_for_ocns.tap do |c|
       to_append = []
       batch.each do |item|
-
-        if ( existing_item = c.ht_item(item.item_id) )
+        if (existing_item = c.ht_item(item.item_id))
           existing_item.update_attributes(item.to_hash)
         else
           remove_old_ht_item(item)
@@ -32,7 +30,7 @@ class ClusterHtItem
   # Move an HTItem from one cluster to another
   #
   # @param new_cluster - the cluster to move to
-  def move(ht_item,new_cluster)
+  def move(ht_item, new_cluster)
     unless new_cluster.id == ht_item._parent.id
       duped_htitem = ht_item.dup
       ht_item.delete
@@ -52,7 +50,7 @@ class ClusterHtItem
   private
 
   def remove_old_ht_item(ht_item)
-    if(cluster = Cluster.with_ht_item(ht_item).first)
+    if (cluster = Cluster.with_ht_item(ht_item).first)
       cluster.ht_item(ht_item.item_id).delete
 
       # Note that technically we only need to do this if there were multiple
@@ -70,10 +68,11 @@ class ClusterHtItem
 
   def existing_cluster_with_ocns
     return unless @ocns.any?
+
     Cluster.merge_many(Cluster.for_ocns(@ocns),
                        transaction: @transaction).tap do |c|
-      c&.add_to_set(ocns: @ocns)
-    end
+                         c&.add_to_set(ocns: @ocns)
+                       end
   end
 
 end

--- a/lib/cluster_ocn_resolution.rb
+++ b/lib/cluster_ocn_resolution.rb
@@ -14,7 +14,7 @@ class ClusterOCNResolution
 
   # Cluster the OCNResolution
   def cluster(transaction: true)
-    c = (Cluster.merge_many(Cluster.where(ocns: { "$in": @resolution.ocns }),transaction: transaction) ||
+    c = (Cluster.merge_many(Cluster.where(ocns: { "$in": @resolution.ocns }), transaction: transaction) ||
          Cluster.new(ocns: @resolution.ocns).tap(&:save))
     c.ocn_resolutions << @resolution
     @resolution.ocns.each do |ocn|

--- a/lib/cluster_ocn_resolution.rb
+++ b/lib/cluster_ocn_resolution.rb
@@ -13,11 +13,13 @@ class ClusterOCNResolution
   end
 
   # Cluster the OCNResolution
-  def cluster
-    c = (Cluster.merge_many(Cluster.where(ocns: { "$in": @resolution.ocns })) ||
+  def cluster(transaction: true)
+    c = (Cluster.merge_many(Cluster.where(ocns: { "$in": @resolution.ocns }),transaction: transaction) ||
          Cluster.new(ocns: @resolution.ocns).tap(&:save))
     c.ocn_resolutions << @resolution
-    c.ocns = c.collect_ocns
+    @resolution.ocns.each do |ocn|
+      c.ocns << ocn unless c.ocns.include?(ocn)
+    end
     c
   end
 

--- a/lib/cluster_ocn_resolution.rb
+++ b/lib/cluster_ocn_resolution.rb
@@ -13,8 +13,8 @@ class ClusterOCNResolution
   end
 
   # Cluster the OCNResolution
-  def cluster(transaction: true)
-    c = (Cluster.merge_many(Cluster.where(ocns: { "$in": @resolution.ocns }), transaction: transaction) ||
+  def cluster
+    c = (Cluster.merge_many(Cluster.where(ocns: { "$in": @resolution.ocns })) ||
          Cluster.new(ocns: @resolution.ocns).tap(&:save))
     c.ocn_resolutions << @resolution
     @resolution.ocns.each do |ocn|

--- a/lib/enum_chron_parser.rb
+++ b/lib/enum_chron_parser.rb
@@ -223,9 +223,9 @@ class EnumChronParser
       end
       return unless ALPHANUM.match?(input_str)
     rescue StandardError => e
-      puts e.message
-      puts e.backtrace.inspect
-      warn "[Parser] Problem parsing '#{input_str}'"
+      Services.logger.warn "[Parser] Problem parsing '#{input_str}'"
+      Services.logger.warn e.message
+      Services.logger.warn e.backtrace.inspect
       return
     end
 

--- a/lib/holdings_db.rb
+++ b/lib/holdings_db.rb
@@ -108,8 +108,7 @@ class HoldingsDB < SimpleDelegator
         Sequel.connect(**db_args)
       end
     rescue Sequel::DatabaseConnectionError => e
-      puts "Error trying to connect"
-      pp e
+      Services.logger.error "Error trying to connect"
       raise e
     end
   end

--- a/lib/ht_item.rb
+++ b/lib/ht_item.rb
@@ -51,6 +51,11 @@ class HtItem
     set_billing_entity
   end
 
+  def enum_chron=(enum_chron)
+    super
+    normalize_enum_chron
+  end
+
   def normalize_enum_chron
     # When created with an enumchron, normalize it into separate
     # n_enum and n_chron
@@ -63,17 +68,7 @@ class HtItem
   end
 
   def to_hash
-    {
-      ocns:       ocns,
-      item_id:    item_id,
-      ht_bib_key: ht_bib_key,
-      rights:     rights,
-      access:     access,
-      bib_fmt:    bib_fmt,
-      enum_chron: enum_chron,
-      n_enum:     n_enum,
-      n_chron:    n_chron
-    }
+    attributes.with_indifferent_access.except(:_id)
   end
 
   private

--- a/lib/ht_item.rb
+++ b/lib/ht_item.rb
@@ -33,12 +33,12 @@ class HtItem
   validates :item_id, uniqueness: true
   validates_presence_of :item_id, :ht_bib_key, :rights, :bib_fmt, :access
 
-  #validates_each :ocns do |record, attr, value|
-  #  value.each do |ocn|
-  #    record.errors.add attr, "must be an integer" \
-  #      unless (ocn.to_i if /\A[+-]?\d+\Z/.match?(ocn.to_s))
-  #  end
-  #end
+  validates_each :ocns do |record, attr, value|
+    value.each do |ocn|
+      record.errors.add attr, "must be an integer" \
+        unless (ocn.to_i if /\A[+-]?\d+\Z/.match?(ocn.to_s))
+    end
+  end
 
   def initialize(params = nil)
     super

--- a/lib/ht_item.rb
+++ b/lib/ht_item.rb
@@ -33,12 +33,12 @@ class HtItem
   validates :item_id, uniqueness: true
   validates_presence_of :item_id, :ht_bib_key, :rights, :bib_fmt, :access
 
-  validates_each :ocns do |record, attr, value|
-    value.each do |ocn|
-      record.errors.add attr, "must be an integer" \
-        unless (ocn.to_i if /\A[+-]?\d+\Z/.match?(ocn.to_s))
-    end
-  end
+  #validates_each :ocns do |record, attr, value|
+  #  value.each do |ocn|
+  #    record.errors.add attr, "must be an integer" \
+  #      unless (ocn.to_i if /\A[+-]?\d+\Z/.match?(ocn.to_s))
+  #  end
+  #end
 
   def initialize(params = nil)
     super

--- a/lib/reclusterer.rb
+++ b/lib/reclusterer.rb
@@ -16,12 +16,18 @@ class Reclusterer
       Services.logger.debug "Deleting and reclustering cluster #{@cluster.inspect}"
       @cluster.delete
 
-      @cluster.ocn_resolutions.each {|r| ClusterOCNResolution.new(r.dup).cluster.save }
-      @cluster.holdings.each {|h| ClusterHolding.new(h.dup).cluster.save }
-      # TODO: group and batch by OCN
-      @cluster.ht_items.each {|h| ClusterHtItem.new(h.dup).cluster.save }
-      @cluster.serials.each {|s| ClusterSerial.new(s.dup).cluster.save }
+      recluster_components
     end
+  end
+
+  private
+
+  def recluster_components
+    @cluster.ocn_resolutions.each {|r| ClusterOCNResolution.new(r.dup).cluster.save }
+    @cluster.holdings.each {|h| ClusterHolding.new(h.dup).cluster.save }
+    # TODO: group and batch by OCN
+    @cluster.ht_items.each {|h| ClusterHtItem.new(h.dup).cluster.save }
+    @cluster.serials.each {|s| ClusterSerial.new(s.dup).cluster.save }
   end
 
 end

--- a/lib/reclusterer.rb
+++ b/lib/reclusterer.rb
@@ -13,7 +13,7 @@ class Reclusterer
 
   def recluster
     Cluster.with_transaction do
-      puts "Deleting and reclustering cluster #{@cluster.inspect}"
+      Services.logger.debug "Deleting and reclustering cluster #{@cluster.inspect}"
       @cluster.delete
 
       @cluster.ocn_resolutions.each {|r| ClusterOCNResolution.new(r.dup).cluster.save }

--- a/lib/reclusterer.rb
+++ b/lib/reclusterer.rb
@@ -12,18 +12,16 @@ class Reclusterer
   end
 
   def recluster
-    @cluster.with_session do |session|
-      session.start_transaction
+    Cluster.with_transaction do
+      puts "Deleting and reclustering cluster #{@cluster.inspect}"
       @cluster.delete
 
-      @cluster.ocn_resolutions.each {|r| ClusterOCNResolution.new(r).cluster(transaction: false).save }
-      @cluster.holdings.each {|h| ClusterHolding.new(h).cluster(transaction: false).save }
+      @cluster.ocn_resolutions.each {|r| ClusterOCNResolution.new(r.dup).cluster.save }
+      @cluster.holdings.each {|h| ClusterHolding.new(h.dup).cluster.save }
       # TODO: group and batch by OCN
-      @cluster.ht_items.each {|h| ClusterHtItem.new(h.ocns, transaction: false).cluster([h]).save }
-      @cluster.serials.each {|s| ClusterSerial.new(s).cluster(transaction: false).save }
-      session.commit_transaction
+      @cluster.ht_items.each {|h| ClusterHtItem.new(h.ocns).cluster([h.dup]).save }
+      @cluster.serials.each {|s| ClusterSerial.new(s.dup).cluster.save }
     end
-    # TODO ClusterCommitment
   end
 
 end

--- a/lib/reclusterer.rb
+++ b/lib/reclusterer.rb
@@ -18,7 +18,8 @@ class Reclusterer
 
       @cluster.ocn_resolutions.each {|r| ClusterOCNResolution.new(r).cluster(transaction: false).save }
       @cluster.holdings.each {|h| ClusterHolding.new(h).cluster(transaction: false).save }
-      @cluster.ht_items.each {|h| ClusterHtItem.new(h).cluster(transaction: false).save }
+      # TODO: group and batch by OCN
+      @cluster.ht_items.each {|h| ClusterHtItem.new(h.ocns, transaction: false).cluster([h]).save }
       @cluster.serials.each {|s| ClusterSerial.new(s).cluster(transaction: false).save }
       session.commit_transaction
     end

--- a/lib/reclusterer.rb
+++ b/lib/reclusterer.rb
@@ -19,7 +19,7 @@ class Reclusterer
       @cluster.ocn_resolutions.each {|r| ClusterOCNResolution.new(r.dup).cluster.save }
       @cluster.holdings.each {|h| ClusterHolding.new(h.dup).cluster.save }
       # TODO: group and batch by OCN
-      @cluster.ht_items.each {|h| ClusterHtItem.new(h.ocns).cluster([h.dup]).save }
+      @cluster.ht_items.each {|h| ClusterHtItem.new(h.dup).cluster.save }
       @cluster.serials.each {|s| ClusterSerial.new(s.dup).cluster.save }
     end
   end

--- a/lib/reclusterer.rb
+++ b/lib/reclusterer.rb
@@ -12,12 +12,16 @@ class Reclusterer
   end
 
   def recluster
-    @cluster.delete
+    @cluster.with_session do |session|
+      session.start_transaction
+      @cluster.delete
 
-    @cluster.ocn_resolutions.each {|r| ClusterOCNResolution.new(r).cluster.save }
-    @cluster.holdings.each {|h| ClusterHolding.new(h).cluster.save }
-    @cluster.ht_items.each {|h| ClusterHtItem.new(h).cluster.save }
-    @cluster.serials.each {|s| ClusterSerial.new(s).cluster.save }
+      @cluster.ocn_resolutions.each {|r| ClusterOCNResolution.new(r).cluster(transaction: false).save }
+      @cluster.holdings.each {|h| ClusterHolding.new(h).cluster(transaction: false).save }
+      @cluster.ht_items.each {|h| ClusterHtItem.new(h).cluster(transaction: false).save }
+      @cluster.serials.each {|s| ClusterSerial.new(s).cluster(transaction: false).save }
+      session.commit_transaction
+    end
     # TODO ClusterCommitment
   end
 

--- a/lib/scrub_fields.rb
+++ b/lib/scrub_fields.rb
@@ -62,7 +62,7 @@ class ScrubFields
 
   attr_accessor :logger
 
-  def initialize(logger = $stdout)
+  def initialize(logger = Services.logger)
     # Store counts of events here using count_x(event)
     # and when you're done you can log stats_to_str()
     @stats  = {}
@@ -96,7 +96,7 @@ class ScrubFields
 
     if candidates.size > MAX_NUM_ITEMS
       count_x(:too_many_ocns)
-      @logger.puts "Too many items (#{candidates.size}) in ocn #{str}"
+      @logger.error "Too many items (#{candidates.size}) in ocn #{str}"
     end
 
     # DO WHILE MAYBE COMEFROM reject_value
@@ -160,12 +160,12 @@ class ScrubFields
     candidates = str.split(LOCAL_ID_SPLIT_DELIM)
 
     if candidates.size > 1
-      @logger.puts "there are #{candidates.size} candidates in this local_id"
+      @logger.warn "there are #{candidates.size} candidates in this local_id"
       # maybe throw something??
     end
 
     if candidates.size > MAX_NUM_ITEMS
-      @logger.puts "in fact lots of items #{candidates.size} in local_id #{str}"
+      @logger.error "in fact lots of items #{candidates.size} in local_id #{str}"
       # maybe definitely throw something??
     end
 
@@ -242,7 +242,7 @@ class ScrubFields
 
   # Directly throws :rejected_value
   def reject_value(reason, val)
-    @logger.puts [reason, val].join(":")
+    @logger.warn [reason, val].join(":")
     count_x("rejected: #{reason}")
     throw :rejected_value
   end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -9,6 +9,11 @@ require "logger"
 Services = Canister.new
 
 Services.register(:holdings_db) { HoldingsDB.new }
+Services.register(:ht_members) { HTMembers.new }
 Services.register(:ht_collections) { HTCollections.new }
 Services.register(:ht_members) { HTMembers.new }
-Services.register(:logger) { Logger.new(STDERR) }
+Services.register(:logger) do
+  Logger.new(STDERR).tap do |l|
+    l.level = Logger::INFO
+  end
+end

--- a/mongoid.yml
+++ b/mongoid.yml
@@ -1,3 +1,16 @@
+production:
+  clients:
+    default:
+      database: holdings
+      hosts:
+        - "<%= ENV['MONGODB_HOST'] %>"
+      options:
+        user: holdings
+        password: "<%= ENV['MONGODB_PASSWORD'] %>"
+        auth_source: admin
+  options:
+    raise_not_found_error: false
+
 development:
   clients:
     default:

--- a/mongoid.yml
+++ b/mongoid.yml
@@ -28,3 +28,4 @@ test:
         - mongo_test:27017
   options:
     raise_not_found_error: false
+    #    log_level: :debug

--- a/spec/cluster_ht_item_spec.rb
+++ b/spec/cluster_ht_item_spec.rb
@@ -1,151 +1,121 @@
-# frozen_string_literal: true
-
 require "spec_helper"
 require "cluster_ht_item"
 RSpec.describe ClusterHtItem do
-  let(:ht) { build(:ht_item) }
-  let(:c) { create(:cluster, ocns: ht.ocns) }
+  let(:item) { build(:ht_item) }
+  let(:ocns) { item.ocns }
+  let(:batch) { [item,build(:ht_item, ocns: ocns)] }
+  let(:empty_cluster) { create(:cluster, ocns: ocns) }
+  let(:cluster_with_item) { create(:cluster, ocns: ocns, ht_items: [item]) }
   let(:no_ocn) { build(:ht_item, ocns: []) }
 
+  before(:each) do
+    Cluster.each(&:delete)
+  end
+
   describe "#cluster" do
-    before(:each) do
-      Cluster.each(&:delete)
+    it "adds multiple htitems to the cluster" do
+      cluster = described_class.new(ocns).cluster(batch)
+      expect(cluster.ht_items.to_a.size).to eq(2)
+    end
+
+    it "first looks in the cluster it has for the htitem to update" do
+      # ocn hasn't changed, so htitem should be in the initial cluster we got and
+      # we shouldn't have to go fish
+      cluster_with_item.save
+      expect(Cluster).not_to receive(:with_ht_item)
+
+      update_item = build(:ht_item, item_id: item.item_id, ocns: item.ocns)
+      cluster = described_class.new(update_item.ocns).cluster([update_item])
     end
 
     it "adds an HT Item to an existing cluster" do
-      c.save
-      cluster = described_class.new(ht).cluster
-      expect(cluster.ht_items.first._parent.id).to eq(c.id)
+      empty_cluster.save
+      cluster = described_class.new(item.ocns).cluster([item])
+      expect(cluster.ht_items.first._parent.id).to eq(empty_cluster.id)
       expect(cluster.ht_items.to_a.size).to eq(1)
       expect(Cluster.each.to_a.size).to eq(1)
     end
 
     it "creates a new cluster if no match is found" do
-      c.save
-      new_cluster = described_class.new(build(:ht_item)).cluster
-      expect(new_cluster.id).not_to eq(c.id)
+      new_item = build(:ht_item)
+      empty_cluster.save
+      new_cluster = described_class.new(new_item.ocns).cluster([new_item])
+      expect(new_cluster.id).not_to eq(empty_cluster.id)
       expect(Cluster.each.to_a.size).to eq(2)
     end
 
     it "merges two or more clusters" do
       # first cluster with ht's ocns
-      c = described_class.new(ht).cluster
+      c = described_class.new(item.ocns).cluster([item])
       # a second cluster with different ocns
-      second_c = described_class.new(build(:ht_item)).cluster
+      new_item = build(:ht_item)
+      second_c = described_class.new(new_item.ocns).cluster([new_item])
       # ht with ocns overlapping both
-      overlapping_ht = build(:ht_item, ocns: c.ocns+second_c.ocns)
-      cluster = described_class.new(overlapping_ht).cluster
+      overlapping_item = build(:ht_item, ocns: c.ocns+second_c.ocns)
+      cluster = described_class.new(overlapping_item.ocns).cluster([overlapping_item])
       expect(Cluster.each.to_a.size).to eq(1)
       expect(cluster.ht_items.to_a.size).to eq(3)
     end
 
-    it "cluster has it's embed's ocns" do
-      c.save
-      ht.ocns << rand(1_000_000)
-      cluster = described_class.new(ht).cluster
-      expect(cluster.ocns).to eq(ht.ocns)
+    it "cluster has its embed's ocns" do
+      empty_cluster.save
+      item.ocns << rand(1_000_000)
+      cluster = described_class.new(item.ocns).cluster([item])
+      expect(cluster.ocns).to eq(item.ocns)
     end
 
     it "creates a new cluster for an OCNless Item" do
-      cluster = described_class.new(no_ocn).cluster
+      cluster = described_class.new([]).cluster([no_ocn])
       expect(cluster.ht_items.to_a.first.item_id).to eq(no_ocn.item_id)
     end
 
     it "cluster without OCN contains OCNless Item" do
-      cluster = described_class.new(no_ocn).cluster
+      cluster = described_class.new([]).cluster([no_ocn])
       expect(cluster.ht_items.to_a.first).to eq(no_ocn)
       expect(Cluster.each.to_a.first.ht_items.to_a.first).to eq(no_ocn)
     end
 
     it "creates a new cluster for multiple OCNless Items" do
       no_ocn2 = build(:ht_item, ocns: [])
-      cluster = described_class.new(no_ocn).cluster
-      cluster2 = described_class.new(no_ocn2).cluster
+      cluster = described_class.new([]).cluster([no_ocn])
+      cluster2 = described_class.new([]).cluster([no_ocn2])
       expect(cluster).not_to eq(cluster2)
       expect(Cluster.each.to_a.size).to eq(2)
     end
-  end
-
-  describe "#move" do
-    let(:c2) { create(:cluster) }
-
-    before(:each) do
-      Cluster.each(&:delete)
-      c.save
-    end
-
-    it "moves an HT Item from one cluster to another" do
-      cluster = described_class.new(ht).cluster
-      expect(cluster.ht_items.to_a.size).to eq(1)
-      described_class.new(ht).move(c2)
-      expect(cluster.ht_items.to_a.size).to eq(0)
-      expect(c2.ht_items.to_a.size).to eq(1)
-    end
-  end
-
-  describe "#delete" do
-    let(:ht2) { build(:ht_item, ocns: ht.ocns) }
-
-    before(:each) do
-      Cluster.each(&:delete)
-      c.save
-    end
-
-    it "removes the cluster if it's only that htitem" do
-      described_class.new(ht).cluster
-      expect(Cluster.each.to_a.size).to eq(1)
-      described_class.new(ht).delete
-      expect(Cluster.each.to_a.size).to eq(0)
-    end
-
-    it "creates a new cluster without the ht_item" do
-      described_class.new(ht).cluster
-      cluster = described_class.new(ht2).cluster
-      expect(cluster.ht_items.to_a.size).to eq(2)
-      described_class.new(ht).delete
-      expect(Cluster.each.to_a.first.ht_items.to_a.size).to eq(1)
-      expect(Cluster.each.to_a.first).not_to eq(cluster)
-    end
-  end
-
-  describe "#update" do
-    before(:each) do
-      Cluster.each(&:delete)
-    end
 
     context "with HT2 as an update to HT" do
-      let(:ht2) { build(:ht_item, item_id: ht.item_id) }
+      let(:update_item) { build(:ht_item, item_id: item.item_id) }
 
       it "removes the old cluster" do
-        first = described_class.new(ht).cluster
-        described_class.new(ht2).update
+        first = described_class.new(item.ocns).cluster([item])
+        described_class.new(update_item.ocns).cluster([update_item])
         expect(Cluster.each.to_a.size).to eq(1)
         new_cluster = Cluster.each.to_a.first
         expect(new_cluster).not_to eq(first)
-        expect(new_cluster.ht_items.first).to eq(ht2)
+        expect(new_cluster.ht_items.first).to eq(update_item)
       end
     end
 
     context "with HT2 with the same OCNS as HT" do
-      let(:ht2) { build(:ht_item, item_id: ht.item_id, ocns: ht.ocns) }
+      let(:update_item) { build(:ht_item, item_id: item.item_id, ocns: item.ocns) }
 
       it "only updates the HT Item" do
-        first = described_class.new(ht).cluster
-        updated = described_class.new(ht2).update
+        first = described_class.new(item.ocns).cluster([item])
+        updated = described_class.new(update_item.ocns).cluster([update_item])
         expect(first).to eq(updated)
         expect(
           Cluster.each.to_a.first.ht_items.first.to_hash
-        ).to eq(ht2.to_hash)
+        ).to eq(update_item.to_hash)
       end
     end
 
     it "reclusters an HTItem that gains an OCN" do
-      ocnless_cluster = described_class.new(no_ocn).cluster
+      ocnless_cluster = described_class.new([]).cluster([no_ocn])
       ocnless_cluster.save
-      c.save
+      empty_cluster.save
       expect(Cluster.each.to_a.size).to eq(2)
-      updated_ht = build(:ht_item, item_id: no_ocn.item_id, ocns: c.ocns)
-      described_class.new(updated_ht).update
+      updated_item = build(:ht_item, item_id: no_ocn.item_id, ocns: empty_cluster.ocns)
+      described_class.new(updated_item.ocns).cluster([updated_item])
       expect(Cluster.each.to_a.size).to eq(1)
     end
 
@@ -153,8 +123,53 @@ RSpec.describe ClusterHtItem do
       resolution = build(:ocn_resolution)
       htitem = build(:ht_item, ocns: [resolution.deprecated])
       create(:cluster, ocns: resolution.ocns, ocn_resolutions: [resolution])
-      c = described_class.new(htitem).cluster
+      c = described_class.new(htitem.ocns).cluster([htitem])
       expect(c.valid?).to be true
     end
   end
+
+
+  describe "#move" do
+    let(:c2) { create(:cluster) }
+
+    before(:each) do
+      Cluster.each(&:delete)
+      empty_cluster.save
+    end
+
+    it "moves an HT Item from one cluster to another" do
+      cluster = described_class.new(item.ocns).cluster([item])
+      expect(cluster.ht_items.to_a.size).to eq(1)
+      described_class.new(item.ocns).move(item,c2)
+      expect(cluster.ht_items.to_a.size).to eq(0)
+      expect(c2.ht_items.to_a.size).to eq(1)
+    end
+  end
+
+  describe "#delete" do
+    let(:item2) { build(:ht_item, ocns: item.ocns) }
+
+    before(:each) do
+      Cluster.each(&:delete)
+      empty_cluster.save
+    end
+
+    it "removes the cluster if it's only that htitem" do
+      described_class.new(item.ocns).cluster([item])
+      expect(Cluster.each.to_a.size).to eq(1)
+      described_class.new(item.ocns).delete(item)
+      expect(Cluster.each.to_a.size).to eq(0)
+    end
+
+    it "creates a new cluster without the ht_item" do
+      described_class.new(item.ocns).cluster([item])
+      cluster = described_class.new(item2.ocns).cluster([item2])
+      expect(cluster.ht_items.to_a.size).to eq(2)
+      described_class.new(item.ocns).delete(item)
+      expect(Cluster.each.to_a.first.ht_items.to_a.size).to eq(1)
+      expect(Cluster.each.to_a.first).not_to eq(cluster)
+    end
+  end
+
+
 end

--- a/spec/cluster_ht_item_spec.rb
+++ b/spec/cluster_ht_item_spec.rb
@@ -25,20 +25,20 @@ RSpec.describe ClusterHtItem do
     end
 
     it "accepts multiple HTItems as direct arguments" do
-      expect(described_class.new(item,item2)).not_to be nil
+      expect(described_class.new(item, item2)).not_to be nil
     end
 
     it "raises ArgumentError with two HTItems with different single OCNs" do
       expect do
-        described_class.new( [item, build(:ht_item)])
+        described_class.new([item, build(:ht_item)])
       end.to raise_exception(ArgumentError)
     end
 
     it "raises ArgumentError with two HTItems with different multiple OCNs" do
       expect do
         described_class.new([
-          build(:ht_item, ocns: [1,2]),
-          build(:ht_item, ocns: [1,3])
+          build(:ht_item, ocns: [1, 2]),
+          build(:ht_item, ocns: [1, 3])
         ])
       end.to raise_exception(ArgumentError)
     end
@@ -66,7 +66,7 @@ RSpec.describe ClusterHtItem do
       expect(Cluster).not_to receive(:with_ht_item)
 
       update_item = build(:ht_item, item_id: item.item_id, ocns: item.ocns)
-      cluster = described_class.new(update_item).cluster
+      described_class.new(update_item).cluster
     end
 
     it "adds an HT Item to an existing cluster" do

--- a/spec/cluster_ht_item_spec.rb
+++ b/spec/cluster_ht_item_spec.rb
@@ -4,8 +4,9 @@ require "spec_helper"
 require "cluster_ht_item"
 RSpec.describe ClusterHtItem do
   let(:item) { build(:ht_item) }
+  let(:item2) { build(:ht_item, ocns: ocns) }
   let(:ocns) { item.ocns }
-  let(:batch) { [item, build(:ht_item, ocns: ocns)] }
+  let(:batch) { [item, item2] }
   let(:empty_cluster) { create(:cluster, ocns: ocns) }
   let(:cluster_with_item) { create(:cluster, ocns: ocns, ht_items: [item]) }
   let(:no_ocn) { build(:ht_item, ocns: []) }
@@ -14,9 +15,47 @@ RSpec.describe ClusterHtItem do
     Cluster.each(&:delete)
   end
 
+  describe "#initialize" do
+    it "accepts a single HTItem" do
+      expect(described_class.new(item)).not_to be nil
+    end
+
+    it "accepts multiple HTItems as an array" do
+      expect(described_class.new(batch)).not_to be nil
+    end
+
+    it "accepts multiple HTItems as direct arguments" do
+      expect(described_class.new(item,item2)).not_to be nil
+    end
+
+    it "raises ArgumentError with two HTItems with different single OCNs" do
+      expect do
+        described_class.new( [item, build(:ht_item)])
+      end.to raise_exception(ArgumentError)
+    end
+
+    it "raises ArgumentError with two HTItems with different multiple OCNs" do
+      expect do
+        described_class.new([
+          build(:ht_item, ocns: [1,2]),
+          build(:ht_item, ocns: [1,3])
+        ])
+      end.to raise_exception(ArgumentError)
+    end
+
+    it "raises ArgumentError with two HTItems without an OCN" do
+      expect do
+        described_class.new([
+          build(:ht_item, ocns: []),
+          build(:ht_item, ocns: [])
+        ])
+      end.to raise_exception(ArgumentError)
+    end
+  end
+
   describe "#cluster" do
     it "adds multiple htitems to the cluster" do
-      cluster = described_class.new(ocns).cluster(batch)
+      cluster = described_class.new(batch).cluster
       expect(cluster.ht_items.to_a.size).to eq(2)
     end
 
@@ -27,12 +66,12 @@ RSpec.describe ClusterHtItem do
       expect(Cluster).not_to receive(:with_ht_item)
 
       update_item = build(:ht_item, item_id: item.item_id, ocns: item.ocns)
-      cluster = described_class.new(update_item.ocns).cluster([update_item])
+      cluster = described_class.new(update_item).cluster
     end
 
     it "adds an HT Item to an existing cluster" do
       empty_cluster.save
-      cluster = described_class.new(item.ocns).cluster([item])
+      cluster = described_class.new(item).cluster
       expect(cluster.ht_items.first._parent.id).to eq(empty_cluster.id)
       expect(cluster.ht_items.to_a.size).to eq(1)
       expect(Cluster.each.to_a.size).to eq(1)
@@ -41,20 +80,20 @@ RSpec.describe ClusterHtItem do
     it "creates a new cluster if no match is found" do
       new_item = build(:ht_item)
       empty_cluster.save
-      new_cluster = described_class.new(new_item.ocns).cluster([new_item])
+      new_cluster = described_class.new(new_item).cluster
       expect(new_cluster.id).not_to eq(empty_cluster.id)
       expect(Cluster.each.to_a.size).to eq(2)
     end
 
     it "merges two or more clusters" do
       # first cluster with ht's ocns
-      c = described_class.new(item.ocns).cluster([item])
+      c = described_class.new(item).cluster
       # a second cluster with different ocns
       new_item = build(:ht_item)
-      second_c = described_class.new(new_item.ocns).cluster([new_item])
+      second_c = described_class.new(new_item).cluster
       # ht with ocns overlapping both
       overlapping_item = build(:ht_item, ocns: c.ocns+second_c.ocns)
-      cluster = described_class.new(overlapping_item.ocns).cluster([overlapping_item])
+      cluster = described_class.new(overlapping_item).cluster
       expect(Cluster.each.to_a.size).to eq(1)
       expect(cluster.ht_items.to_a.size).to eq(3)
     end
@@ -62,25 +101,25 @@ RSpec.describe ClusterHtItem do
     it "cluster has its embed's ocns" do
       empty_cluster.save
       item.ocns << rand(1_000_000)
-      cluster = described_class.new(item.ocns).cluster([item])
+      cluster = described_class.new(item).cluster
       expect(cluster.ocns).to eq(item.ocns)
     end
 
     it "creates a new cluster for an OCNless Item" do
-      cluster = described_class.new([]).cluster([no_ocn])
+      cluster = described_class.new(no_ocn).cluster
       expect(cluster.ht_items.to_a.first.item_id).to eq(no_ocn.item_id)
     end
 
     it "cluster without OCN contains OCNless Item" do
-      cluster = described_class.new([]).cluster([no_ocn])
+      cluster = described_class.new(no_ocn).cluster
       expect(cluster.ht_items.to_a.first).to eq(no_ocn)
       expect(Cluster.each.to_a.first.ht_items.to_a.first).to eq(no_ocn)
     end
 
     it "creates a new cluster for multiple OCNless Items" do
       no_ocn2 = build(:ht_item, ocns: [])
-      cluster = described_class.new([]).cluster([no_ocn])
-      cluster2 = described_class.new([]).cluster([no_ocn2])
+      cluster = described_class.new(no_ocn).cluster
+      cluster2 = described_class.new(no_ocn2).cluster
       expect(cluster).not_to eq(cluster2)
       expect(Cluster.each.to_a.size).to eq(2)
     end
@@ -89,8 +128,8 @@ RSpec.describe ClusterHtItem do
       let(:update_item) { build(:ht_item, item_id: item.item_id) }
 
       it "removes the old cluster" do
-        first = described_class.new(item.ocns).cluster([item])
-        described_class.new(update_item.ocns).cluster([update_item])
+        first = described_class.new(item).cluster
+        described_class.new(update_item).cluster
         expect(Cluster.each.to_a.size).to eq(1)
         new_cluster = Cluster.each.to_a.first
         expect(new_cluster).not_to eq(first)
@@ -102,8 +141,8 @@ RSpec.describe ClusterHtItem do
       let(:update_item) { build(:ht_item, item_id: item.item_id, ocns: item.ocns) }
 
       it "only updates the HT Item" do
-        first = described_class.new(item.ocns).cluster([item])
-        updated = described_class.new(update_item.ocns).cluster([update_item])
+        first = described_class.new(item).cluster
+        updated = described_class.new(update_item).cluster
         expect(first).to eq(updated)
         expect(
           Cluster.each.to_a.first.ht_items.first.to_hash
@@ -112,12 +151,12 @@ RSpec.describe ClusterHtItem do
     end
 
     it "reclusters an HTItem that gains an OCN" do
-      ocnless_cluster = described_class.new([]).cluster([no_ocn])
+      ocnless_cluster = described_class.new(no_ocn).cluster
       ocnless_cluster.save
       empty_cluster.save
       expect(Cluster.each.to_a.size).to eq(2)
       updated_item = build(:ht_item, item_id: no_ocn.item_id, ocns: empty_cluster.ocns)
-      described_class.new(updated_item.ocns).cluster([updated_item])
+      described_class.new(updated_item).cluster
       expect(Cluster.each.to_a.size).to eq(1)
     end
 
@@ -125,7 +164,7 @@ RSpec.describe ClusterHtItem do
       resolution = build(:ocn_resolution)
       htitem = build(:ht_item, ocns: [resolution.deprecated])
       create(:cluster, ocns: resolution.ocns, ocn_resolutions: [resolution])
-      c = described_class.new(htitem.ocns).cluster([htitem])
+      c = described_class.new(htitem).cluster
       expect(c.valid?).to be true
     end
   end
@@ -139,11 +178,15 @@ RSpec.describe ClusterHtItem do
     end
 
     it "moves an HT Item from one cluster to another" do
-      cluster = described_class.new(item.ocns).cluster([item])
+      cluster = described_class.new(item).cluster
       expect(cluster.ht_items.to_a.size).to eq(1)
-      described_class.new(item.ocns).move(item, c2)
+      described_class.new(item).move(c2)
       expect(cluster.ht_items.to_a.size).to eq(0)
       expect(c2.ht_items.to_a.size).to eq(1)
+    end
+
+    it "won't move multiple htitems" do
+      expect { described_class.new(batch).move(c2) }.to raise_exception(ArgumentError)
     end
   end
 
@@ -156,19 +199,23 @@ RSpec.describe ClusterHtItem do
     end
 
     it "removes the cluster if it's only that htitem" do
-      described_class.new(item.ocns).cluster([item])
+      described_class.new(item).cluster
       expect(Cluster.each.to_a.size).to eq(1)
-      described_class.new(item.ocns).delete(item)
+      described_class.new(item).delete
       expect(Cluster.each.to_a.size).to eq(0)
     end
 
     it "creates a new cluster without the ht_item" do
-      described_class.new(item.ocns).cluster([item])
-      cluster = described_class.new(item2.ocns).cluster([item2])
+      described_class.new(item).cluster
+      cluster = described_class.new(item2).cluster
       expect(cluster.ht_items.to_a.size).to eq(2)
-      described_class.new(item.ocns).delete(item)
+      described_class.new(item).delete
       expect(Cluster.each.to_a.first.ht_items.to_a.size).to eq(1)
       expect(Cluster.each.to_a.first).not_to eq(cluster)
+    end
+
+    it "won't delete multiple items" do
+      expect { described_class.new(batch).delete }.to raise_exception(ArgumentError)
     end
   end
 end

--- a/spec/cluster_ht_item_spec.rb
+++ b/spec/cluster_ht_item_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "cluster_ht_item"
 RSpec.describe ClusterHtItem do
   let(:item) { build(:ht_item) }
   let(:ocns) { item.ocns }
-  let(:batch) { [item,build(:ht_item, ocns: ocns)] }
+  let(:batch) { [item, build(:ht_item, ocns: ocns)] }
   let(:empty_cluster) { create(:cluster, ocns: ocns) }
   let(:cluster_with_item) { create(:cluster, ocns: ocns, ht_items: [item]) }
   let(:no_ocn) { build(:ht_item, ocns: []) }
@@ -128,7 +130,6 @@ RSpec.describe ClusterHtItem do
     end
   end
 
-
   describe "#move" do
     let(:c2) { create(:cluster) }
 
@@ -140,7 +141,7 @@ RSpec.describe ClusterHtItem do
     it "moves an HT Item from one cluster to another" do
       cluster = described_class.new(item.ocns).cluster([item])
       expect(cluster.ht_items.to_a.size).to eq(1)
-      described_class.new(item.ocns).move(item,c2)
+      described_class.new(item.ocns).move(item, c2)
       expect(cluster.ht_items.to_a.size).to eq(0)
       expect(c2.ht_items.to_a.size).to eq(1)
     end
@@ -170,6 +171,4 @@ RSpec.describe ClusterHtItem do
       expect(Cluster.each.to_a.first).not_to eq(cluster)
     end
   end
-
-
 end

--- a/spec/concurrency_spec.rb
+++ b/spec/concurrency_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "cluster_ht_item"
+require "tmpdir"
+
+class InstrumentedClusterHtItem < ClusterHtItem
+
+  def initialize(ocns = [], pid:, tmpdir:, wait_before_merge: nil,
+    wait_before_save: nil, wait_before_delete: nil)
+    super(ocns)
+    @pid = pid
+    @wait_before_merge = wait_before_merge
+    @wait_before_save = wait_before_save
+    @wait_before_delete = wait_before_delete
+    @tmpdir = tmpdir
+  end
+
+  def cluster_for_ocns
+    wait_for(@wait_before_merge)
+
+    super.tap do |_c|
+      write_status("#{@pid}_got_cluster")
+      wait_for(@wait_before_save)
+    end
+  end
+
+  def cluster(htitems)
+    super(htitems).tap do |_c|
+      write_status("#{@pid}_saved_cluster")
+    end
+  end
+
+  def delete_htitem_and_recluster(c,ht_otem)
+    puts "before delete: htitems from #{c}: #{c.ht_items.inspect}"
+    write_status("#{@pid}_got_cluster")
+    wait_for(@wait_before_delete)
+    super
+  end
+
+  def write_status(file)
+    puts "#{@pid} writing status #{file}"
+    File.open("#{@tmpdir}/#{file}", "w") {|_| }
+  end
+
+  def wait_for(file)
+    puts "#{@pid} waiting on #{file}"
+    return unless file
+
+    sleep(0.05) until File.exist?("#{@tmpdir}/#{file}")
+  end
+end
+
+RSpec.describe "concurrency" do
+  def run_concurrent(first_process,second_process)
+    Dir.mktmpdir do |tmpdir|
+      fork do
+        second_process.call(tmpdir)
+      end
+      first_process.call(tmpdir)
+      Process.wait
+    end
+
+    setup_mongo
+    #Cluster.all.each {|c| puts JSON.pretty_generate(JSON.parse(c.to_json)) }
+  end
+
+  def setup_mongo
+    Mongoid.load!("mongoid.yml", :test)
+    Cluster.create_indexes
+  end
+
+  before(:each) do
+    Cluster.each(&:delete)
+  end
+
+  context "when a process writes an htitem into a cluster that was deleted in another process" do
+
+    let(:first_process) do
+      Proc.new do |tmpdir|
+        setup_mongo
+        ClusterHtItem.new([1]).cluster([]).save
+        ClusterHtItem.new([2]).cluster([]).save
+
+        ht_item = FactoryBot.build(:ht_item, ocns: [2])
+
+        InstrumentedClusterHtItem.new(ht_item.ocns, pid: "first",
+                                        wait_before_save: "second_got_cluster",
+                                        tmpdir: tmpdir).cluster([ht_item])
+      end
+    end
+
+    let(:second_process) do
+      Proc.new do |tmpdir|
+        setup_mongo
+        ht_item = FactoryBot.build(:ht_item, ocns: [1, 2])
+
+        InstrumentedClusterHtItem.new(ht_item.ocns, pid: "second",
+                                   wait_before_merge: "first_got_cluster",
+                                   wait_before_save: "first_saved_cluster",
+                                   tmpdir: tmpdir).cluster([ht_item])
+      end
+    end
+
+    it "doesn't lose the htitem" do
+      run_concurrent(first_process, second_process)
+      expect(Cluster.count).to eq(1)
+      expect(Cluster.first.ocns).to contain_exactly(1, 2)
+      expect(Cluster.first.ht_items.count).to eq(2)
+    end
+  end
+
+  context "when a process writes an htitem into a cluster that will be reclustered" do
+    # Reclusterer race condition potential scenario
+    #   - Process 1 gets a handle to the cluster and reads the htitems
+    #   - Process 2 adds an htitem to the cluster
+    #   - Process 1 deletes a different htitem and calls reclusterer
+    #   - Ensure the htitem added by process 2 hasn't disappeared
+
+    let(:first_ht_item)  { FactoryBot.build(:ht_item, ocns: [1,2]) }
+    let(:second_ht_item) { FactoryBot.build(:ht_item, ocns: [1]) }
+
+    let(:first_process) do
+      Proc.new do |tmpdir|
+        setup_mongo
+        ocns = first_ht_item.ocns
+        puts "first saving cluster"
+        ClusterHtItem.new(ocns).cluster([first_ht_item]).save
+
+        puts "first starting instrumentcluster"
+
+        InstrumentedClusterHtItem.new(ocns, pid: "first",
+                                     wait_before_delete: "second_saved_cluster",
+                                     tmpdir: tmpdir)
+          .delete(first_ht_item)
+
+      end
+    end
+
+    let(:second_process) do
+      Proc.new do |tmpdir|
+        setup_mongo
+
+        InstrumentedClusterHtItem.new(second_ht_item.ocns, pid: "second",
+                                   wait_before_save: "first_got_cluster",
+                                   tmpdir: tmpdir)
+          .cluster([second_ht_item])
+      end
+    end
+
+    it "doesn't lose the htitem added by the second process" do
+      run_concurrent(first_process, second_process)
+      expect(Cluster.count).to eq(1)
+      expect(Cluster.first.ocns).to contain_exactly(1)
+      expect(Cluster.first.ht_items.count).to eq(1)
+    end
+  end
+end

--- a/spec/fixtures/collections.rb
+++ b/spec/fixtures/collections.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+def mock_collections
+  HTCollections.new(
+    "TEST" => HTCollection.new(collection: "TEST", content_provider_cluster: "test",
+                               responsible_entity: "test", original_from_inst_id: "test",
+                               billing_entity: "test"),
+    "PU" => HTCollection.new(collection: "PU", content_provider_cluster: "upenn",
+                             responsible_entity: "upenn", original_from_inst_id: "upenn",
+                             billing_entity: "upenn"),
+    "MIU" => HTCollection.new(collection: "MIU", content_provider_cluster: "umich",
+                              responsible_entity: "umich", original_from_inst_id: "umich",
+                              billing_entity: "umich"),
+    "HVD" => HTCollection.new(collection: "HVD", content_provider_cluster: "harvard",
+                              responsible_entity: "harvard", original_from_inst_id: "harvard",
+                              billing_entity: "harvard"),
+    "OKS" => HTCollection.new(collection: "OKS", content_provider_cluster: "okstate",
+                              responsible_entity: "okstate", original_from_inst_id: "okstate",
+                              billing_entity: "okstate"),
+    "KEIO" => HTCollection.new(collection: "KEIO", content_provider_cluster: "keio",
+                               responsible_entity: "hathitrust", original_from_inst_id: "keio",
+                               billing_entity: "hathitrust")
+  )
+end

--- a/spec/fixtures/members.rb
+++ b/spec/fixtures/members.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+def mock_members
+  HTMembers.new(
+    "carleton" => HTMember.new(inst_id: "carleton", country_code: "us", weight: 1.0),
+    "umich" => HTMember.new(inst_id: "umich", country_code: "us", weight: 1.0),
+    "smu" => HTMember.new(inst_id: "smu", country_code: "us", weight: 1.0),
+    "stanford" => HTMember.new(inst_id: "stanford", country_code: "us", weight: 1.0),
+    "ualberta" => HTMember.new(inst_id: "ualberta", country_code: "ca", weight: 1.0),
+    "utexas" => HTMember.new(inst_id: "utexas", country_code: "us", weight: 3.0)
+  )
+end

--- a/spec/ht_collections_spec.rb
+++ b/spec/ht_collections_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe HTCollections do
   end
 
   describe "db connection" do
+    # Ensure we have a clean database connection for each test
+    around(:each) do |example|
+      old_holdings_db = Services.holdings_db
+      Services.register(:holdings_db) { HoldingsDB.connection }
+      example.run
+      Services.register(:holdings_db) { old_holdings_db }
+    end
+
     let(:ht_collections) { described_class.new }
 
     it "can fetch data from the database" do

--- a/spec/ht_item_spec.rb
+++ b/spec/ht_item_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe HtItem do
   let(:ocn_rand) { rand(1_000_000).to_i }
   let(:item_id_rand) { rand(1_000_000).to_s }
   let(:ht_bib_key_rand) { rand(1_000_000).to_i }
-  let(:htitem_hash) { build(:ht_item).to_hash }
+  let(:htitem) { build(:ht_item) }
+  let(:htitem_hash) { htitem.to_hash }
   let(:c) { create(:cluster, ocns: htitem_hash[:ocns]) }
 
   before(:each) do
@@ -20,11 +21,11 @@ RSpec.describe HtItem do
     expect(described_class.new(htitem_hash)).to be_a(described_class)
   end
 
-  it "does not have a parent" do
+  it "has no parent when built on its own" do
     expect(build(:ht_item)._parent).to be_nil
   end
 
-  it "has a parent" do
+  it "has a parent when created via a cluster" do
     c.ht_items.create(htitem_hash)
     expect(c.ht_items.first._parent).to be(c)
   end
@@ -49,32 +50,37 @@ RSpec.describe HtItem do
   end
 
   it "normalizes enum_chron" do
-    cloned = htitem_hash
-    enumchron_input = "v.1 Jul 1999"
-    cloned[:enum_chron] = enumchron_input
-    c.ht_items.create(cloned)
-    expect(c.ht_items.first.enum_chron).to eq(enumchron_input)
-    expect(c.ht_items.first.n_enum).to eq("1")
-    expect(c.ht_items.first.n_chron).to eq("Jul 1999")
+    htitem = build(:ht_item, enum_chron: "v.1 Jul 1999")
+    expect(htitem.enum_chron).to eq("v.1 Jul 1999")
+    expect(htitem.n_enum).to eq("1")
+    expect(htitem.n_chron).to eq("Jul 1999")
   end
 
   it "does nothing if given an empty enum_chron" do
-    cloned = htitem_hash
-    enumchron_input = ""
-    cloned[:enum_chron] = enumchron_input
-    c.ht_items.create(cloned)
-    expect(c.ht_items.first.enum_chron).to eq(enumchron_input)
-    expect(c.ht_items.first.n_enum).to eq(nil)
-    expect(c.ht_items.first.n_chron).to eq(nil)
+    htitem = build(:ht_item, enum_chron: "")
+    expect(htitem.enum_chron).to eq("")
+    expect(htitem.n_enum).to be nil
+    expect(htitem.n_chron).to be nil
   end
 
   it "has an access of deny or allow" do
     expect(build(:ht_item).access).to be_in(["allow", "deny"])
   end
 
+
   describe "#billing_entity" do
     it "is automatically set when collection_code is set" do
       expect(build(:ht_item, collection_code: "KEIO").billing_entity).to eq("hathitrust")
+    end
+  end
+
+  describe "#to_hash" do
+    it "contains content_provider_code" do
+      expect(htitem_hash[:content_provider_code]).not_to be nil
+    end
+
+    it "does not contain _id" do
+      expect(htitem_hash.key?(:_id)).to be false
     end
   end
 end

--- a/spec/ht_item_spec.rb
+++ b/spec/ht_item_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe HtItem do
     expect(build(:ht_item).access).to be_in(["allow", "deny"])
   end
 
-
   describe "#billing_entity" do
     it "is automatically set when collection_code is set" do
       expect(build(:ht_item, collection_code: "KEIO").billing_entity).to eq("hathitrust")
@@ -75,8 +74,8 @@ RSpec.describe HtItem do
   end
 
   describe "#to_hash" do
-    it "contains content_provider_code" do
-      expect(htitem_hash[:content_provider_code]).not_to be nil
+    it "contains billing_entity" do
+      expect(htitem_hash[:billing_entity]).not_to be nil
     end
 
     it "does not contain _id" do

--- a/spec/ht_members_spec.rb
+++ b/spec/ht_members_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe HTMembers do
 
   let(:ht_members) { described_class.new(mock_data) }
 
+  let(:temp_member) do
+    HTMember.new(inst_id: "temp", country_code: "zz", weight: 1.0)
+  end
+
   describe "#[]" do
     it "can fetch an institution" do
       expect(ht_members["example"].country_code).to eq("xx")
@@ -32,40 +36,42 @@ RSpec.describe HTMembers do
   end
 
   describe "#add_temp" do
-    let(:temp_member) do
-      HTMember.new(inst_id: "temp", country_code: "zz", weight: 1.0)
-    end
-
     it "can add a temporary institution" do
-      expect(described_class.new(mock_data)
-        .add_temp(temp_member)).not_to be(nil)
+      expect(ht_members.add_temp(temp_member)).not_to be(nil)
     end
 
     it "can fetch a temporary institution" do
-      ht_members = described_class.new(mock_data)
       ht_members.add_temp(temp_member)
 
       expect(ht_members["temp"].country_code).to eq("zz")
     end
+  end
 
-    describe "db connection" do
-      let(:ht_members) { described_class.new }
+  describe "db connection" do
+    let(:ht_members) { described_class.new }
 
-      it "can fetch data from the database" do
-        expect(ht_members["umich"].country_code).to eq("us")
-        expect(ht_members["umich"].weight).to eq(1.33)
-        expect(ht_members["umich"].oclc_sym).to eq("EYM")
-      end
+    # Ensure we have a clean database connection for each test
+    around(:each) do |example|
+      old_holdings_db = Services.holdings_db
+      Services.register(:holdings_db) { HoldingsDB.connection }
+      example.run
+      Services.register(:holdings_db) { old_holdings_db }
+    end
 
-      it "can fetch the full set of members" do
-        expect(ht_members.members.size).to be > 10
-      end
+    it "can fetch data from the database" do
+      expect(ht_members["umich"].country_code).to eq("us")
+      expect(ht_members["umich"].weight).to eq(1.33)
+      expect(ht_members["umich"].oclc_sym).to eq("EYM")
+    end
 
-      it "does not persist temp members to the database/across instances" do
-        ht_members.add_temp(temp_member)
+    it "can fetch the full set of members" do
+      expect(ht_members.members.size).to be > 10
+    end
 
-        expect(described_class.new.members.key?("temp")).to be false
-      end
+    it "does not persist temp members to the database/across instances" do
+      ht_members.add_temp(temp_member)
+
+      expect(described_class.new.members.key?("temp")).to be false
     end
   end
 end

--- a/spec/overlap_report_mysql_import_spec.rb
+++ b/spec/overlap_report_mysql_import_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe "overlap_report_import_to_mysql" do
     org = nil # all orgs
     File.open(tempfilepath, "w:utf-8") do |tmpfile|
       matching_clusters(org).each do |c|
-        puts "adding #{c}"
         ClusterOverlap.new(c, org).each do |overlap|
           tmpfile.puts overlap_line(overlap.to_hash)
         end

--- a/spec/single_part_overlap_spec.rb
+++ b/spec/single_part_overlap_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "spec_helper"
+require "cluster_holding"
 require "single_part_overlap"
 
 RSpec.describe SinglePartOverlap do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,5 +55,9 @@ RSpec.configure do |config|
         "utexas" => HTMember.new(inst_id: "utexas", country_code: "us", weight: 3.0)
       )
     end
+
+    Services.register(:logger) do
+      Logger.new("test.log").tap { |l| l.level == Logger::DEBUG }
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,4 +40,20 @@ RSpec.configure do |config|
   config.before(:suite) do
     FactoryBot.find_definitions
   end
+
+  config.before(:all) do
+    # Ensure we don't try to use DB for tests by default and that we have
+    # mock HT member data to use in tests
+    Services.register(:holdings_db) { nil }
+    Services.register(:ht_members) do
+      HTMembers.new(
+        "carleton" => HTMember.new(inst_id: "carleton", country_code: "us", weight: 1.0),
+        "umich" => HTMember.new(inst_id: "umich", country_code: "us", weight: 1.0),
+        "smu" => HTMember.new(inst_id: "smu", country_code: "us", weight: 1.0),
+        "stanford" => HTMember.new(inst_id: "stanford", country_code: "us", weight: 1.0),
+        "ualberta" => HTMember.new(inst_id: "ualberta", country_code: "ca", weight: 1.0),
+        "utexas" => HTMember.new(inst_id: "utexas", country_code: "us", weight: 3.0)
+      )
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require "factory_bot"
 require "simplecov"
 require "mongoid"
 require "fixtures/members"
+require "fixtures/collections"
 SimpleCov.start
 
 Mongoid.load!("mongoid.yml", :test)
@@ -47,6 +48,7 @@ RSpec.configure do |config|
     # mock HT member data to use in tests
     Services.register(:holdings_db) { nil }
     Services.register(:ht_members) { mock_members }
+    Services.register(:ht_collections) { mock_collections }
 
     Services.register(:logger) do
       Logger.new("test.log").tap {|l| l.level = Logger::DEBUG }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require "bundler/setup"
 require "factory_bot"
 require "simplecov"
 require "mongoid"
+require "fixtures/members"
 SimpleCov.start
 
 Mongoid.load!("mongoid.yml", :test)
@@ -45,19 +46,10 @@ RSpec.configure do |config|
     # Ensure we don't try to use DB for tests by default and that we have
     # mock HT member data to use in tests
     Services.register(:holdings_db) { nil }
-    Services.register(:ht_members) do
-      HTMembers.new(
-        "carleton" => HTMember.new(inst_id: "carleton", country_code: "us", weight: 1.0),
-        "umich" => HTMember.new(inst_id: "umich", country_code: "us", weight: 1.0),
-        "smu" => HTMember.new(inst_id: "smu", country_code: "us", weight: 1.0),
-        "stanford" => HTMember.new(inst_id: "stanford", country_code: "us", weight: 1.0),
-        "ualberta" => HTMember.new(inst_id: "ualberta", country_code: "ca", weight: 1.0),
-        "utexas" => HTMember.new(inst_id: "utexas", country_code: "us", weight: 3.0)
-      )
-    end
+    Services.register(:ht_members) { mock_members }
 
     Services.register(:logger) do
-      Logger.new("test.log").tap { |l| l.level == Logger::DEBUG }
+      Logger.new("test.log").tap {|l| l.level = Logger::DEBUG }
     end
   end
 end


### PR DESCRIPTION
This is a large PR, but primarily addresses concerns around:

1) performance with respect to large clusters, by batching operations that pertain to a single OCN

2) concurrency support, by:
 - using multi-document transactions when merging and splitting
 - using the underlying Mongo update operator to allows detection of if we updated a document deleted out from under us
 - retrying operations when they fail
 - adding specs to verify this all works.

It also:
 - adds some support towards using this code in loading data in production
 - cleans up the output from specs by using `Logger` instead of `puts`

The next step is to apply the changes to `ClusterHtItem` to the other `Cluster` classes, and likely extract some of the common functionality from those objects, but I would like to get this PR merged and into master before I attempt that.