### PR TITLE
Bugfix: HTItems w/o n_enum match all other items

### DIFF
--- a/lib/enum_chron.rb
+++ b/lib/enum_chron.rb
@@ -7,8 +7,9 @@ require "services"
 module EnumChron
 
   def initialize(params = nil)
+    params ||= {}
+    params[:enum_chron] ||= ""
     super
-    normalize_enum_chron
   end
 
   def enum_chron=(enum_chron)
@@ -18,7 +19,6 @@ module EnumChron
 
   def normalize_enum_chron
     # normalize into separate n_enum and n_chron
-    enum_chron = self.enum_chron || ""
     ec_parser = EnumChronParser.new
     ec_parser.parse(enum_chron)
     self.n_enum  = ec_parser.normalized_enum || ""

--- a/lib/enum_chron.rb
+++ b/lib/enum_chron.rb
@@ -18,11 +18,10 @@ module EnumChron
 
   def normalize_enum_chron
     # normalize into separate n_enum and n_chron
-    unless enum_chron.nil?
-      ec_parser = EnumChronParser.new
-      ec_parser.parse(enum_chron)
-      self.n_enum  = ec_parser.normalized_enum
-      self.n_chron = ec_parser.normalized_chron
-    end
+    enum_chron = self.enum_chron || ""
+    ec_parser = EnumChronParser.new
+    ec_parser.parse(enum_chron)
+    self.n_enum  = ec_parser.normalized_enum || ""
+    self.n_chron = ec_parser.normalized_chron || ""
   end
 end

--- a/lib/holding.rb
+++ b/lib/holding.rb
@@ -13,9 +13,9 @@ class Holding
   field :ocn, type: Integer
   field :organization, type: String
   field :local_id, type: String
-  field :enum_chron, type: String
+  field :enum_chron, type: String, default: ""
   field :n_enum, type: String, default: ""
-  field :n_chron, type: String
+  field :n_chron, type: String, default: ""
   field :status, type: String
   field :condition, type: String
   field :gov_doc_flag, type: Boolean

--- a/lib/ht_item.rb
+++ b/lib/ht_item.rb
@@ -24,9 +24,9 @@ class HtItem
   field :rights, type: String
   field :access, type: String
   field :bib_fmt, type: String
-  field :enum_chron, type: String
-  field :n_enum, type: String
-  field :n_chron, type: String
+  field :enum_chron, type: String, default: ""
+  field :n_enum, type: String, default: ""
+  field :n_chron, type: String, default: ""
   field :collection_code, type: String
   field :billing_entity, type: String
 

--- a/lib/multi_part_overlap.rb
+++ b/lib/multi_part_overlap.rb
@@ -9,8 +9,7 @@ class MultiPartOverlap < Overlap
     if @ht_item.n_enum == ""
       @cluster.ht_items.pluck(:billing_entity).uniq
     else
-      @cluster.ht_items.where("$or": [{ n_enum: @ht_item.n_enum },
-                                      { n_enum: "" }])
+      @cluster.ht_items.select {|h| h.n_enum.empty? || h.n_enum == @ht_item.n_enum }
         .pluck(:billing_entity).uniq
     end
   end

--- a/lib/multi_part_overlap.rb
+++ b/lib/multi_part_overlap.rb
@@ -6,9 +6,13 @@ require "overlap"
 class MultiPartOverlap < Overlap
 
   def members_with_matching_ht_items
-    @cluster.ht_items.where("$or": [{ n_enum: @ht_item.n_enum },
-                                    { n_enum: nil }])
-      .pluck(:billing_entity).uniq
+    if @ht_item.n_enum == ""
+      @cluster.ht_items.pluck(:billing_entity).uniq
+    else
+      @cluster.ht_items.where("$or": [{ n_enum: @ht_item.n_enum },
+                                      { n_enum: "" }])
+        .pluck(:billing_entity).uniq
+    end
   end
 
   def copy_count
@@ -38,7 +42,7 @@ class MultiPartOverlap < Overlap
   end
 
   def matching_holdings
