### PR TITLE
HT-2717 improve perf of Cost Report generation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -44,7 +44,7 @@ Metrics/BlockLength:
     - 'spec/support/**/*.rb'
     - 'spec/**/*_spec.rb'
 
-# Offense count: 4
+# Offense count: 5
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -52,6 +52,7 @@ Metrics/ClassLength:
     - 'lib/enum_chron_parser.rb'
     - 'lib/scrub_fields.rb'
     - 'lib/cost_report.rb'
+    - 'lib/cluster.rb'
 
 # Offense count: 6
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/bin/compile_cost_reports.rb
+++ b/bin/compile_cost_reports.rb
@@ -34,7 +34,7 @@ def to_tsv(report)
 end
 
 if __FILE__ == $PROGRAM_NAME
-  BATCH_SIZE = 10_000
+  BATCH_SIZE = 1_000
   waypoint = Utils::Waypoint.new(BATCH_SIZE)
   logger = Services.logger
   logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
@@ -43,6 +43,6 @@ if __FILE__ == $PROGRAM_NAME
 
   cost_report = CostReport.new(org, lines: BATCH_SIZE, logger: logger)
 
-  logger.info waypoint.final_line
   puts to_tsv(cost_report)
+  logger.info waypoint.final_line
 end

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -5,6 +5,7 @@ require "holding"
 require "ht_item"
 require "commitment"
 require "ocn_resolution"
+require "calculate_format"
 require "cluster_ht_item"
 require "cluster_error"
 
@@ -127,21 +128,23 @@ class Cluster
 
   # Maps enumchrons to list of orgs that have an item with that enumchron
   # Not necessary for SPMs/SERs
-  def item_enum_chron_orgs(enum)
+  def item_enum_chron_orgs
     @item_enum_chron_orgs ||= ht_items.group_by(&:n_enum)
       .transform_values {|htitems| htitems.map(&:billing_entity) }
-    @item_enum_chron_orgs[enum] || []
+      .tap {|h| h.default = [] }
+    @item_enum_chron_orgs
   end
 
   # Maps enumchrons to list of orgs that have a holding with that enumchron
-  def holding_enum_chron_orgs(enum)
+  def holding_enum_chron_orgs
     @holding_enum_chron_orgs ||= holdings.group_by(&:n_enum)
       .transform_values {|holdings| holdings.map(&:organization) }
-    @holding_enum_chron_orgs[enum] || []
+      .tap {|h| h.default = [] }
+    @holding_enum_chron_orgs
   end
 
-  def enum_chron_orgs(enum_chron)
-    (item_enum_chron_orgs(enum_chron) + holding_enum_chron_orgs(enum_chron)).uniq
+  def enum_chron_orgs(enum)
+    (item_enum_chron_orgs[enum] + holding_enum_chron_orgs[enum]).uniq
   end
 
   def billing_entities

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -127,25 +127,21 @@ class Cluster
 
   # Maps enumchrons to list of orgs that have an item with that enumchron
   # Not necessary for SPMs/SERs
-  def item_enum_chron_orgs
-    return @item_enum_chron_orgs if @item_enum_chron_orgs
-
-    @item_enum_chron_orgs = Hash.new {|h, k| h[k] = [] }
-    ht_items.each {|ht| @item_enum_chron_orgs[ht.n_enum] << ht.billing_entity }
-    @item_enum_chron_orgs
+  def item_enum_chron_orgs(enum)
+    @item_enum_chron_orgs ||= ht_items.group_by(&:n_enum)
+      .transform_values {|htitems| htitems.map(&:billing_entity) }
+    @item_enum_chron_orgs[enum] || []
   end
 
   # Maps enumchrons to list of orgs that have a holding with that enumchron
-  def holding_enum_chron_orgs
-    return @holding_enum_chron_orgs if @holding_enum_chron_orgs
-
-    @holding_enum_chron_orgs = Hash.new {|h, k| h[k] = [] }
-    holdings.each {|h| @holding_enum_chron_orgs[h.n_enum] << h.organization }
-    @holding_enum_chron_orgs
+  def holding_enum_chron_orgs(enum)
+    @holding_enum_chron_orgs ||= holdings.group_by(&:n_enum)
+      .transform_values {|holdings| holdings.map(&:organization) }
+    @holding_enum_chron_orgs[enum] || []
   end
 
   def enum_chron_orgs(enum_chron)
