### PR TITLE
Ht 2467 holdings enumchron

### DIFF
--- a/lib/enum_chron.rb
+++ b/lib/enum_chron.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "enum_chron_parser"
+require "services"
+
+# Handles automatic normalization of enum_chron fields for Holdings and HTItems
+module EnumChron
+
+  def initialize(params = nil)
+    super
+    normalize_enum_chron
+  end
+
+  def enum_chron=(enum_chron)
+    super
+    normalize_enum_chron
+  end
+
+  def normalize_enum_chron
+    # normalize into separate n_enum and n_chron
+    unless enum_chron.nil?
+      ec_parser = EnumChronParser.new
+      ec_parser.parse(enum_chron)
+      self.n_enum  = ec_parser.normalized_enum
+      self.n_chron = ec_parser.normalized_chron
+    end
+  end
+end

--- a/lib/holding.rb
+++ b/lib/holding.rb
@@ -29,12 +29,28 @@ class Holding
 
   def initialize(params = nil)
     super
+    normalize_enum_chron
     set_member_data if organization
   end
 
   def organization=(organization)
     super
     set_member_data
+  end
+
+  def enum_chron=(enum_chron)
+    super
+    normalize_enum_chron
+  end
+
+  def normalize_enum_chron
+    # normalize into separate n_enum and n_chron
+    unless enum_chron.nil?
+      ec_parser = EnumChronParser.new
+      ec_parser.parse(enum_chron)
+      self.n_enum  = ec_parser.normalized_enum
+      self.n_chron = ec_parser.normalized_chron
+    end
   end
 
   # Convert a tsv line from a validated holding file into a record like hash

--- a/lib/holding.rb
+++ b/lib/holding.rb
@@ -3,10 +3,12 @@
 require "mongoid"
 require "ht_members"
 require "services"
+require "enum_chron"
 
 # A member holding
 class Holding
   include Mongoid::Document
+  include EnumChron
   # Changes to the field list must be reflected in `==` and `same_as`
   field :ocn, type: Integer
   field :organization, type: String
@@ -29,28 +31,12 @@ class Holding
 
   def initialize(params = nil)
     super
-    normalize_enum_chron
     set_member_data if organization
   end
 
   def organization=(organization)
     super
     set_member_data
-  end
-
-  def enum_chron=(enum_chron)
-    super
-    normalize_enum_chron
-  end
-
-  def normalize_enum_chron
-    # normalize into separate n_enum and n_chron
-    unless enum_chron.nil?
-      ec_parser = EnumChronParser.new
-      ec_parser.parse(enum_chron)
-      self.n_enum  = ec_parser.normalized_enum
-      self.n_chron = ec_parser.normalized_chron
-    end
   end
 
   # Convert a tsv line from a validated holding file into a record like hash

--- a/lib/ht_item.rb
+++ b/lib/ht_item.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mongoid"
-require "enum_chron_parser"
+require "enum_chron"
 require "services"
 
 # An HT Item
@@ -17,6 +17,7 @@ require "services"
 # - billing_entity
 class HtItem
   include Mongoid::Document
+  include EnumChron
   field :ocns, type: Array, default: []
   field :item_id, type: String
   field :ht_bib_key, type: Integer
@@ -42,29 +43,12 @@ class HtItem
 
   def initialize(params = nil)
     super
-    normalize_enum_chron
     set_billing_entity if collection_code
   end
 
   def collection_code=(collection_code)
     super
     set_billing_entity
-  end
-
-  def enum_chron=(enum_chron)
-    super
-    normalize_enum_chron
-  end
-
-  def normalize_enum_chron
-    # When created with an enumchron, normalize it into separate
-    # n_enum and n_chron
-    unless enum_chron.nil?
-      ec_parser = EnumChronParser.new
-      ec_parser.parse(enum_chron)
-      self.n_enum  = ec_parser.normalized_enum
-      self.n_chron = ec_parser.normalized_chron
-    end
   end
 
   def to_hash

--- a/spec/holding_spec.rb
+++ b/spec/holding_spec.rb
@@ -18,6 +18,19 @@ RSpec.describe Holding do
     expect(c.holdings.first._parent).to be(c)
   end
 
+  it "normalizees enum_chron" do
+    holding = build(:holding, enum_chron: "v.1 Jul 1999")
+    expect(holding.n_enum).to eq("1")
+    expect(holding.n_chron).to eq("Jul 1999")
+  end
+
+  it "does nothing if given an empty enum_chron" do
+    holding = build(:holding, enum_chron:"")
+    expect(holding.enum_chron).to eq("")
+    expect(holding.n_enum).to be nil
+    expect(holding.n_chron).to be nil
+  end
+
   describe "#==" do
     it "== is true if all fields match except date_received" do
       h2.date_received = Date.yesterday
@@ -60,7 +73,7 @@ RSpec.describe Holding do
       rec = described_class.new_from_holding_file_line(line)
       expect(rec).to be_a(described_class)
       expect(rec.mono_multi_serial).to eq("mono")
-      expect(rec.n_enum).to eq("")
+      expect(rec.n_enum).to eq(nil)
     end
   end
 end

--- a/spec/holding_spec.rb
+++ b/spec/holding_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Holding do
   end
 
   it "does nothing if given an empty enum_chron" do
-    holding = build(:holding, enum_chron:"")
+    holding = build(:holding, enum_chron: "")
     expect(holding.enum_chron).to eq("")
     expect(holding.n_enum).to be nil
     expect(holding.n_chron).to be nil


### PR DESCRIPTION
First commit duplicates the HTItem enumchron normalization code/tests for Holdings. 
Second commit moves duplicative code into a module. Maybe silly.