### PR TITLE
HT-2638: output more useful debug info for cluster compare

### DIFF
--- a/lib/compare_cluster.rb
+++ b/lib/compare_cluster.rb
@@ -19,7 +19,7 @@ class CompareCluster
     puts "Comparing holdings for htitem #{item_id}; " \
       "cluster format: #{CalculateFormat.new(@cluster).cluster_format}"
 
-    compare_htitems
+    #compare_htitems
     compare_holdings_keys
     compare_holdings_values
   end
@@ -105,7 +105,7 @@ class CompareCluster
   end
 
   def old_holdings
-    @old_holdings ||= Services.holdings_db[:holdings_htitem_htmember]
+    @old_holdings ||= Services.holdings_db[:holdings_htitem_htmember_jn_oct]
       .where(volume_id: item_id)
       .to_h {|h| [h[:member_id], h] }
   end

--- a/lib/compare_cluster.rb
+++ b/lib/compare_cluster.rb
@@ -3,15 +3,11 @@
 require "cluster"
 require "cluster_overlap"
 
-require "rspec"
-require "rspec/expectations"
-require "rspec/matchers"
+require "pp"
 
 # Compares htitems and holdings in the cluster for a given htitem with what is
 # in mongodb and what is in the production holdings mysql tables
 class CompareCluster
-  include RSpec::Matchers
-
   attr_reader :item_id, :cluster
 
   def initialize(item_id)
@@ -20,20 +16,87 @@ class CompareCluster
   end
 
   def compare
-    begin
-      result = true
-      expect(new_htitems).to match_array(old_htitems)
-      expect(new_holdings.keys).to match_array(old_holdings.keys)
-      expect(new_holdings).to eq(old_holdings)
-    rescue RSpec::Expectations::ExpectationNotMetError => e
-      puts e.inspect
-      result = false
-    end
+    puts "Comparing holdings for htitem #{item_id}; " \
+      "cluster format: #{CalculateFormat.new(@cluster).cluster_format}"
 
-    puts "Result for comparing cluster & holdings for #{item_id}: #{result}"
+    compare_htitems
+    compare_holdings_keys
+    compare_holdings_values
   end
 
   private
+
+  def dump_cluster_htitem_ocns(item_id)
+    cluster = Cluster.where("ht_items.item_id": item_id).first
+    pp(cluster.ht_items.select {|h| h.item_id == item_id })
+    puts "Cluster OCNS: #{@cluster.ocns}"
+  end
+
+  def dump_cluster_holdings(org)
+    pp(cluster.holdings.select {|h| h.organization == org })
+  end
+
+  def compare_htitems
+    return if new_htitems != old_htitems
+
+    new_not_old = new_htitems - old_htitems
+    old_not_new = old_htitems - new_htitems
+
+    new_not_old.each do |item_id|
+      puts "In new system but not old system: #{item_id}"
+      dump_cluster_htitem_ocns(item_id)
+    end
+
+    old_not_new.each do |item_id|
+      puts "In old system but not new system: #{item_id}"
+      dump_cluster_htitem_ocns(item_id)
+    end
+  end
+
+  def compare_holdings_keys
+    new_org = new_holdings.keys.sort
+    old_org = old_holdings.keys.sort
+    return if new_org == old_org
+
+    new_not_old = new_org - old_org
+    old_not_new = old_org - new_org
+
+    puts "HTItem with mismatched holdings: "
+    dump_cluster_htitem_ocns(item_id)
+
+    new_not_old.each do |org|
+      puts "New system has overlap holdings, old system doesn't for #{org}"
+      puts "Holdings on cluster for #{org}:"
+      dump_cluster_holdings(org)
+    end
+
+    old_not_new.each do |org|
+      puts "Old system has overlap holdings, new system doesn't for #{org}"
+      puts "Holdings on cluster for #{org}:"
+      dump_cluster_holdings(org)
+      puts "Old holdings for #{org}:"
+      pp old_holdings[org]
+    end
+  end
+
+  def compare_holdings_values
+    return if new_holdings == old_holdings
+
+    puts "Mismatched holdings values: "
+    # keys should match
+    new_holdings
+      .reject {|org, holdings| holdings == old_holdings[org] }
+      .each do |org, holdings|
+        puts "New system holdings for #{org}"
+        pp holdings
+
+        puts "Old system holdings for #{org}"
+        pp old_holdings[org]
+
+        puts "Holdings on cluster for #{org}"
+        dump_cluster_holdings(org)
+      end
+  end
 
   def new_holdings
     @new_holdings ||= ClusterOverlap.new(cluster)

