### PR TITLE
Prevent duplicate holdings in large clusters

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -43,6 +43,7 @@ Metrics/BlockLength:
     # uncomment in .rubocop.yml when above are fixed
     - 'spec/support/**/*.rb'
     - 'spec/**/*_spec.rb'
+    - 'spec/spec_helper.rb'
 
 # Offense count: 5
 # Configuration parameters: CountComments.

--- a/bin/add_print_holdings.rb
+++ b/bin/add_print_holdings.rb
@@ -9,16 +9,10 @@ require "services"
 
 Services.mongo!
 
-update = ARGV[0] == "-u"
-if update
-  filename = ARGV[1]
-  Services.logger.info "Updating Print Holdings."
-else
-  filename = ARGV[0]
-  Services.logger.info "Adding Print Holdings."
-end
+filename = ARGV[0]
+Services.logger.info "Adding Print Holdings."
 
-holding_loader = HoldingLoader.new(update: update)
+holding_loader = HoldingLoader.new
 
 FileLoader.new(batch_loader: holding_loader).load(filename, skip_header_match: /\A\s*OCN/)
 

--- a/lib/calculate_format.rb
+++ b/lib/calculate_format.rb
@@ -15,7 +15,7 @@ class CalculateFormat
   #
   # @param ht_item, the HT item to calculate the format on.
   def item_format(ht_item)
-    if matching_serial? ht_item
+    if matching_serial?(ht_item) || @cluster.large?
       "ser"
     elsif cluster_has_item_with_enum_chron_and_same_ht_bib_key? ht_item
       "mpm"

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -122,4 +122,7 @@ class Cluster
     end
   end
 
+  def large?
+    (Services.large_clusters.ocns & ocns).any?
+  end
 end

--- a/lib/cluster_getter.rb
+++ b/lib/cluster_getter.rb
@@ -50,6 +50,11 @@ class ClusterGetter
         raise ClusterError, "clusters disappeared, try again" if source.nil?
         next if source._id == @target._id
 
+        if source.large? ^ @target.large?
+          warn("Merging into a large cluster. " \
+                "OCNs: [#{source.ocns.join(",")}] and [#{@target.ocns.join(",")}]")
+        end
+
         source.delete
         @target.add_members_from(source)
         @target.add_to_set(ocns: source.ocns)

--- a/lib/cluster_getter.rb
+++ b/lib/cluster_getter.rb
@@ -50,6 +50,7 @@ class ClusterGetter
         raise ClusterError, "clusters disappeared, try again" if source.nil?
         next if source._id == @target._id
 
+        # Boolean xor. One and only one is "large"
         if source.large? ^ @target.large?
           warn("Merging into a large cluster. " \
                 "OCNs: [#{source.ocns.join(",")}] and [#{@target.ocns.join(",")}]")

--- a/lib/cluster_holding.rb
+++ b/lib/cluster_holding.rb
@@ -17,14 +17,8 @@ class ClusterHolding
     raise ArgumentError, "Holding must have exactly one OCN" if @ocn.nil?
   end
 
-  def cluster(getter: ClusterGetter.new([@ocn]))
-    getter.get do |cluster|
-      cluster.add_holdings(@holdings)
-    end
-  end
-
   # Updates a matching holding or adds it
-  def update(getter: ClusterGetter.new([@ocn]))
+  def cluster(getter: ClusterGetter.new([@ocn]))
     getter.get do |c|
       to_add = []
 
@@ -50,6 +44,7 @@ class ClusterHolding
       c.add_holdings(to_add)
     end
   end
+  alias_method :update, :cluster
 
   def delete
     raise ArgumentError, "Can only delete one holding at a time" unless @holdings.length == 1

--- a/lib/cluster_holding.rb
+++ b/lib/cluster_holding.rb
@@ -44,7 +44,6 @@ class ClusterHolding
       c.add_holdings(to_add)
     end
   end
