### PR TITLE
Calc cost rpt on item format not cluster format

### DIFF
--- a/bin/compile_cost_reports.rb
+++ b/bin/compile_cost_reports.rb
@@ -42,6 +42,13 @@ if __FILE__ == $PROGRAM_NAME
   org = ARGV.shift
 
   cost_report = CostReport.new(org, lines: BATCH_SIZE, logger: logger)
+  puts "Target cost: #{cost_report.target_cost}"
+  puts "Num volumes: #{cost_report.num_volumes}"
+  puts "Num pd volumes: #{cost_report.num_pd_volumes}"
+  puts "Cost per volume: #{cost_report.cost_per_volume}"
+  puts "Total weight: #{cost_report.total_weight}"
+  puts "PD Cost: #{cost_report.pd_cost}"
+  puts "Num members: #{Services.ht_members.members.count}"
 
   puts to_tsv(cost_report)
   logger.info waypoint.final_line

--- a/lib/calculate_format.rb
+++ b/lib/calculate_format.rb
@@ -45,7 +45,7 @@ class CalculateFormat
 
   def cluster_has_item_with_enum_chron_and_same_ht_bib_key?(ht_item)
     @cluster.ht_items.any? do |ht|
-      ht.ht_bib_key == ht_item.ht_bib_key && !ht.enum_chron.empty?
+      ht.ht_bib_key == ht_item.ht_bib_key && !ht.n_enum_chron.empty?
     end
   end
 

--- a/lib/cost_report.rb
+++ b/lib/cost_report.rb
@@ -80,9 +80,10 @@ class CostReport
   end
 
   def add_ht_item_to_freq_table(ht_item)
+    item_format = CalculateFormat.new(ht_item._parent).item_format(ht_item).to_sym
     item_overlap = HtItemOverlap.new(ht_item)
     item_overlap.matching_orgs.each do |org|
-      @freq_table[org.to_sym][ht_item._parent.format.to_sym][item_overlap.matching_orgs.count] += 1
+      @freq_table[org.to_sym][item_format][item_overlap.matching_orgs.count] += 1
     end
   end
 

--- a/spec/calculate_format_spec.rb
+++ b/spec/calculate_format_spec.rb
@@ -31,7 +31,14 @@ RSpec.describe CalculateFormat do
       ht_spm.ht_bib_key = ht_mpm.ht_bib_key
       c.ht_items << ht_mpm
       c.ht_items << ht_spm
-      expect(described_class.new(c).item_format(ht_mpm)).to eq("mpm")
+      expect(described_class.new(c).item_format(ht_spm)).to eq("mpm")
+    end
+
+    it "is NOT an MPM just because another ht item in the cluster has an enum_chron" do
+      ht_spm.ht_bib_key = "not ht_mpm's bib key"
+      c.ht_items << ht_mpm
+      c.ht_items << ht_spm
+      expect(described_class.new(c).item_format(ht_spm)).to eq("spm")
     end
 
     it "is a SER if it is found in the serials file" do

--- a/spec/compile_cost_reports_spec.rb
+++ b/spec/compile_cost_reports_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "CompileCostReports" do
   let(:ht_mpm2) do
     build(:ht_item,
           ocns: ht_mpm1.ocns,
-          ht_bib_key: ht_mpm1.ht_bib_key, 
+          ht_bib_key: ht_mpm1.ht_bib_key,
           enum_chron: "",
           collection_code: "PU",
           access: "deny")

--- a/spec/compile_cost_reports_spec.rb
+++ b/spec/compile_cost_reports_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "CompileCostReports" do
   let(:ht_mpm2) do
     build(:ht_item,
           ocns: ht_mpm1.ocns,
+          ht_bib_key: ht_mpm1.ht_bib_key, 
           enum_chron: "",
           collection_code: "PU",
           access: "deny")


### PR DESCRIPTION
* also makes explicit in spec that shared bib_id not cluster is req'd for mpm item format contagion.