-    if @ht_item.n_enum.nil? || (@ht_item.n_enum == "")
+    if @ht_item.n_enum == ""
       @cluster.holdings.where(organization: @org)
     else
       @cluster.holdings.where(organization: @org,

--- a/spec/enum_chron_spec.rb
+++ b/spec/enum_chron_spec.rb
@@ -6,7 +6,9 @@ require "enum_chron"
 class DummyRecord
   include Mongoid::Document
   include EnumChron
-  attr_accessor :enum_chron, :n_enum, :n_chron
+  field :enum_chron
+  field :n_enum
+  field :n_chron
 
 end
 
@@ -16,6 +18,7 @@ RSpec.describe EnumChron do
   let(:rec_wo_ec) { DummyRecord.new }
 
   it "uses EnumChronParser to set n_chron and n_enum" do
+    expect(rec_w_ec.enum_chron).to eq("1 aug")
     expect(rec_w_ec.n_enum).to eq("1")
     expect(rec_w_ec.n_chron).to eq("aug")
   end
@@ -26,6 +29,7 @@ RSpec.describe EnumChron do
   end
 
   it "sets n_chron and n_enum to empty string if nil enumchron" do
+    expect(rec_wo_ec.enum_chron).to eq("")
     expect(rec_wo_ec.n_chron).to eq("")
     expect(rec_wo_ec.n_enum).to eq("")
   end

--- a/spec/enum_chron_spec.rb
+++ b/spec/enum_chron_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "enum_chron"
+
+class DummyRecord
+  include Mongoid::Document
+  include EnumChron
+  attr_accessor :enum_chron, :n_enum, :n_chron
+
+end
+
+RSpec.describe EnumChron do
+  let(:rec_w_ec) { DummyRecord.new(enum_chron: "1 aug") }
+  let(:rec_w_empty_ec) { DummyRecord.new(enum_chron: "") }
+  let(:rec_wo_ec) { DummyRecord.new }
+
+  it "uses EnumChronParser to set n_chron and n_enum" do
+    expect(rec_w_ec.n_enum).to eq("1")
+    expect(rec_w_ec.n_chron).to eq("aug")
+  end
+
+  it "sets n_chron and n_enum to empty string if empty enumchron" do
+    expect(rec_w_empty_ec.n_chron).to eq("")
+    expect(rec_w_empty_ec.n_enum).to eq("")
+  end
+
+  it "sets n_chron and n_enum to empty string if nil enumchron" do
+    expect(rec_wo_ec.n_chron).to eq("")
+    expect(rec_wo_ec.n_enum).to eq("")
+  end
+end

--- a/spec/holding_spec.rb
+++ b/spec/holding_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Holding do
   it "does nothing if given an empty enum_chron" do
     holding = build(:holding, enum_chron: "")
     expect(holding.enum_chron).to eq("")
-    expect(holding.n_enum).to be nil
-    expect(holding.n_chron).to be nil
+    expect(holding.n_enum).to eq("")
+    expect(holding.n_chron).to eq("")
   end
 
   describe "#==" do
@@ -73,7 +73,7 @@ RSpec.describe Holding do
       rec = described_class.new_from_holding_file_line(line)
       expect(rec).to be_a(described_class)
       expect(rec.mono_multi_serial).to eq("mono")
-      expect(rec.n_enum).to eq(nil)
+      expect(rec.n_enum).to eq("")
     end
   end
 end

--- a/spec/ht_item_spec.rb
+++ b/spec/ht_item_spec.rb
@@ -56,11 +56,11 @@ RSpec.describe HtItem do
     expect(htitem.n_chron).to eq("Jul 1999")
   end
 
-  it "does nothing if given an empty enum_chron" do
+  it "gives empty string if given an empty enum_chron" do
     htitem = build(:ht_item, enum_chron: "")
     expect(htitem.enum_chron).to eq("")
-    expect(htitem.n_enum).to be nil
-    expect(htitem.n_chron).to be nil
+    expect(htitem.n_enum).to eq("")
+    expect(htitem.n_chron).to eq("")
   end
 
   it "has an access of deny or allow" do

--- a/spec/multi_part_overlap_spec.rb
+++ b/spec/multi_part_overlap_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe MultiPartOverlap do
       overlap = described_class.new(cluster, "different_member", ht_w_ec)
       expect(overlap.members_with_matching_ht_items).to include("different_member")
     end
+
+    it "finds a member with any ht_item if this ht_item enumchron is nil" do
+      ht_w_ec_dupe = ht_wo_ec.clone
+      ht_w_ec_dupe.enum_chron = "1"
+      ht_w_ec_dupe.billing_entity = "different_member"
+      ClusterHtItem.new(ht_wo_ec).cluster.tap(&:save)
+      cluster = ClusterHtItem.new(ht_w_ec_dupe).cluster.tap(&:save)
+      overlap = described_class.new(cluster, "different_member", ht_wo_ec)
+      expect(overlap.members_with_matching_ht_items).to include("different_member")
+    end
   end
 
   describe "#matching_holdings" do


### PR DESCRIPTION
  - HTItems with n_enum were matching those without, but not the reverse.
  - n_enum and n_chron default to "" instead of nil