-  alias_method :update, :cluster
 
   def delete
     raise ArgumentError, "Can only delete one holding at a time" unless @holdings.length == 1

--- a/lib/cluster_holding.rb
+++ b/lib/cluster_holding.rb
@@ -8,6 +8,8 @@ class ClusterHolding
 
   def initialize(*holdings)
     @holdings = holdings.flatten
+    raise ArgumentError, "Must have holdings to cluster" unless @holdings.any?
+
     @ocn = @holdings.first.ocn
 
     if @holdings.count > 1 && @holdings.any? {|h| !h.batch_with?(@holdings.first) }

--- a/lib/holding_loader.rb
+++ b/lib/holding_loader.rb
@@ -5,10 +5,9 @@ require "cluster_holding"
 
 # Constructs batches of Holdings from incoming file data
 class HoldingLoader
-  def initialize(update: false)
+  def initialize
     @organization = nil
     @current_date = nil
-    @update = update
   end
 
   def item_from_line(line)
@@ -19,11 +18,7 @@ class HoldingLoader
   end
 
   def load(batch)
-    if @update
-      ClusterHolding.new(batch).update
-    else
-      ClusterHolding.new(batch).cluster
-    end
+    ClusterHolding.new(batch).cluster
   end
 
   def finalize

--- a/lib/large_cluster_error.rb
+++ b/lib/large_cluster_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Indication of a reclustering of a "large cluster"
+class LargeClusterError < RuntimeError
+end

--- a/lib/large_clusters.rb
+++ b/lib/large_clusters.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "set"
+
+# List of ocns for clusters too large to be stored with all holdings records
+class LargeClusters
+
+  attr_accessor :ocns
+
+  def initialize(ocns = load_large_clusters)
+    @ocns = ocns
+  end
+
+  def load_large_clusters
+    ocns = Set.new
+    Services.logger.info("Loading large clusters file #{@filename}")
+    File.open(ENV["LARGE_CLUSTER_OCNS"]).each_line do |line|
+      ocns.add(line.to_i)
+    end
+    Services.logger.info("Loaded large clusters file, #{ocns.count} ocns loaded")
+    ocns
+  end
+end

--- a/lib/reclusterer.rb
+++ b/lib/reclusterer.rb
@@ -15,6 +15,12 @@ class Reclusterer
   end
 
   def recluster
+    if @cluster.large?
+      raise LargeClusterError,
+            "Reclustering large cluster will lead to incomplete holdings. " \
+            "OCNs: #{@cluster.ocns.join(", ")}"
+    end
+
     Retryable.with_transaction do
       Services.logger.debug "Deleting and reclustering cluster #{@cluster.inspect}"
       @cluster.delete

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -6,6 +6,7 @@ require "ht_collections"
 require "ht_members"
 require "serials_file"
 require "logger"
+require "large_clusters"
 
 Services = Canister.new
 Services.register(:"mongo!") do
@@ -22,3 +23,4 @@ Services.register(:logger) do
 end
 
 Services.register(:serials) { SerialsFile.new(ENV["SERIALS_FILE"]) }
+Services.register(:large_clusters) { LargeClusters.new }

--- a/spec/calculate_format_spec.rb
+++ b/spec/calculate_format_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe CalculateFormat do
       ).to eq("ser")
     end
 
+    it "is a SER if it is in the list of large cluster ocns" do
+      c_mpm = ClusterHtItem.new(ht_mpm).cluster
+      Services.large_clusters.ocns.add(ht_mpm.ocns.first)
+      expect(described_class.new(c_mpm).item_format(ht_mpm)).to eq("ser")
+    end
+
     it "MPM's don't clobber Serials just yet" do
       c.ht_items << ht_ser
       c.ht_items << ht_mpm

--- a/spec/cluster_holding_spec.rb
+++ b/spec/cluster_holding_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ClusterHolding do
         expect(cluster.holdings.first.date_received).to eq(old_date)
         h2.date_received = Date.today
         h2.uuid = SecureRandom.uuid
