### PR TITLE
HT-2771: revert mpm matching to only use n_enum

### DIFF
--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -73,28 +73,28 @@ class Cluster
                                   ht_items.pluck(:billing_entity)).uniq
   end
 
-  def item_enum_chrons
-    @item_enum_chrons ||= ht_items.pluck(:n_enum_chron).uniq
+  def item_enums
+    @item_enums ||= ht_items.pluck(:n_enum).uniq
   end
 
-  # Maps enumchrons to list of orgs that have a holding with that enumchron
-  def holding_enum_chron_orgs
-    @holding_enum_chron_orgs ||= holdings.group_by(&:n_enum_chron)
+  # Maps enums to list of orgs that have a holding with that enum
+  def holding_enum_orgs
+    @holding_enum_chron_orgs ||= holdings.group_by(&:n_enum)
       .transform_values {|holdings| holdings.map(&:organization) }
       .tap {|h| h.default = [] }
     @holding_enum_chron_orgs
   end
 
-  def org_enum_chrons
-    @org_enum_chrons ||= holdings.group_by(&:organization)
-      .transform_values {|holdings| holdings.map(&:n_enum_chron) }
+  def org_enums
+    @org_enums ||= holdings.group_by(&:organization)
+      .transform_values {|holdings| holdings.map(&:n_enum) }
       .tap {|h| h.default = [] }
   end
 
   # Orgs that don't have "" enum chron or an enum chron found in the items
   def organizations_with_holdings_but_no_matches
-    org_enum_chrons.reject do |_org, enums|
-      enums.include?(" ") || (enums & item_enum_chrons).any?
+    org_enums.reject do |_org, enums|
+      enums.include?(" ") || (enums & item_enums).any?
     end.keys
   end
 

--- a/lib/ht_item_overlap.rb
+++ b/lib/ht_item_overlap.rb
@@ -18,11 +18,11 @@ class HtItemOverlap
   def organizations_with_holdings
     if @cluster.format != "mpm"
       # all orgs with a holding hold every spm or ser in cluster
-      (@cluster.org_enum_chrons.keys + [@ht_item.billing_entity]).uniq
+      (@cluster.org_enums.keys + [@ht_item.billing_entity]).uniq
     else
       # ht_items match on enum and holdings without enum
-      (@cluster.holding_enum_chron_orgs[""] +
-      @cluster.holding_enum_chron_orgs[@ht_item.n_enum_chron] +
+      (@cluster.holding_enum_orgs[""] +
+      @cluster.holding_enum_orgs[@ht_item.n_enum] +
       @cluster.organizations_with_holdings_but_no_matches + [@ht_item.billing_entity]).uniq
     end
   end

--- a/lib/multi_part_overlap.rb
+++ b/lib/multi_part_overlap.rb
@@ -33,7 +33,7 @@ class MultiPartOverlap < Overlap
 
   def matching_holdings
     @cluster.holdings.where(organization: @org,
-                            "$or": [{ n_enum_chron: @ht_item.n_enum_chron }, { n_enum_chron: "" }])
+                            "$or": [{ n_enum: @ht_item.n_enum }, { n_enum: "" }])
   end
 
 end

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -94,24 +94,24 @@ RSpec.describe Cluster do
       end
     end
 
-    describe "#item_enum_chrons" do
-      it "collects all item enum_chrons in the cluster" do
+    describe "#item_enums" do
+      it "collects all item enums in the cluster" do
         c = described_class.first
-        expect(c.item_enum_chrons).to eq(["3\t"])
+        expect(c.item_enums).to eq(["3"])
       end
     end
 
-    describe "#holding_enum_chron_orgs" do
-      it "maps enumchrons to member holdings" do
+    describe "#holding_enum_orgs" do
+      it "maps enums to member holdings" do
         c = described_class.first
-        expect(c.holding_enum_chron_orgs[h1.n_enum_chron]).to eq([h1.organization])
+        expect(c.holding_enum_orgs[h1.n_enum]).to eq([h1.organization])
       end
     end
 
-    describe "#org_enum_chrons" do
-      it "maps orgs to their enum_chrons" do
+    describe "#org_enums" do
+      it "maps orgs to their enums" do
         c = described_class.first
-        expect(c.org_enum_chrons[h1.organization]).to eq([h1.n_enum_chron, h2.n_enum_chron])
+        expect(c.org_enums[h1.organization]).to eq([h1.n_enum, h2.n_enum])
       end
     end
 

--- a/spec/ht_item_overlap_spec.rb
+++ b/spec/ht_item_overlap_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe HtItemOverlap do
                    billing_entity: "ucr")
       ClusterHtItem.new(mpm2).cluster.tap(&:save)
       c.reload
-      overlap = described_class.new(c.ht_items.where(n_enum_chron: "2\t").first)
-      expect(overlap.ht_item.n_enum_chron).to eq("2\t")
+      overlap = described_class.new(c.ht_items.where(n_enum: "2").first)
+      expect(overlap.ht_item.n_enum).to eq("2")
       expect(overlap.organizations_with_holdings).not_to include("umich")
     end
 
@@ -78,13 +78,26 @@ RSpec.describe HtItemOverlap do
       expect(overlap.organizations_with_holdings.count).to eq(4)
     end
 
-    it "matches if holding enum_chron is ''" do
+    it "matches if holding enum is ''" do
       empty_holding = build(:holding,
                             ocn: c.ocns.first,
                             organization: "upenn",
                             enum_chron: "",
                             n_enum: "")
       ClusterHolding.new(empty_holding).cluster.tap(&:save)
+      c.reload
+      overlap = described_class.new(c.ht_items.first)
+      expect(overlap.organizations_with_holdings).to include("upenn")
+    end
+
+    it "matches if holding enum is '', but chron exists" do
+      almost_empty_holding = build(:holding,
+                                   ocn: c.ocns.first,
+                                   organization: "upenn",
+                                   enum_chron: "Aug",
+                                   n_enum: "",
+                                   n_chron: "Aug")
+      ClusterHolding.new(almost_empty_holding).cluster.tap(&:save)
       c.reload
       overlap = described_class.new(c.ht_items.first)
       expect(overlap.organizations_with_holdings).to include("upenn")


### PR DESCRIPTION
After further review it was discovered that the existing print holdings process only uses normalized enum and not both enum and chron. This changes matching back to using only "n_enum", but keeps the n_enum_chron attribute in place.