-    (item_enum_chron_orgs[enum_chron] + holding_enum_chron_orgs[enum_chron]).uniq
+    (item_enum_chron_orgs(enum_chron) + holding_enum_chron_orgs(enum_chron)).uniq
   end
 
   def billing_entities

--- a/lib/cluster_overlap.rb
+++ b/lib/cluster_overlap.rb
@@ -10,11 +10,11 @@ require "serial_overlap"
 class ClusterOverlap
   include Enumerable
 
-  attr_accessor :orgs
+  attr_accessor :orgs, :cluster
 
   def initialize(cluster, orgs = nil)
     @cluster = cluster
-    @orgs = orgs.nil? ? organizations_in_cluster : [orgs].flatten
+    @orgs = orgs.nil? ? @cluster.organizations_in_cluster : [orgs].flatten
   end
 
   def each
@@ -31,7 +31,7 @@ class ClusterOverlap
   end
 
   def overlap_record(ht_item, org)
-    case ht_item._parent.format
+    case @cluster.format
     when "ser"
       SerialOverlap.new(@cluster, org, ht_item)
     when "spm"
@@ -41,11 +41,6 @@ class ClusterOverlap
     when "ser/spm"
       SinglePartOverlap.new(@cluster, org, ht_item)
     end
-  end
-
-  def organizations_in_cluster
-    (@cluster.holdings.pluck(:organization) +
- @cluster.ht_items.pluck(:billing_entity)).uniq
   end
 
   def self.matching_clusters(org = nil)

--- a/lib/cost_report.rb
+++ b/lib/cost_report.rb
@@ -80,9 +80,9 @@ class CostReport
   end
 
   def add_ht_item_to_freq_table(ht_item)
-    overlap = HtItemOverlap.new(ht_item)
-    overlap.matching_orgs.each do |org|
-      @freq_table[org.to_sym][ht_item._parent.format.to_sym][overlap.matching_orgs.count] += 1
+    item_overlap = HtItemOverlap.new(ht_item)
+    item_overlap.matching_orgs.each do |org|
+      @freq_table[org.to_sym][ht_item._parent.format.to_sym][item_overlap.matching_orgs.count] += 1
     end
   end
 

--- a/lib/ht_item_overlap.rb
+++ b/lib/ht_item_overlap.rb
@@ -16,11 +16,14 @@ class HtItemOverlap
 
   # Find all organization with holdings that match the given ht_item
   def organizations_with_holdings
-    if /s/.match?(@cluster.format)
+    if @cluster.format != "mpm"
+      # all orgs in the cluster hold every spm or ser in cluster
       @cluster.organizations_in_cluster
     elsif @ht_item.n_enum == ""
+      # all orgs in the cluster match an ht_item without an enum
       @cluster.organizations_in_cluster
     else
+      # ht_items match on enum and holdings without enum
       (@cluster.enum_chron_orgs("") + @cluster.enum_chron_orgs(@ht_item.n_enum)).uniq
     end
   end

--- a/lib/ht_item_overlap.rb
+++ b/lib/ht_item_overlap.rb
@@ -16,11 +16,13 @@ class HtItemOverlap
 
   # Find all organization with holdings that match the given ht_item
   def organizations_with_holdings
-    co = ClusterOverlap.new(@cluster)
-    co.orgs.map {|cluster_org| co.overlap_record(@ht_item, cluster_org) }
-      .select {|overlap| overlap.copy_count.nonzero? }
-      .collect(&:org)
-      .uniq
+    if /s/.match?(@cluster.format)
+      @cluster.organizations_in_cluster
+    elsif @ht_item.n_enum == ""
+      @cluster.organizations_in_cluster
+    else
+      (@cluster.enum_chron_orgs("") + @cluster.enum_chron_orgs(@ht_item.n_enum)).uniq
+    end
   end
 
   # Share of this particular item and organization

