### PR TITLE
Bugfix: HTItems w/o n_enum match all other items

### DIFF
--- a/lib/multi_part_overlap.rb
+++ b/lib/multi_part_overlap.rb
@@ -6,9 +6,13 @@ require "overlap"
 class MultiPartOverlap < Overlap
 
   def members_with_matching_ht_items
-    @cluster.ht_items.where("$or": [{ n_enum: @ht_item.n_enum },
-                                    { n_enum: nil }])
-      .pluck(:billing_entity).uniq
+    if @ht_item.n_enum.nil? || (@ht_item.n_enum == "")
+      @cluster.ht_items.pluck(:billing_entity).uniq
+    else
+      @cluster.ht_items.where("$or": [{ n_enum: @ht_item.n_enum },
+                                      { n_enum: nil }])
+        .pluck(:billing_entity).uniq
+    end
   end
 
   def copy_count

--- a/spec/multi_part_overlap_spec.rb
+++ b/spec/multi_part_overlap_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe MultiPartOverlap do
       overlap = described_class.new(cluster, "different_member", ht_w_ec)
       expect(overlap.members_with_matching_ht_items).to include("different_member")
     end
+
+    it "finds a member with any ht_item if this ht_item enumchron is nil" do
+      ht_w_ec_dupe = ht_wo_ec.clone
+      ht_w_ec_dupe.enum_chron = "1"
+      ht_w_ec_dupe.billing_entity = "different_member"
+      ClusterHtItem.new(ht_wo_ec).cluster.tap(&:save)
+      cluster = ClusterHtItem.new(ht_w_ec_dupe).cluster.tap(&:save)
+      overlap = described_class.new(cluster, "different_member", ht_wo_ec)
+      expect(overlap.members_with_matching_ht_items).to include("different_member")
+    end
   end
 
   describe "#matching_holdings" do


### PR DESCRIPTION
  - HTItems with n_enum were matching those without, but not the reverse.