### PR TITLE
Remove deprecated methods from Cluster

### DIFF
--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -45,48 +45,6 @@ class Cluster
           record.ocn_resolutions.collect(&:ocns).flatten - value).any?
   end
 
-  # Adds the members of the given cluster to this cluster.
-  # Deletes the other cluster.
-  #
-  # @param other The cluster whose members to merge with this cluster.
-  # @return This cluster
-  def merge(other)
-    self.ocns = (ocns + other.ocns).sort.uniq
-    move_members_to_self(other)
-    Services.logger.debug "Deleted cluster #{other.inspect} (merged into #{inspect})"
-    other.delete
-    self
-  end
-
-  # Merges all clusters in clusters into the given
-  # destination cluster
-  #
-  # @parm clusters The clusters whose members to merge with this cluster
-  # @return this cluster
-  def merge_many(clusters)
-    clusters.each do |source|
-      raise ClusterError, "clusters disappeared, try again" if source.nil?
-
-      merge(source) unless source._id == _id
-    end
-    save if changed?
-    self
-  end
-
-  # Merges multiple clusters together
-  #
-  # @param clusters All the clusters we need to merge
-  # @return a cluster or nil if nil set
-  def self.merge_many(clusters)
-    c = clusters.shift
-    if clusters.any?
-      raise ClusterError, "cluster disappeared, try again" if c.nil?
-
-      Retryable.with_transaction { c.merge_many(clusters) }
-    end
-    c
-  end
-
   # returns the first matching ht item by item id in this cluster, if any
   #
   # @param the item id to find
@@ -104,17 +62,6 @@ class Cluster
 
   def add_ocn_resolutions(*items)
     push_to_field(:ocn_resolutions, items.flatten)
-  end
-
-  def add_ocns(*ocns_to_add)
-    return if ocns_to_add.empty?
-
-    result = collection.update_one(
-      { _id: _id },
-      { "$push" => { ocns: { "$each" => ocns_to_add.flatten } } },
-      session: Mongoid::Threaded.get_session
-    )
-    raise ClusterError, "#{inspect} deleted before update" unless result.modified_count > 0
   end
 
   def format
@@ -149,10 +96,6 @@ class Cluster
     org_enum_chrons.reject do |_org, enums|
       enums.include?("") || (enums & item_enum_chrons).any?
     end.keys
-  end
-
-  def billing_entities
-    @billing_entities ||= ht_items.pluck(:billing_entity).uniq
   end
 
   def push_to_field(field, items)


### PR DESCRIPTION
  The following methods in the Cluster class were untested and unused.
  Likely remnants of approaches discarded or refactored.
 * merge
 * merge_many
 * self.merge_many
 * add_ocns
 * billing_entities