### PR TITLE
HT-2621 Confirm UCM HTItems are treated as any other

### DIFF
--- a/spec/fixtures/collections.rb
+++ b/spec/fixtures/collections.rb
@@ -14,11 +14,11 @@ def mock_collections
     "HVD" => HTCollection.new(collection: "HVD", content_provider_cluster: "harvard",
                               responsible_entity: "harvard", original_from_inst_id: "harvard",
                               billing_entity: "harvard"),
-    "OKS" => HTCollection.new(collection: "OKS", content_provider_cluster: "okstate",
-                              responsible_entity: "okstate", original_from_inst_id: "okstate",
-                              billing_entity: "okstate"),
     "KEIO" => HTCollection.new(collection: "KEIO", content_provider_cluster: "keio",
                                responsible_entity: "hathitrust", original_from_inst_id: "keio",
-                               billing_entity: "hathitrust")
+                               billing_entity: "hathitrust"),
+    "UCM" => HTCollection.new(collection: "UCM", content_provider_cluster: "ucm",
+                               responsible_entity: "ucm", original_from_inst_id: "ucm",
+                               billing_entity: "ucm")
   )
 end

--- a/spec/ht_collections_spec.rb
+++ b/spec/ht_collections_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe HTCollections do
     it "can fetch data from the database" do
       expect(ht_collections["MIU"].billing_entity).to eq("umich")
       expect(ht_collections["KEIO"].billing_entity).to eq("hathitrust")
+      expect(ht_collections["UCM"].billing_entity).to eq("ucm")
     end
 
     it "can fetch the full set of members" do

--- a/spec/ht_item_overlap_spec.rb
+++ b/spec/ht_item_overlap_spec.rb
@@ -72,6 +72,13 @@ RSpec.describe HtItemOverlap do
             enum_chron: "1")
     end
 
+    let(:ucm_item) do
+      build(:ht_item,
+            ocns: c.ocns,
+            collection_code: "UCM",
+            enum_chron: "1")
+    end
+
     it "returns ratio of organizations" do
       c.reload
       overlap = described_class.new(c.ht_items.first)
@@ -84,6 +91,15 @@ RSpec.describe HtItemOverlap do
       overlap = described_class.new(c.ht_items.first)
       expect(c.ht_items.first.billing_entity).not_to eq("hathitrust")
       expect(overlap.h_share("hathitrust")).to eq(1.0 / 4)
+      expect(overlap.h_share("umich")).to eq(1.0 / 4)
+    end
+
+    it "assigns an h_share to UCM as it would anyone else" do
+      ClusterHtItem.new(ucm_item).cluster.tap(&:save)
+      c.reload
+      overlap = described_class.new(c.ht_items.first)
+      expect(c.ht_items.first.billing_entity).not_to eq("ucm")
+      expect(overlap.h_share("ucm")).to eq(1.0 / 4)
       expect(overlap.h_share("umich")).to eq(1.0 / 4)
     end
 

--- a/spec/single_part_overlap_spec.rb
+++ b/spec/single_part_overlap_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SinglePartOverlap do
           ocns: c.ocns,
           bib_fmt: "spm",
           enum_chron: "",
-          collection_code: "OKS")
+          collection_code: "HVD")
   end
   let(:h) { build(:holding, ocn: c.ocns.first, organization: "umich", status: "lm") }
   let(:h2) do


### PR DESCRIPTION
This is expected behavior, although it may not be current behavior. This has the potential to create a few dollar discrepancy that will need explaining later.

* OKS was removed from the HTCollections fixture because rubocop was complaining about method length and we had no need for that particular collection.