-        described_class.new(h2).update
+        described_class.new(h2).cluster
         cluster = Cluster.first
         expect(cluster.holdings.first.date_received).not_to eq(old_date)
         expect(cluster.holdings.first.date_received).to eq(h2.date_received)
@@ -67,7 +67,7 @@ RSpec.describe ClusterHolding do
         Cluster.first.add_holdings(h.clone)
         h2.date_received = Date.today
         h2.uuid = SecureRandom.uuid
-        described_class.new(h2).update
+        described_class.new(h2).cluster
         cluster = Cluster.first
         expect(cluster.holdings.first.date_received).to eq(h2.date_received)
         expect(cluster.holdings.last.date_received).not_to \
@@ -77,7 +77,7 @@ RSpec.describe ClusterHolding do
       it "adds the holding if there is no existing holding" do
         described_class.new(h).cluster
         h2.uuid = SecureRandom.uuid
-        described_class.new(h2).update
+        described_class.new(h2).cluster
         cluster = Cluster.first
         expect(cluster.holdings.count).to eq(2)
       end
@@ -85,7 +85,7 @@ RSpec.describe ClusterHolding do
       it "can update a batch of holdings" do
         described_class.new(batch).cluster
 
-        described_class.new(batch2).update
+        described_class.new(batch2).cluster
         cluster = Cluster.first
         expect(cluster.holdings.count).to eq(2)
         expect(cluster.holdings.all? {|h| h.date_received == Date.today }).to be true
@@ -94,7 +94,7 @@ RSpec.describe ClusterHolding do
       it "does not add additional holdings when re-running a batch" do
         described_class.new(batch).cluster
 
-        described_class.new(batch.map(&:dup)).update
+        described_class.new(batch.map(&:dup)).cluster
 
         cluster = Cluster.first
         expect(cluster.holdings.count).to eq(2)
@@ -104,14 +104,14 @@ RSpec.describe ClusterHolding do
         described_class.new(batch).cluster
 
         h2.date_received = Date.today
-        expect { described_class.new(h2).update }.to raise_exception(/same UUID/)
+        expect { described_class.new(h2).cluster }.to raise_exception(/same UUID/)
       end
 
       it "raises an error with different attributes but same uuid" do
         described_class.new(batch).cluster
 
         h2 = build(:holding, ocn: h.ocn, uuid: h.uuid)
-        expect { described_class.new(h2).update }.to raise_exception(/same UUID/)
+        expect { described_class.new(h2).cluster }.to raise_exception(/same UUID/)
       end
     end
 
@@ -121,7 +121,7 @@ RSpec.describe ClusterHolding do
         c.save
         dupes = [build(:holding, organization: "umich", ocn: c.ocns.first),
                  build(:holding, organization: "umich", ocn: c.ocns.first)]
-        described_class.new(dupes).update
+        described_class.new(dupes).cluster
         cluster = Cluster.first
         expect(cluster.holdings.count).to eq(1)
       end
@@ -136,7 +136,7 @@ RSpec.describe ClusterHolding do
                        date_received: Date.today),
                  build(:holding, organization: "umich", ocn: c.ocns.first,
                        date_received: Date.today)]
-        described_class.new(dupes).update
+        described_class.new(dupes).cluster
         cluster = Cluster.first
         expect(cluster.holdings.count).to eq(1)
         expect(cluster.holdings.first.date_received).to eq(Date.today)
@@ -150,7 +150,7 @@ RSpec.describe ClusterHolding do
         h2 = h.dup
         h2.date_received = Date.today
         h2.uuid = SecureRandom.uuid
-        described_class.new(h2).update
+        described_class.new(h2).cluster
         cluster = Cluster.first
         expect(cluster.holdings.first.date_received).to eq(h2.date_received)
         expect(cluster.holdings.last.date_received).to \
@@ -208,10 +208,10 @@ RSpec.describe ClusterHolding do
       new2.date_received = current_date
       new2.uuid = SecureRandom.uuid
       # replaces first old record
