### PR TITLE
HT-2771 combine n_chron/n_enum for matching purposes

### DIFF
--- a/bin/renormalize_enumchrons.rb
+++ b/bin/renormalize_enumchrons.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "dotenv"
+Dotenv.load(".env")
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+require "bundler/setup"
+require "utils/waypoint"
+require "utils/ppnum"
+require "cluster"
+require "services"
+
+Mongoid.load!("mongoid.yml", ENV["MONGOID_ENV"])
+
+def renormalize(item)
+  item.normalize_enum_chron
+  item.save
+end
+
+def records_with_enum_chrons
+  return enum_for(:records_with_enum_chrons) unless block_given?
+
+  Cluster.where("$or": [{ "holdings.enum_chron": { "$ne": "" } },
+                        { "ht_items.enum_chron": { "$ne": "" } }]).each do |c|
+                          (c.holdings + c.ht_items).each do |item|
+                            yield item unless item.enum_chron == ""
+                          end
+                        end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  BATCH_SIZE = 1_000
+  waypoint = Utils::Waypoint.new(BATCH_SIZE)
+  logger = Services.logger
+  logger.info "Starting renormalization of enum chrons. Batches of #{ppnum BATCH_SIZE}"
+
+  records_with_enum_chrons.each do |rec|
+    waypoint.incr
+    renormalize(rec)
+    waypoint.on_batch {|wp| logger.info wp.batch_line }
+  end
+  logger.info waypoint.final_line
+end

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -74,12 +74,12 @@ class Cluster
   end
 
   def item_enum_chrons
-    @item_enum_chrons ||= ht_items.pluck(:n_enum).uniq
+    @item_enum_chrons ||= ht_items.pluck(:n_enum_chron).uniq
   end
 
   # Maps enumchrons to list of orgs that have a holding with that enumchron
   def holding_enum_chron_orgs
-    @holding_enum_chron_orgs ||= holdings.group_by(&:n_enum)
+    @holding_enum_chron_orgs ||= holdings.group_by(&:n_enum_chron)
       .transform_values {|holdings| holdings.map(&:organization) }
       .tap {|h| h.default = [] }
     @holding_enum_chron_orgs
@@ -87,14 +87,14 @@ class Cluster
 
   def org_enum_chrons
     @org_enum_chrons ||= holdings.group_by(&:organization)
-      .transform_values {|holdings| holdings.map(&:n_enum) }
+      .transform_values {|holdings| holdings.map(&:n_enum_chron) }
       .tap {|h| h.default = [] }
   end
 
   # Orgs that don't have "" enum chron or an enum chron found in the items
   def organizations_with_holdings_but_no_matches
     org_enum_chrons.reject do |_org, enums|
-      enums.include?("") || (enums & item_enum_chrons).any?
+      enums.include?(" ") || (enums & item_enum_chrons).any?
     end.keys
   end
 

--- a/lib/enum_chron.rb
+++ b/lib/enum_chron.rb
@@ -23,6 +23,6 @@ module EnumChron
     ec_parser.parse(enum_chron)
     self.n_enum  = ec_parser.normalized_enum || ""
     self.n_chron = ec_parser.normalized_chron || ""
-    self.n_enum_chron = [n_enum, n_chron].join(" ").sub(/^ $/, "")
+    self.n_enum_chron = [n_enum, n_chron].join("\t").sub(/^\t$/, "")
   end
 end

--- a/lib/enum_chron.rb
+++ b/lib/enum_chron.rb
@@ -23,5 +23,6 @@ module EnumChron
     ec_parser.parse(enum_chron)
     self.n_enum  = ec_parser.normalized_enum || ""
     self.n_chron = ec_parser.normalized_chron || ""
+    self.n_enum_chron = [n_enum, n_chron].join(" ").sub(/^ $/, "")
   end
 end

--- a/lib/enum_chron_parser.rb
+++ b/lib/enum_chron_parser.rb
@@ -58,6 +58,7 @@ class EnumChronParser
     str.gsub!(" - ", "-")
     str.tr! "(", " "
     str.tr! ")", " "
+    str.tr!("\t", " ")
     # remove spaces after dots except when followed by a date
     newstr = dot_sub(str)
     # recover the 'n.s.' pattern

