### PR TITLE
Calc extra per member

### DIFF
--- a/lib/cost_report.rb
+++ b/lib/cost_report.rb
@@ -123,7 +123,7 @@ class CostReport
   end
 
   def extra_per_member
-    total_ic_costs(:hathitrust) / (Services.ht_members.members.keys - ['hathitrust']).count
+    total_ic_costs(:hathitrust) / (Services.ht_members.members.keys - ["hathitrust"]).count
   end
 
   def total_cost_for_member(member)

--- a/lib/cost_report.rb
+++ b/lib/cost_report.rb
@@ -123,7 +123,7 @@ class CostReport
   end
 
   def extra_per_member
-    total_ic_costs(:hathitrust) / Services.ht_members.members.count
+    total_ic_costs(:hathitrust) / (Services.ht_members.members.keys - ['hathitrust']).count
   end
 
   def total_cost_for_member(member)


### PR DESCRIPTION
Hathitrust gets some IC costs assigned to it that need to be distributed to the members as "extra". 

This is a one line change that removes 'hathitrust' from the list of ht_members when calculating the extra_per_member.