--- a/lib/ht_item_overlap.rb
+++ b/lib/ht_item_overlap.rb
@@ -6,7 +6,7 @@ require "ht_item"
 # Collects organizations with an HTItem overlap
 class HtItemOverlap
 
-  attr_accessor :matching_orgs
+  attr_accessor :matching_orgs, :ht_item
 
   def initialize(ht_item)
     @ht_item = ht_item
@@ -17,14 +17,12 @@ class HtItemOverlap
   # Find all organization with holdings that match the given ht_item
   def organizations_with_holdings
     if @cluster.format != "mpm"
-      # all orgs in the cluster hold every spm or ser in cluster
-      @cluster.organizations_in_cluster
-    elsif @ht_item.n_enum == ""
-      # all orgs in the cluster match an ht_item without an enum
-      @cluster.organizations_in_cluster
+      # all orgs with a holding hold every spm or ser in cluster
+      (@cluster.org_enum_chrons.keys + [@ht_item.billing_entity]).uniq
     else
       # ht_items match on enum and holdings without enum
-      (@cluster.enum_chron_orgs("") + @cluster.enum_chron_orgs(@ht_item.n_enum)).uniq
+      (@cluster.holding_enum_chron_orgs[""] + @cluster.holding_enum_chron_orgs[@ht_item.n_enum] +
+      @cluster.organizations_with_holdings_but_no_matches + [@ht_item.billing_entity]).uniq
     end
   end
 

--- a/lib/multi_part_overlap.rb
+++ b/lib/multi_part_overlap.rb
@@ -5,17 +5,9 @@ require "overlap"
 # Overlap record for items in MPM clusters
 class MultiPartOverlap < Overlap
 
-  def members_with_matching_ht_items
-    if @ht_item.n_enum == ""
-      @cluster.billing_entities
-    else
-      (@cluster.item_enum_chron_orgs[@ht_item.n_enum] + @cluster.item_enum_chron_orgs[""]).uniq
-    end
-  end
-
   def copy_count
     cc = matching_holdings.count
-    if cc.zero? && (members_with_matching_ht_items.include? @org)
+    if cc.zero? && @ht_item.billing_entity == @org
       1
     else
       cc
@@ -40,12 +32,8 @@ class MultiPartOverlap < Overlap
   end
 
   def matching_holdings
