### PR TITLE
HT-2900: Add n_enum and lock_id to overlap reports

### DIFF
--- a/bin/export_overlap_report.rb
+++ b/bin/export_overlap_report.rb
@@ -18,8 +18,10 @@ Mongoid.load!("mongoid.yml", :test)
 BATCH_SIZE = 10_000
 
 def overlap_line(overlap_hash)
-  [overlap_hash[:cluster_id],
+  [overlap_hash[:lock_id],
+   overlap_hash[:cluster_id],
    overlap_hash[:volume_id],
+   overlap_hash[:n_enum],
    overlap_hash[:member_id],
    overlap_hash[:copy_count],
    overlap_hash[:brt_count],

--- a/lib/overlap.rb
+++ b/lib/overlap.rb
@@ -5,7 +5,7 @@ require "cluster"
 # The most basic overlap record
 # Inherited by SinglePartOverlap, MultiPartOverlap, and SerialOverlap
 class Overlap
-  attr_accessor :org, :ht_item
+  attr_accessor :org, :ht_item, :cluster
 
   def initialize(cluster, org, ht_item)
     @cluster = cluster
@@ -26,8 +26,10 @@ class Overlap
 
   def to_hash
     {
+      lock_id:      lock_id,
       cluster_id:   @cluster._id.to_s,
       volume_id:    @ht_item.item_id,
+      n_enum:       @ht_item.n_enum,
       member_id:    @org,
       copy_count:   copy_count,
       brt_count:    brt_count,
@@ -35,5 +37,17 @@ class Overlap
       lm_count:     lm_count,
       access_count: access_count
     }
+  end
+
+  # Precomputed for the ETAS tables
+  def lock_id
+    case @cluster.format
+    when "mpm"
+      [@cluster._id.to_s, @ht_item.n_enum].join(":")
+    when "spm"
+      @cluster._id.to_s
+    when "ser", "ser/spm"
+      @ht_item.item_id
+    end
   end
 end

--- a/spec/overlap_report_mysql_import_spec.rb
+++ b/spec/overlap_report_mysql_import_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe "overlap_report_import_to_mysql" do
       expect(lines.size).to equal(3)
     end
 
-    it "has lines with 8 columns" do
-      expect(lines.map(&:size)).to all(be == 8)
+    it "has lines with 10 columns" do
+      expect(lines.map(&:size)).to all(be == 10)
     end
   end
 

--- a/spec/overlap_report_spec.rb
+++ b/spec/overlap_report_spec.rb
@@ -7,8 +7,8 @@ require_relative "../bin/export_overlap_report"
 
 RSpec.describe "overlap_report" do
   let(:h) { build(:holding) }
-  let(:ht) { build(:ht_item, ocns: [h.ocn], billing_entity: "not_same_as_holding") }
-  let(:ht2) { build(:ht_item, billing_entity: "not_same_as_holding") }
+  let(:ht) { build(:ht_item, ocns: [h.ocn], billing_entity: "not_same_as_holding", enum_chron: "") }
+  let(:ht2) { build(:ht_item, billing_entity: "not_same_as_holding", enum_chron: "") }
 
   before(:each) do
     Cluster.each(&:delete)
@@ -22,17 +22,20 @@ RSpec.describe "overlap_report" do
       h2 = h.dup
       h2.condition = "BRT"
       Cluster.first.add_holdings(h2).tap(&:save)
+      cid = Cluster.first._id
       expect(full_report(h.organization)).to eq([
-        "#{Cluster.first._id}\t#{ht.item_id}\t#{h.organization}\t2\t1\t0\t0\t1"
+        "#{cid}\t#{cid}\t#{ht.item_id}\t#{ht.n_enum}\t#{h.organization}\t2\t1\t0\t0\t1"
       ])
     end
 
     it "generates the correct report for the billing entity" do
       cluster1 = Cluster.first
       cluster2 = Cluster.find_by(ocns: ht2.ocns)
+      cid1 = cluster1._id
+      cid2 = cluster2._id
       expect(full_report("not_same_as_holding")).to eq([
-        "#{cluster1._id}\t#{ht.item_id}\tnot_same_as_holding\t1\t0\t0\t0\t0",
-        "#{cluster2._id}\t#{ht2.item_id}\tnot_same_as_holding\t1\t0\t0\t0\t0"
+        "#{cid1}\t#{cid1}\t#{ht.item_id}\t#{ht.n_enum}\tnot_same_as_holding\t1\t0\t0\t0\t0",
+        "#{cid2}\t#{cid2}\t#{ht2.item_id}\t#{ht2.n_enum}\tnot_same_as_holding\t1\t0\t0\t0\t0"
       ])
     end
   end

--- a/sql/003_holdings_htitem_htmember.sql
+++ b/sql/003_holdings_htitem_htmember.sql
@@ -1,8 +1,10 @@
 USE `ht_repository`;
 
 CREATE TABLE IF NOT EXISTS `holdings_htitem_htmember` (
+  `lock_id` varchar(100) NOT NULL,
   `cluster_id` bigint NOT NULL,
   `volume_id` varchar(50) NOT NULL,
+  `n_enum` varchar(50) DEFAULT '',
   `member_id` varchar(20) NOT NULL,
   `copy_count` int(11) DEFAULT NULL,
   `lm_count` smallint(6) DEFAULT NULL,


### PR DESCRIPTION
Edits bin/export_overlap_report.rb and lib/overlap.rb. Adds columns `lock_id` and `n_enum` to `holdings_htitem_htmember` table. 

I don't know what bin/export_etas_overlap_report.rb or lib/etas_overlap.rb are for. 