--- a/lib/multi_part_overlap.rb
+++ b/lib/multi_part_overlap.rb
@@ -7,10 +7,9 @@ class MultiPartOverlap < Overlap
 
   def members_with_matching_ht_items
     if @ht_item.n_enum == ""
-      @cluster.ht_items.pluck(:billing_entity).uniq
+      @cluster.billing_entities
     else
-      @cluster.ht_items.select {|h| h.n_enum.empty? || h.n_enum == @ht_item.n_enum }
-        .pluck(:billing_entity).uniq
+      (@cluster.item_enum_chron_orgs[@ht_item.n_enum] + @cluster.item_enum_chron_orgs[""]).uniq
     end
   end
 

--- a/lib/multi_part_overlap.rb
+++ b/lib/multi_part_overlap.rb
@@ -9,7 +9,7 @@ class MultiPartOverlap < Overlap
     if @ht_item.n_enum == ""
       @cluster.billing_entities
     else
-      (@cluster.item_enum_chron_orgs(@ht_item.n_enum) + @cluster.item_enum_chron_orgs("")).uniq
+      (@cluster.item_enum_chron_orgs[@ht_item.n_enum] + @cluster.item_enum_chron_orgs[""]).uniq
     end
   end
 

--- a/lib/multi_part_overlap.rb
+++ b/lib/multi_part_overlap.rb
@@ -9,7 +9,7 @@ class MultiPartOverlap < Overlap
     if @ht_item.n_enum == ""
       @cluster.billing_entities
     else
-      (@cluster.item_enum_chron_orgs[@ht_item.n_enum] + @cluster.item_enum_chron_orgs[""]).uniq
+      (@cluster.item_enum_chron_orgs(@ht_item.n_enum) + @cluster.item_enum_chron_orgs("")).uniq
     end
   end
 

--- a/lib/overlap.rb
+++ b/lib/overlap.rb
@@ -25,9 +25,9 @@ class Overlap
   end
 
   # Members that provided matching ht_items
-  # Overridden in MultiPartOverlap to deal with enum chrons
+  # Overridden in MultiPartOverlap to deal with more complex enum chron matching
   def members_with_matching_ht_items
-    @cluster.ht_items.pluck(:billing_entity).uniq
+    @cluster.billing_entities
   end
 
   def to_hash

--- a/spec/cluster_overlap_spec.rb
+++ b/spec/cluster_overlap_spec.rb
@@ -42,13 +42,6 @@ RSpec.describe ClusterOverlap do
     end
   end
 
-  describe "#organization_in_cluster" do
-    it "collects all of the organizations found in the cluster" do
-      expect(described_class.new(Cluster.first).organizations_in_cluster).to \
-        eq(["umich", "smu", "ucr"])
-    end
-  end
-
   describe "ClusterOverlap.matching_clusters" do
     let(:h) { build(:holding) }
     let(:ht) { build(:ht_item, ocns: [h.ocn], billing_entity: "not_same_as_holding") }

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -97,14 +97,14 @@ RSpec.describe Cluster do
     describe "#holding_enum_chron_orgs" do
       it "maps enumchrons to member holdings" do
         c = described_class.first
-        expect(c.holding_enum_chron_orgs[h1.n_enum]).to eq([h1.organization])
+        expect(c.holding_enum_chron_orgs(h1.n_enum)).to eq([h1.organization])
       end
     end
 
     describe "#item_enum_chron_orgs" do
       it "has an item enumchrons orgs" do
         c = described_class.first
-        expect(c.item_enum_chron_orgs[ht1.n_enum]).to eq([ht1.billing_entity])
+        expect(c.item_enum_chron_orgs(ht1.n_enum)).to eq([ht1.billing_entity])
       end
     end
   end

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -94,17 +94,22 @@ RSpec.describe Cluster do
       end
     end
 
-    describe "#holding_enum_chron_orgs" do
-      it "maps enumchrons to member holdings" do
-        c = described_class.first
-        expect(c.holding_enum_chron_orgs(h1.n_enum)).to eq([h1.organization])
-      end
-    end
-
     describe "#item_enum_chron_orgs" do
       it "has an item enumchrons orgs" do
         c = described_class.first
