### PR TITLE
HT-2754 - automatically publish docker image

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -1,0 +1,34 @@
+name: Run CI
+
+on:
+  push:
+    branches:
+      - $default_branch
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up tests
+        run: ./bin/setup_test.sh
+
+      - name: Run tests
+        run: docker-compose run --rm -e MONGOID_ENV=test dev bin/wait-for mariadb:3306 -- bundle exec rspec
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build image and push to DockerHub
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: 'hathitrust/holdings-client-unstable:${{ github.sha }}, hathitrust/holdings-client-unstable:latest'
+          file: Dockerfile
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: Run CI
 
 on:
-  push:
-    branches:
-      - $default-branch
-
   pull_request:
 
 jobs:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,26 @@
+name: Docker Tag Latest Release
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Clone latest repository
+      uses: actions/checkout@v2
+    - name: Tag latest release in DockerHub
+      run: |
+        docker pull hathitrust/holdings-client-unstable:${{ github.sha }}
+        docker tag hathitrust/holdings-client-unstable:${{ github.sha }} hathitrust/holdings-client:${{ github.event.release.tag_name }}
+        docker tag hathitrust/holdings-client-unstable:${{ github.sha }} hathitrust/holdings-client:latest
+        docker push hathitrust/holdings-client:${{ github.event.release.tag_name }}
+        docker push hathitrust/holdings-client:latest


### PR DESCRIPTION
Cribbed from https://github.com/mlibrary/patron_account/blob/main/.github/workflows

@daaang Is the plan to at some point factor this out to actions shared under the "phineas" brand? As is, I'm a little worried about the potential for meaningless arbitrary variation between repositorie and/or a bunch of stuff that nobody fully understands or commits to owning (à la the capistrano installs), or is this relatively minimal enough that the duplication across repositories isn't a big deal? Certainly https://github.com/mlibrary/patron_account/blob/main/.github/workflows/deploy-testing.yaml at least seems like it would benefit from abstraction (not duplicating it here since there's no deployment as such to roll out yet..)