### PR TITLE
Test for KEIO contributed items

### DIFF
--- a/spec/ht_item_overlap_spec.rb
+++ b/spec/ht_item_overlap_spec.rb
@@ -65,10 +65,26 @@ RSpec.describe HtItemOverlap do
   end
 
   describe "#h_share" do
+    let(:keio_item) do
+      build(:ht_item,
+            ocns: c.ocns,
+            collection_code: "KEIO",
+            enum_chron: "1")
+    end
+
     it "returns ratio of organizations" do
       c.reload
       overlap = described_class.new(c.ht_items.first)
       expect(overlap.h_share("umich")).to eq(1.0 / 3)
+    end
+
+    it "assigns an h_share to hathitrust for KEIO items" do
+      ClusterHtItem.new(keio_item).cluster.tap(&:save)
+      c.reload
+      overlap = described_class.new(c.ht_items.first)
+      expect(c.ht_items.first.billing_entity).not_to eq("hathitrust")
+      expect(overlap.h_share("hathitrust")).to eq(1.0 / 4)
+      expect(overlap.h_share("umich")).to eq(1.0 / 4)
     end
 
     it "returns 0 if not held" do


### PR DESCRIPTION
A single test to confirm the allocation of hshares for KEIO contributed items. It is redundant, but makes the relationship of hshares and HTItem billing entities more explicit. Also, HT-2623.