--- a/lib/holding.rb
+++ b/lib/holding.rb
@@ -16,6 +16,7 @@ class Holding
   field :enum_chron, type: String, default: ""
   field :n_enum, type: String, default: ""
   field :n_chron, type: String, default: ""
+  field :n_enum_chron, type: String, default: ""
   field :status, type: String
   field :condition, type: String
   field :gov_doc_flag, type: Boolean

--- a/lib/ht_item.rb
+++ b/lib/ht_item.rb
@@ -27,6 +27,7 @@ class HtItem
   field :enum_chron, type: String, default: ""
   field :n_enum, type: String, default: ""
   field :n_chron, type: String, default: ""
+  field :n_enum_chron, type: String, default: ""
   field :collection_code, type: String
   field :billing_entity, type: String
 

--- a/lib/ht_item_overlap.rb
+++ b/lib/ht_item_overlap.rb
@@ -21,7 +21,8 @@ class HtItemOverlap
       (@cluster.org_enum_chrons.keys + [@ht_item.billing_entity]).uniq
     else
       # ht_items match on enum and holdings without enum
-      (@cluster.holding_enum_chron_orgs[""] + @cluster.holding_enum_chron_orgs[@ht_item.n_enum] +
+      (@cluster.holding_enum_chron_orgs[""] +
+      @cluster.holding_enum_chron_orgs[@ht_item.n_enum_chron] +
       @cluster.organizations_with_holdings_but_no_matches + [@ht_item.billing_entity]).uniq
     end
   end

--- a/lib/multi_part_overlap.rb
+++ b/lib/multi_part_overlap.rb
@@ -33,7 +33,7 @@ class MultiPartOverlap < Overlap
 
   def matching_holdings
     @cluster.holdings.where(organization: @org,
-                              "$or": [{ n_enum: @ht_item.n_enum }, { n_enum: "" }])
+                            "$or": [{ n_enum_chron: @ht_item.n_enum_chron }, { n_enum_chron: "" }])
   end
 
 end

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -97,21 +97,21 @@ RSpec.describe Cluster do
     describe "#item_enum_chrons" do
       it "collects all item enum_chrons in the cluster" do
         c = described_class.first
-        expect(c.item_enum_chrons).to eq(["3"])
+        expect(c.item_enum_chrons).to eq(["3 "])
       end
     end
 
     describe "#holding_enum_chron_orgs" do
       it "maps enumchrons to member holdings" do
         c = described_class.first
-        expect(c.holding_enum_chron_orgs[h1.n_enum]).to eq([h1.organization])
+        expect(c.holding_enum_chron_orgs[h1.n_enum_chron]).to eq([h1.organization])
       end
     end
 
     describe "#org_enum_chrons" do
       it "maps orgs to their enum_chrons" do
         c = described_class.first
-        expect(c.org_enum_chrons[h1.organization]).to eq([h1.enum_chron, h2.enum_chron])
+        expect(c.org_enum_chrons[h1.organization]).to eq([h1.n_enum_chron, h2.n_enum_chron])
       end
     end
 

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Cluster do
     describe "#item_enum_chrons" do
       it "collects all item enum_chrons in the cluster" do
         c = described_class.first
-        expect(c.item_enum_chrons).to eq(["3 "])
+        expect(c.item_enum_chrons).to eq(["3\t"])
       end
     end
 

--- a/spec/enum_chron_spec.rb
+++ b/spec/enum_chron_spec.rb
@@ -9,6 +9,7 @@ class DummyRecord
   field :enum_chron
   field :n_enum
   field :n_chron
+  field :n_enum_chron
 
 end
 
@@ -17,20 +18,21 @@ RSpec.describe EnumChron do
   let(:rec_w_empty_ec) { DummyRecord.new(enum_chron: "") }
   let(:rec_wo_ec) { DummyRecord.new }
 
-  it "uses EnumChronParser to set n_chron and n_enum" do
-    expect(rec_w_ec.enum_chron).to eq("1 aug")
+  it "uses EnumChronParser to set n_chron, n_enum, and n_enum_chron" do
     expect(rec_w_ec.n_enum).to eq("1")
     expect(rec_w_ec.n_chron).to eq("aug")
+    expect(rec_w_ec.n_enum_chron).to eq("1 aug")
   end
 