-    if @ht_item.n_enum == ""
-      @cluster.holdings.where(organization: @org)
-    else
-      @cluster.holdings.where(organization: @org,
+    @cluster.holdings.where(organization: @org,
                               "$or": [{ n_enum: @ht_item.n_enum }, { n_enum: "" }])
-    end
   end
 
 end

--- a/lib/overlap.rb
+++ b/lib/overlap.rb
@@ -24,12 +24,6 @@ class Overlap
     @cluster.holdings.where(organization: @org)
   end
 
-  # Members that provided matching ht_items
-  # Overridden in MultiPartOverlap to deal with more complex enum chron matching
-  def members_with_matching_ht_items
-    @cluster.billing_entities
-  end
-
   def to_hash
     {
       cluster_id:   @cluster._id.to_s,

--- a/lib/serial_overlap.rb
+++ b/lib/serial_overlap.rb
@@ -8,7 +8,7 @@ class SerialOverlap < Overlap
 
   def copy_count
     cc = @cluster.holdings.where(organization: @org).count
-    if !cc.zero? || (members_with_matching_ht_items.include? @org)
+    if !cc.zero? || @ht_item.billing_entity == @org
       1
     else
       0

--- a/lib/single_part_overlap.rb
+++ b/lib/single_part_overlap.rb
@@ -7,7 +7,7 @@ class SinglePartOverlap < Overlap
 
   def copy_count
     cc = @cluster.holdings.where(organization: @org).count
-    if cc.zero? && (members_with_matching_ht_items.include? @org)
+    if cc.zero? && @ht_item.billing_entity == @org
       1
     else
       cc

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -101,18 +101,6 @@ RSpec.describe Cluster do
       end
     end
 
-    describe "#item_enum_chron_orgs" do
-      xit "has an item enumchrons orgs" do
-        c = described_class.first
-        expect(c.item_enum_chron_orgs[ht1.n_enum]).to eq([ht1.billing_entity])
-      end
-
-      xit "returns an empty set if none found" do
-        c = described_class.first
-        expect(c.item_enum_chron_orgs["invalid_enum"]).to eq([])
-      end
-    end
-
     describe "#holding_enum_chron_orgs" do
       it "maps enumchrons to member holdings" do
         c = described_class.first

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -94,13 +94,20 @@ RSpec.describe Cluster do
       end
     end
 
+    describe "#item_enum_chrons" do
+      it "collects all item enum_chrons in the cluster" do
+        c = described_class.first
+        expect(c.item_enum_chrons).to eq(["3"])
+      end
+    end
+
     describe "#item_enum_chron_orgs" do
-      it "has an item enumchrons orgs" do
+      xit "has an item enumchrons orgs" do
         c = described_class.first
         expect(c.item_enum_chron_orgs[ht1.n_enum]).to eq([ht1.billing_entity])
       end
 
-      it "returns an empty set if none found" do
+      xit "returns an empty set if none found" do
         c = described_class.first
         expect(c.item_enum_chron_orgs["invalid_enum"]).to eq([])
       end
@@ -110,6 +117,42 @@ RSpec.describe Cluster do
       it "maps enumchrons to member holdings" do
         c = described_class.first
         expect(c.holding_enum_chron_orgs[h1.n_enum]).to eq([h1.organization])
+      end
+    end
+
+    describe "#org_enum_chrons" do
+      it "maps orgs to their enum_chrons" do
+        c = described_class.first
+        expect(c.org_enum_chrons[h1.organization]).to eq([h1.enum_chron, h2.enum_chron])
+      end
+    end
+
+    describe "#organizations_with_holdings_but_no_matches" do
+      it "is a list of orgs in the cluster that don't match anything" do
+        h3 = build(:holding, ocn: ocn1, enum_chron: "4", organization: "ualberta")
+        ClusterHolding.new(h3).cluster.tap(&:save)
+        c = described_class.first
+        expect(c.organizations_with_holdings_but_no_matches).to include("ualberta")
+      end
+
+      it "does not include orgs that do have a match" do
+        matching_holding = build(:holding, ocn: ocn1, enum_chron: "3")
+        ClusterHolding.new(matching_holding).cluster.tap(&:save)
+        c = described_class.first
+        expect(c.organizations_with_holdings_but_no_matches).not_to \
+          include(matching_holding.organization)
+      end
+
+      it "DOES NOT include orgs that only have a billing entity match" do
+        ht2 = build(:ht_item, ocns: [ocn1], enum_chron: "5", billing_entity: "ualberta")
+        ClusterHtItem.new(ht2).cluster.tap(&:save)
+        c = described_class.first
+        expect(c.organizations_with_holdings_but_no_matches).not_to include("ualberta")
+        # but does if they have a non-matching holding
+        h3 = build(:holding, ocn: ocn1, enum_chron: "6", organization: "ualberta")
+        ClusterHolding.new(h3).cluster.tap(&:save)
+        c = described_class.where(ocns: ocn1).first
+        expect(c.organizations_with_holdings_but_no_matches).to include("ualberta")
       end
     end
   end

--- a/spec/compile_cost_reports_spec.rb
+++ b/spec/compile_cost_reports_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "CompileCostReports" do
   # - 1 spm with 0 holdings
   # - 2 mpm with the same ocns with 1 holding
   # - 1 spm with access = allow
-  let(:cr) { CostReport.new(cost: 10) }
+  let(:cr) { CostReport.new(cost: 5) }
 
   let(:ht_serial) do
     build(:ht_item,
@@ -51,6 +51,12 @@ RSpec.describe "CompileCostReports" do
   let(:holding_mpm) do
     build(:holding, ocn: ht_mpm1.ocns.first, organization: "smu", enum_chron: "", n_enum: "")
   end
+  let(:texas_mpm) do
+    build(:holding, ocn: ht_mpm1.ocns.first, organization: "utexas", enum_chron: "1", n_enum: "1")
+  end
+  let(:umich_mpm) do
+    build(:holding, ocn: ht_mpm1.ocns.first, organization: "umich", enum_chron: "", n_enum: "")
+  end
 
   before(:each) do
     Cluster.each(&:delete)
@@ -64,6 +70,8 @@ RSpec.describe "CompileCostReports" do
     ClusterHolding.new(holding_serial1).cluster.tap(&:save)
     ClusterHolding.new(holding_serial2).cluster.tap(&:save)
     ClusterHolding.new(holding_mpm).cluster.tap(&:save)
+    ClusterHolding.new(texas_mpm).cluster.tap(&:save)
+    ClusterHolding.new(umich_mpm).cluster.tap(&:save)
   end
 
   it "computes the correct hscores" do
@@ -71,38 +79,39 @@ RSpec.describe "CompileCostReports" do
     # 1 of the ht_spm
     # 1/3 of ht_mpm1 (with SMU and upenn)
     # 1/3 of ht_mpm2 (with SMU and upenn)
+    # {:mpm=>{2=>1}, :ser=>{2=>1}, :spm=>{1=>1}}
     expect(cr.freq_table[:umich]).to eq(spm: { 1=>1 }, ser: { 2=>1 }, mpm: { 3=>2 })
     expect(cr.total_hscore(:umich)).to be_within(0.0001).of(1/2.0 + 1.0 + 1/3.0 + 1/3.0)
-    expect(cr.freq_table[:utexas]).to eq(ser: { 2 => 1 })
+    expect(cr.freq_table[:utexas]).to eq(ser: { 2 => 1 }, mpm: { 3 => 1 })
   end
 
   it "computes total pd_cost" do
-    expect(cr.pd_cost).to be_within(0.0001).of(1 * 2.0)
+    expect(cr.pd_cost).to be_within(0.0001).of(1 * cr.target_cost / cr.num_volumes)
   end
 
   it "computes costs for each format" do
-    # target_cost = $10
+    # target_cost = $5
     # num_volumes = 5
-    # cost_per_volume = $2
-    expect(cr.spm_costs(:umich)).to eq(2.0)
-    # A third of two volumes for $2 each
-    expect(cr.mpm_costs(:umich)).to eq(1/3.0 * 2 * 2.00)
-    expect(cr.ser_costs(:umich)).to eq(1/2.0 * 1 * 2.00)
+    # cost_per_volume = $1
+    expect(cr.spm_costs(:umich)).to eq(1.0)
+    # A third of two volumes for $1 each
+    expect(cr.mpm_costs(:umich)).to eq(1/3.0 * 2 * 1.00)
+    expect(cr.ser_costs(:umich)).to eq(1/2.0 * 1 * 1.00)
   end
 
   it "computes total IC costs for a member" do
-    expect(cr.total_ic_costs(:umich)).to eq(cr.total_hscore(:umich) * 2.0)
+    expect(cr.total_ic_costs(:umich)).to eq(cr.total_hscore(:umich) * 1.0)
   end
 
   it "produces .tsv output" do
     expect(to_tsv(cr)).to eq([
       "member_id	spm	mpm	ser	pd	weight	extra	total",
-      "smu	0.0	1.3333333333333333	0.0	0.25	1.0	0.0	1.5833333333333333",
-      "stanford	0.0	0.0	0.0	0.25	1.0	0.0	0.25",
-      "ualberta	0.0	0.0	0.0	0.25	1.0	0.0	0.25",
-      "umich	2.0	1.3333333333333333	1.0	0.25	1.0	0.0	4.583333333333333",
-      "upenn	0.0	1.3333333333333333	0.0	0.25	1.0	0.0	1.5833333333333333",
-      "utexas	0.0	0.0	1.0	0.75	3.0	0.0	1.75"
+      "smu	0.0	0.6666666666666666	0.0	0.125	1.0	0.0	0.7916666666666666",
+      "stanford	0.0	0.0	0.0	0.125	1.0	0.0	0.125",
+      "ualberta	0.0	0.0	0.0	0.125	1.0	0.0	0.125",
+      "umich	1.0	0.6666666666666666	0.5	0.125	1.0	0.0	2.2916666666666665",
+      "upenn	0.0	0.3333333333333333	0.0	0.125	1.0	0.0	0.4583333333333333",
+      "utexas	0.0	0.3333333333333333	0.5	0.375	3.0	0.0	1.2083333333333333"
     ].join("\n"))
   end
 end

--- a/spec/ht_item_overlap_spec.rb
+++ b/spec/ht_item_overlap_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe HtItemOverlap do
     it "returns all organizations that overlap with an item" do
       c.reload
       overlap = described_class.new(c.ht_items.first)
-      expect(overlap.organizations_with_holdings.count).to eq(3)
+      # billing_entity: ucr, holdings: smu, umich, non_matching: stanford
+      expect(overlap.organizations_with_holdings.count).to eq(4)
     end
 
     it "member should match mpm if none of their holdings match" do
@@ -74,7 +75,7 @@ RSpec.describe HtItemOverlap do
       c.reload
       expect(CalculateFormat.new(c).cluster_format).to eq("mpm")
       overlap = described_class.new(c.ht_items.first)
-      expect(overlap.organizations_with_holdings.count).to eq(3)
+      expect(overlap.organizations_with_holdings.count).to eq(4)
     end
 
     it "matches if holding enum is ''" do
@@ -121,14 +122,14 @@ RSpec.describe HtItemOverlap do
     it "returns ratio of organizations" do
       c.reload
       overlap = described_class.new(c.ht_items.first)
-      expect(overlap.h_share("umich")).to eq(1.0 / 3)
+      expect(overlap.h_share("umich")).to eq(1.0 / 4)
     end
 
     it "assigns an h_share to hathitrust for KEIO items" do
       ClusterHtItem.new(keio_item).cluster.tap(&:save)
       c.reload
-      overlap = described_class.new(c.ht_items.first)
-      expect(c.ht_items.first.billing_entity).not_to eq("hathitrust")
+      overlap = described_class.new(c.ht_items.last)
+      expect(c.ht_items.last.billing_entity).to eq("hathitrust")
       expect(overlap.h_share("hathitrust")).to eq(1.0 / 4)
       expect(overlap.h_share("umich")).to eq(1.0 / 4)
     end
@@ -136,8 +137,8 @@ RSpec.describe HtItemOverlap do
     it "assigns an h_share to UCM as it would anyone else" do
       ClusterHtItem.new(ucm_item).cluster.tap(&:save)
       c.reload
-      overlap = described_class.new(c.ht_items.first)
-      expect(c.ht_items.first.billing_entity).not_to eq("ucm")
+      overlap = described_class.new(c.ht_items.last)
+      expect(c.ht_items.last.billing_entity).to eq("ucm")
       expect(overlap.h_share("ucm")).to eq(1.0 / 4)
       expect(overlap.h_share("umich")).to eq(1.0 / 4)
     end
@@ -145,7 +146,7 @@ RSpec.describe HtItemOverlap do
     it "returns 0 if not held" do
       c.reload
       overlap = described_class.new(c.ht_items.first)
-      expect(overlap.h_share("stanford")).to eq(0)
+      expect(overlap.h_share("upenn")).to eq(0)
     end
   end
 end

--- a/spec/ht_item_overlap_spec.rb
+++ b/spec/ht_item_overlap_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "spec_helper"
 require "ht_item_overlap"
 
 RSpec.describe HtItemOverlap do
@@ -49,10 +50,23 @@ RSpec.describe HtItemOverlap do
       expect(overlap.organizations_with_holdings.count).to eq(3)
     end
 
-    it "does not include non-matching organizations" do
+    it "member should match mpm if none of their holdings match" do
       c.reload
       overlap = described_class.new(c.ht_items.first)
-      expect(overlap.organizations_with_holdings).not_to include("stanford")
+      expect(overlap.organizations_with_holdings).to include("stanford")
+    end
+
+    it "does not include non-matching organizations that match something else" do
+      mpm2 = build(:ht_item,
+                   ocns: c.ocns,
+                   enum_chron: "2",
+                   n_enum: "2",
+                   billing_entity: "ucr")
+      ClusterHtItem.new(mpm2).cluster.tap(&:save)
+      c.reload
+      overlap = described_class.new(c.ht_items.where(n_enum: "2").first)
+      expect(overlap.ht_item.n_enum).to eq("2")
+      expect(overlap.organizations_with_holdings).not_to include("umich")
     end
 
     it "only returns unique organizations" do
@@ -61,6 +75,31 @@ RSpec.describe HtItemOverlap do
       expect(CalculateFormat.new(c).cluster_format).to eq("mpm")
       overlap = described_class.new(c.ht_items.first)
       expect(overlap.organizations_with_holdings.count).to eq(3)
+    end
+
+    it "matches if holding enum is ''" do
+      empty_holding = build(:holding,
+                            ocn: c.ocns.first,
+                            organization: "upenn",
+                            enum_chron: "",
+                            n_enum: "")
+      ClusterHolding.new(empty_holding).cluster.tap(&:save)
+      c.reload
+      overlap = described_class.new(c.ht_items.first)
+      expect(overlap.organizations_with_holdings).to include("upenn")
+    end
+
+    it "does not match if ht item enum is ''" do
+      empty_mpm = build(:ht_item,
+                        ocns: c.ocns,
+                         billing_entity: "ucr",
+                         enum_chron: "",
+                         n_enum: "")
+      ClusterHtItem.new(empty_mpm).cluster.tap(&:save)
+      c.reload
+      overlap = described_class.new(c.ht_items.where(enum_chron: "").first)
+      expect(overlap.organizations_with_holdings).to eq([non_match_holding.organization,
+                                                         empty_mpm.billing_entity])
     end
   end
 

--- a/spec/multi_part_overlap_spec.rb
+++ b/spec/multi_part_overlap_spec.rb
@@ -32,34 +32,6 @@ RSpec.describe MultiPartOverlap do
     ClusterHtItem.new(ht_w_ec).cluster.tap(&:save)
   end
 
-  describe "#members_with_matching_ht_items" do
-    it "finds a member with ht_item with the same enumchron" do
-      ht_w_ec_dupe = ht_w_ec.clone
-      ht_w_ec_dupe.billing_entity = "different_member"
-      cluster = ClusterHtItem.new(ht_w_ec_dupe).cluster.tap(&:save)
-      overlap = described_class.new(cluster, "different_member", ht_w_ec)
-      expect(overlap.members_with_matching_ht_items).to include("different_member")
-    end
-
-    it "finds a member with ht_item with nil enumchron" do
-      ht_wo_ec_dupe = ht_wo_ec.clone
-      ht_wo_ec_dupe.billing_entity = "different_member"
-      cluster = ClusterHtItem.new(ht_wo_ec_dupe).cluster.tap(&:save)
-      overlap = described_class.new(cluster, "different_member", ht_w_ec)
-      expect(overlap.members_with_matching_ht_items).to include("different_member")
-    end
-
-    it "finds a member with any ht_item if this ht_item enumchron is nil" do
-      ht_w_ec_dupe = ht_wo_ec.clone
-      ht_w_ec_dupe.enum_chron = "1"
-      ht_w_ec_dupe.billing_entity = "different_member"
-      ClusterHtItem.new(ht_wo_ec).cluster.tap(&:save)
-      cluster = ClusterHtItem.new(ht_w_ec_dupe).cluster.tap(&:save)
-      overlap = described_class.new(cluster, "different_member", ht_wo_ec)
-      expect(overlap.members_with_matching_ht_items).to include("different_member")
-    end
-  end
-
   describe "#matching_holdings" do
     it "finds holdings that match on enum chron" do
       cluster = ClusterHolding.new(h_w_ec).cluster.tap(&:save)
@@ -75,12 +47,12 @@ RSpec.describe MultiPartOverlap do
       expect(overlap.matching_holdings.count).to eq(1)
     end
 
-    it "finds holdings when ht item has no enum chron" do
+    it "does not find holdings with enum when ht item has no enum chron" do
       ht_w_ec.update_attributes(n_enum: "")
       cluster = ClusterHolding.new(h_w_ec).cluster.tap(&:save)
       overlap = described_class.new(cluster, h_w_ec.organization, ht_w_ec)
       expect(overlap.matching_holdings).to be_a(Enumerable)
-      expect(overlap.matching_holdings.count).to eq(1)
+      expect(overlap.matching_holdings.count).to eq(0)
     end
 
     it "does not find holdings with the wrong enum chron" do
@@ -115,14 +87,6 @@ RSpec.describe MultiPartOverlap do
       ht_w_ec.update_attributes(billing_entity: "different_org")
       c.reload
       mpo = described_class.new(c, "different_org", ht_w_ec)
-      expect(mpo.copy_count).to be(1)
-    end
-
-    it "returns 1 copy if billing_entity in members_with_matching_ht_items" do
-      ht_wo_ec_dupe = ht_wo_ec.clone
-      ht_wo_ec_dupe.billing_entity = "different_member"
-      cluster = ClusterHtItem.new(ht_wo_ec_dupe).cluster.tap(&:save)
-      mpo = described_class.new(cluster, "different_member", ht_w_ec)
       expect(mpo.copy_count).to be(1)
     end
   end

--- a/spec/overlap_spec.rb
+++ b/spec/overlap_spec.rb
@@ -39,13 +39,6 @@ RSpec.describe Overlap do
     end
   end
 
-  describe "#members_with_matching_ht_items" do
-    it "returns all billing_entitys in matching ht_items" do
-      overlap = described_class.new(c, "irrelevant", ht)
-      expect(overlap.members_with_matching_ht_items).to eq([ht.billing_entity])
-    end
-  end
-
   describe "#matching_holdings" do
     it "finds all matching holdings for an org" do
       overlap = described_class.new(c, "umich", ht)

--- a/spec/serial_overlap_spec.rb
+++ b/spec/serial_overlap_spec.rb
@@ -49,10 +49,5 @@ RSpec.describe SerialOverlap do
       c.reload
       expect(described_class.new(c, "different_org", ht).copy_count).to eq(1)
     end
-
-    it "returns 1 if any billing_entity in the cluster matches" do
-      # ht2.billing_entity will have a CC for a umich item despite no holdings
-      expect(described_class.new(c, ht2.billing_entity, ht).copy_count).to eq(1)
-    end
   end
 end

--- a/spec/single_part_overlap_spec.rb
+++ b/spec/single_part_overlap_spec.rb
@@ -45,13 +45,6 @@ RSpec.describe SinglePartOverlap do
       expect(described_class.new(c, "different_org", ht).copy_count).to eq(1)
     end
 
-    it "returns 1 if any billing_entity in the cluster matches" do
-      ClusterHtItem.new(ht2).cluster.tap(&:save)
-      c.reload
-      # ht2.billing_entity will have a CC for a umich item despite no holdings
-      expect(described_class.new(c, ht2.billing_entity, ht).copy_count).to eq(1)
-    end
-
     it "returns 0 if nothing matches" do
       expect(described_class.new(c, "not an org", ht).copy_count).to eq(0)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require "mongoid"
 require "fixtures/members"
 require "fixtures/collections"
 require "fixtures/mock_serials"
+require "pry"
 SimpleCov.start
 
 Mongoid.load!("mongoid.yml", :test)


### PR DESCRIPTION
While using the rspec matchers was nice in that it was quite concise, it didn't make tracking down the reasons for the differences very easy. This computes the differences, formats them (potentially) more usefully, and shows more context.