-      described_class.new(new1).update
+      described_class.new(new1).cluster
       # adds new record
       new2.status = "WD"
-      described_class.new(new2).update
+      described_class.new(new2).cluster
       c.save
       expect(Cluster.first.holdings.size).to eq(3)
       described_class.delete_old_holdings(old1.organization, new2.date_received)
@@ -232,7 +232,7 @@ RSpec.describe ClusterHolding do
       new_copy = h.clone
       new_copy.date_received = new_date
       new_copy.uuid = SecureRandom.uuid
-      c = described_class.new(new_copy).update
+      c = described_class.new(new_copy).cluster
       c.save
       clust = Cluster.first
       expect(clust.holdings.pluck(:date_received)).to \

--- a/spec/cost_report_spec.rb
+++ b/spec/cost_report_spec.rb
@@ -224,8 +224,8 @@ RSpec.describe CostReport do
         mpm_holding = spm_holding.clone
         mpm_holding.n_enum = "1"
         mpm_holding.mono_multi_serial = "multi"
-        ClusterHolding.new(spm_holding).cluster.tap(&:save)
-        ClusterHolding.new(mpm_holding).cluster.tap(&:save)
+        cluster = ClusterHolding.new(spm_holding).cluster.tap(&:save)
+        cluster.add_holdings(mpm_holding).tap(&:save)
         cr.matching_clusters.each do |c|
           c.ht_items.each {|ht_item| cr.add_ht_item_to_freq_table(ht_item) }
         end

--- a/spec/fixtures/large_clusters.rb
+++ b/spec/fixtures/large_clusters.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+def mock_large_clusters
+  LargeClusters.new(Set.new([1_759_445, 8_878_489, 1_001_117_803, 1_042_124_096]))
+end

--- a/spec/large_clusters_spec.rb
+++ b/spec/large_clusters_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "large_clusters"
+require "spec_helper"
+
+RSpec.describe LargeClusters do
+  let(:mock_data) { [1_759_445, 8_878_489].to_set }
+  let(:large_clusters) { described_class.new(mock_data) }
+
+  describe "#ocns" do
+    it "has the list of ocns provided" do
+      expect(large_clusters.ocns).to include(1_759_445)
+    end
+  end
+
+  describe "#load_large_clusters" do
+    it "pulls the list of ocns from the ENV file" do
+      ENV["LARGE_CLUSTER_OCNS"] = "/tmp/large_cluster_ocns.txt"
+      `echo "1001117803" > /tmp/large_cluster_ocns.txt`
+      large_clusters = described_class.new
+      expect(large_clusters.ocns).to include(1_001_117_803)
+    end
+  end
+end

--- a/spec/large_clusters_spec.rb
+++ b/spec/large_clusters_spec.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
 
+require "cluster"
+require "cluster_ht_item"
 require "large_clusters"
+require "large_cluster_error"
 require "spec_helper"
 
 RSpec.describe LargeClusters do
   let(:mock_data) { [1_759_445, 8_878_489].to_set }
   let(:large_clusters) { described_class.new(mock_data) }
+
+  before(:each) do
+    Cluster.each(&:delete)
+  end
 
   describe "#ocns" do
     it "has the list of ocns provided" do
@@ -19,6 +26,65 @@ RSpec.describe LargeClusters do
       `echo "1001117803" > /tmp/large_cluster_ocns.txt`
       large_clusters = described_class.new
       expect(large_clusters.ocns).to include(1_001_117_803)