-  it "sets n_chron and n_enum to empty string if empty enumchron" do
+  it "sets n_chron, n_enum, n_enum_chron to empty string if empty enumchron" do
     expect(rec_w_empty_ec.n_chron).to eq("")
     expect(rec_w_empty_ec.n_enum).to eq("")
+    expect(rec_w_empty_ec.n_enum_chron).to eq("")
   end
 
-  it "sets n_chron and n_enum to empty string if nil enumchron" do
-    expect(rec_wo_ec.enum_chron).to eq("")
+  it "sets n_chron, n_enum, n_enum_chron to empty string if nil enumchron" do
     expect(rec_wo_ec.n_chron).to eq("")
     expect(rec_wo_ec.n_enum).to eq("")
+    expect(rec_wo_ec.n_enum_chron).to eq("")
   end
 end

--- a/spec/enum_chron_spec.rb
+++ b/spec/enum_chron_spec.rb
@@ -21,7 +21,12 @@ RSpec.describe EnumChron do
   it "uses EnumChronParser to set n_chron, n_enum, and n_enum_chron" do
     expect(rec_w_ec.n_enum).to eq("1")
     expect(rec_w_ec.n_chron).to eq("aug")
-    expect(rec_w_ec.n_enum_chron).to eq("1 aug")
+    expect(rec_w_ec.n_enum_chron).to eq("1\taug")
+  end
+
+  it "replaces tabs in enum and chron so we can use it as delimiter" do
+    rec_w_ec = DummyRecord.new(enum_chron: "vol\t1\tAug\t5")
+    expect(rec_w_ec.n_enum_chron).to eq("vol:1\tAug 5")
   end
 
   it "sets n_chron, n_enum, n_enum_chron to empty string if empty enumchron" do

--- a/spec/holding_spec.rb
+++ b/spec/holding_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Holding do
     holding = build(:holding, enum_chron: "v.1 Jul 1999")
     expect(holding.n_enum).to eq("1")
     expect(holding.n_chron).to eq("Jul 1999")
-    expect(holding.n_enum_chron).to eq("1 Jul 1999")
+    expect(holding.n_enum_chron).to eq("1\tJul 1999")
   end
 
   it "does nothing if given an empty enum_chron" do

--- a/spec/holding_spec.rb
+++ b/spec/holding_spec.rb
@@ -22,13 +22,14 @@ RSpec.describe Holding do
     holding = build(:holding, enum_chron: "v.1 Jul 1999")
     expect(holding.n_enum).to eq("1")
     expect(holding.n_chron).to eq("Jul 1999")
+    expect(holding.n_enum_chron).to eq("1 Jul 1999")
   end
 
   it "does nothing if given an empty enum_chron" do
     holding = build(:holding, enum_chron: "")
-    expect(holding.enum_chron).to eq("")
     expect(holding.n_enum).to eq("")
     expect(holding.n_chron).to eq("")
+    expect(holding.n_enum_chron).to eq("")
   end
 
   describe "#==" do

--- a/spec/ht_item_overlap_spec.rb
+++ b/spec/ht_item_overlap_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe HtItemOverlap do
                    billing_entity: "ucr")
       ClusterHtItem.new(mpm2).cluster.tap(&:save)
       c.reload
-      overlap = described_class.new(c.ht_items.where(n_enum: "2").first)
-      expect(overlap.ht_item.n_enum).to eq("2")
+      overlap = described_class.new(c.ht_items.where(n_enum_chron: "2 ").first)
+      expect(overlap.ht_item.n_enum_chron).to eq("2 ")
       expect(overlap.organizations_with_holdings).not_to include("umich")
     end
 
@@ -78,7 +78,7 @@ RSpec.describe HtItemOverlap do
       expect(overlap.organizations_with_holdings.count).to eq(4)
     end
 
-    it "matches if holding enum is ''" do
+    it "matches if holding enum_chron is ''" do
       empty_holding = build(:holding,
                             ocn: c.ocns.first,
                             organization: "upenn",

--- a/spec/ht_item_overlap_spec.rb
+++ b/spec/ht_item_overlap_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe HtItemOverlap do
                    billing_entity: "ucr")
       ClusterHtItem.new(mpm2).cluster.tap(&:save)
       c.reload