-        expect(c.item_enum_chron_orgs(ht1.n_enum)).to eq([ht1.billing_entity])
+        expect(c.item_enum_chron_orgs[ht1.n_enum]).to eq([ht1.billing_entity])
+      end
+
+      it "returns an empty set if none found" do
+        c = described_class.first
+        expect(c.item_enum_chron_orgs["invalid_enum"]).to eq([])
+      end
+    end
+
+    describe "#holding_enum_chron_orgs" do
+      it "maps enumchrons to member holdings" do
+        c = described_class.first
+        expect(c.holding_enum_chron_orgs[h1.n_enum]).to eq([h1.organization])
       end
     end
   end

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -75,4 +75,37 @@ RSpec.describe Cluster do
       expect(described_class.where(ocns: ocn1).count).to eq(1)
     end
   end
+
+  describe "Precomputed fields" do
+    let(:h1) { build(:holding, ocn: ocn1, enum_chron: "1") }
+    let(:h2) { build(:holding, ocn: ocn1, enum_chron: "2", organization: h1.organization) }
+    let(:ht1) { build(:ht_item, ocns: [ocn1], enum_chron: "3", billing_entity: h1.organization) }
+
+    before(:each) do
+      ClusterHolding.new(h1).cluster.tap(&:save)
+      ClusterHolding.new(h2).cluster.tap(&:save)
+      ClusterHtItem.new(ht1).cluster.tap(&:save)
+    end
+
+    describe "#organizations_in_cluster" do
+      it "collects all of the organizations found in the cluster" do
+        expect(described_class.first.organizations_in_cluster).to \
+          eq([h1.organization, h2.organization, ht1.billing_entity].uniq)
+      end
+    end
+
+    describe "#holding_enum_chron_orgs" do
+      it "maps enumchrons to member holdings" do
+        c = described_class.first
+        expect(c.holding_enum_chron_orgs[h1.n_enum]).to eq([h1.organization])
+      end
+    end
+
+    describe "#item_enum_chron_orgs" do
+      it "has an item enumchrons orgs" do
+        c = described_class.first
+        expect(c.item_enum_chron_orgs[ht1.n_enum]).to eq([ht1.billing_entity])
+      end
+    end
+  end
 end

--- a/spec/compile_cost_reports_spec.rb
+++ b/spec/compile_cost_reports_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "CompileCostReports" do
     Cluster.each(&:delete)
     Services.register(:ht_members) { mock_members }
     ClusterHtItem.new(ht_serial).cluster.tap(&:save)
-    ClusterSerial.new(serial).cluster.tap(&:save)
+    Services.serials.bibkeys.add(ht_serial.ht_bib_key.to_i)
     ClusterHtItem.new(ht_spm).cluster.tap(&:save)
     ClusterHtItem.new(ht_mpm1).cluster.tap(&:save)
     ClusterHtItem.new(ht_mpm2).cluster.tap(&:save)

--- a/spec/cost_report_spec.rb
+++ b/spec/cost_report_spec.rb
@@ -4,7 +4,6 @@ require "spec_helper"
 require "cost_report"
 require "cluster_holding"
 require "cluster_ht_item"
-require "cluster_serial"
 
 RSpec.describe CostReport do
   let(:cr) { described_class.new(cost: 10) }

--- a/spec/overlap_report_spec.rb
+++ b/spec/overlap_report_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "overlap_report" do
   describe "full_report" do
     it "generates the correct report for the holding org" do
       h2 = h.dup
-      h2.condition = "brt"
+      h2.condition = "BRT"
       ClusterHolding.new(h2).cluster.tap(&:save)
       expect(full_report(h.organization)).to eq([
         "#{Cluster.first._id}\t#{ht.item_id}\t#{h.organization}\t2\t1\t0\t0\t1"


### PR DESCRIPTION
  - compiles ec=>org and org=>ec data structures in Cluster objects
  - removes dependence on ClusterOverlap and overlap records for cost report generation
  - simple conditional in HtItemOverlap for computing item/holding overlap
Processes ~740 access:deny items per second so roughly a 4 hour run of 10m items.   


ETAS and the other overlap report likely have performance problems due to its reliance on:
 * ClusterOverlap
 * MultiPartOverlap
* SinglePartOverlap
* SerialOverlap