+    end
+  end
+
+  describe "reclustering of large clusters" do
+    # A change in the OCNs of ht_items' OCNs or ocn_resolutions can result in a recluster.
+    # Reclustering a "large cluster" will result in a cluster with incomplete holdings.
+    let(:ht1) { build(:ht_item, ocns: [large_clusters.ocns.first]) }
+    let(:ht2) { build(:ht_item, ocns: [large_clusters.ocns.first]) }
+    let(:ht3) { build(:ht_item, ocns: [1]) }
+
+    it "does not raise an error when performing a simple update" do
+      ClusterHtItem.new(ht1).cluster
+      ClusterHtItem.new(ht2).cluster
+      ht2.ocns << 1
+      expect { ClusterHtItem.new(ht2).cluster }.not_to raise_error
+    end
+
+    it "raises a LargeClusterError when reclustering a large cluster" do
+      ClusterHtItem.new(ht1).cluster
+      ClusterHtItem.new(ht2).cluster
+      expect(Cluster.first.ht_items.count).to eq(2)
+      ht2.ocns = [1]
+      expect do
+        ClusterHtItem.new(ht2).cluster
+      end.to raise_exception(LargeClusterError)
+    end
+  end
+
+  describe "merging of large clusters" do
+    # Merging a non-"large cluster" into a "large cluster" means future holdings will be deduped.
+    # This is expected behavior, but worth tracking
+    let(:ht1) { build(:ht_item, ocns: [large_clusters.ocns.first]) }
+
+    before(:each) do
+      Cluster.each(&:delete)
+      ClusterHtItem.new(ht1).cluster
+      # @orig_stderr = $stderr
+      # $stderr = StringIO.new
+    end
+
+    it "warns when merging non-large with large clusters" do
+      ht2 = build(:ht_item, ocns: [1])
+      ClusterHtItem.new(ht2).cluster
+      expect(Cluster.count).to eq(2)
+      glue = build(:ht_item, ocns: [1, large_clusters.ocns.first])
+      expect { ClusterHtItem.new(glue).cluster }.to \
+        output("Merging into a large cluster. OCNs: [#{large_clusters.ocns.first}] and [1]\n")
+        .to_stderr
+      expect(Cluster.count).to eq(1)
+    end
+
+    it "is silent when merging 2 large clusters" do
+      ht2 = build(:ht_item, ocns: [large_clusters.ocns.to_a.last])
+      ClusterHtItem.new(ht2).cluster
+      expect(Cluster.count).to eq(2)
+      glue = build(:ht_item, ocns: [large_clusters.ocns.to_a.last, large_clusters.ocns.first])
+
+      expect { ClusterHtItem.new(glue).cluster }.not_to output(/Merging/).to_stderr
+      expect(Cluster.count).to eq(1)
     end
   end
 end

--- a/spec/overlap_report_spec.rb
+++ b/spec/overlap_report_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "overlap_report" do
     it "generates the correct report for the holding org" do
       h2 = h.dup
       h2.condition = "BRT"
-      ClusterHolding.new(h2).cluster.tap(&:save)
+      Cluster.first.add_holdings(h2).tap(&:save)
       expect(full_report(h.organization)).to eq([
         "#{Cluster.first._id}\t#{ht.item_id}\t#{h.organization}\t2\t1\t0\t0\t1"
       ])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,9 @@ require "mongoid"
 require "fixtures/members"
 require "fixtures/collections"
 require "fixtures/mock_serials"
+require "fixtures/large_clusters"
 require "pry"
+require "services"
 SimpleCov.start
 
 Mongoid.load!("mongoid.yml", :test)
@@ -52,6 +54,7 @@ RSpec.configure do |config|
     Services.register(:ht_members) { mock_members }
     Services.register(:ht_collections) { mock_collections }
     Services.register(:serials) { mock_serials }
+    Services.register(:large_clusters) { mock_large_clusters }
 
     Services.register(:logger) do
       Logger.new("test.log").tap {|l| l.level = Logger::DEBUG }


### PR DESCRIPTION
 * Services.large_clusters is little more than a list of OCNs
 * ClusterHolding.update prevents cluster.large? from having more than 1 holding per member
 * Does NOT resolve cases where there are already multiple holdings per member
 * Does NOT prevent duplication in merged clusters
 * CalculateFormat returns "ser" when cluster.large?