-      overlap = described_class.new(c.ht_items.where(n_enum_chron: "2 ").first)
-      expect(overlap.ht_item.n_enum_chron).to eq("2 ")
+      overlap = described_class.new(c.ht_items.where(n_enum_chron: "2\t").first)
+      expect(overlap.ht_item.n_enum_chron).to eq("2\t")
       expect(overlap.organizations_with_holdings).not_to include("umich")
     end
 

--- a/spec/multi_part_overlap_spec.rb
+++ b/spec/multi_part_overlap_spec.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
+require "spec_helper"
 require "multi_part_overlap"
 
 RSpec.describe MultiPartOverlap do
   let(:c) { build(:cluster) }
-  let(:ht_w_ec) { build(:ht_item, ocns: c.ocns, bib_fmt: "mpm", n_enum: "1") }
-  let(:ht_wo_ec) { build(:ht_item, ocns: c.ocns, bib_fmt: "mpm", n_enum: "") }
-  let(:h_w_ec) { build(:holding, ocn: c.ocns.first, n_enum: "1") }
-  let(:h_wo_ec) { build(:holding, ocn: c.ocns.first, n_enum: "") }
-  let(:h_wrong_ec) { build(:holding, ocn: c.ocns.first, n_enum: "2") }
+  let(:ht_w_ec) { build(:ht_item, ocns: c.ocns, bib_fmt: "mpm", enum_chron: "1", n_enum: "1") }
+  let(:ht_wo_ec) { build(:ht_item, ocns: c.ocns, bib_fmt: "mpm", enum_chron: "1", n_enum: "") }
+  let(:h_w_ec) { build(:holding, ocn: c.ocns.first, enum_chron: "1", n_enum: "1") }
+  let(:h_wo_ec) { build(:holding, ocn: c.ocns.first, enum_chron: "1", n_enum: "") }
+  let(:h_wrong_ec) { build(:holding, ocn: c.ocns.first, enum_chron: "2", n_enum: "2") }
   let(:h_lm) do
     build(:holding,
           ocn: c.ocns.first,
@@ -48,7 +49,7 @@ RSpec.describe MultiPartOverlap do
     end
 
     it "does not find holdings with enum when ht item has no enum chron" do
-      ht_w_ec.update_attributes(n_enum: "")
+      ht_w_ec.update_attributes(n_enum_chron: "")
       cluster = ClusterHolding.new(h_w_ec).cluster.tap(&:save)
       overlap = described_class.new(cluster, h_w_ec.organization, ht_w_ec)
       expect(overlap.matching_holdings).to be_a(Enumerable)

--- a/spec/renormalize_enum_chron_spec.rb
+++ b/spec/renormalize_enum_chron_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Renormalize Enumchrons" do
       expect(h.n_enum_chron).to be_nil
 
       renormalize(h)
-      expect(h.n_enum_chron).to eq("1 ")
+      expect(h.n_enum_chron).to eq("1\t")
     end
   end
 

--- a/spec/renormalize_enum_chron_spec.rb
+++ b/spec/renormalize_enum_chron_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "cluster_holding"
+require_relative "../bin/renormalize_enumchrons"
+
+RSpec.describe "Renormalize Enumchrons" do
+  let(:h) { build(:holding, enum_chron: "1") }
+
+  before(:each) do
+    Cluster.each(&:delete)
+    h.n_enum_chron = nil
+    ClusterHolding.new(h).cluster.tap(&:save)
+  end
+
+  describe "#renormalize" do
+    it "re-extracts from the enum_chron field" do
+      c = Cluster.first
+      h = c.holdings.first
+      expect(h.n_enum_chron).to be_nil
+
+      renormalize(h)
+      expect(h.n_enum_chron).to eq("1 ")
+    end
+  end
+
+  describe "#records_with_enum_chrons" do
+    it "find holdings and ht items with enum chrons" do
+      ht = build(:ht_item, enum_chron: "1", ocns: [h.ocn])
+      ht.n_enum_chron = nil
+      ClusterHtItem.new(ht).cluster.tap(&:save)
+      expect(records_with_enum_chrons.each.to_a.size).to eq(2)
+      expect(records_with_enum_chrons.count(&:n_enum_chron)).to eq(0)
+      records_with_enum_chrons {|i| renormalize(i) }
+      expect(records_with_enum_chrons.count(&:n_enum_chron)).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
n_enum_chron = [n_enum, n_chron].join(" ").sub(/^ $/, '')

Uses of n_enum for comparison have been replaced by n_enum_chron.