### PR TITLE
Optimizations for when to recluster

### DIFF
--- a/config/environments/production.yml
+++ b/config/environments/production.yml
@@ -1,0 +1,7 @@
+database:
+  opts:
+    adapter: 'mysql2'
+    host: <%= ENV['MYSQL_HOST'] %>
+    database: <%= ENV['MYSQL_DATABASE'] %>
+    user: <%= ENV['MYSQL_USER'] %>
+    password: <%= ENV['MYSQL_PASSWORD'] %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,8 +1,8 @@
 serials_file: <%= ENV["SERIALS_FILE"] %>
 hathifile_path: <%= ENV["HATHIFILE_PATH"] %>
-large_cluster_ocns: <%= ENV["LARGE_CLUSTER_OCNS"] %>
+large_cluster_ocns: /usr/src/app/config/large_cluster_ocns.txt
 database:
-  url: <%= ENV["DB_CONNECTION_STRING"] %>
+  url: <%= ENV["MYSQL_CONNECTION_STRING"] %>
 mongodb:
   host: <%= ENV["MONGODB_HOST"] %>
   password: <%= ENV["MONGODB_PASSWORD"] %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - .:/usr/src/app
       - gem_cache:/gems
     environment:
-      DB_CONNECTION_STRING: "mysql2://ht_repository:ht_repository@mariadb/ht_repository"
+      MYSQL_CONNECTION_STRING: "mysql2://ht_repository:ht_repository@mariadb/ht_repository"
 
   mongo_dev:
     image: mongo

--- a/lib/ht_item_cluster_getter.rb
+++ b/lib/ht_item_cluster_getter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "cluster"
+
+# Cluster getter for OCN-less HTItems
+#
+# Returns the cluster containing the HTItem or a new cluster if one does not
+# exist.
+class HtItemClusterGetter
+  def initialize(ht_item)
+    @ht_item = ht_item
+
+    raise ArgumentError, "only for ocnless HTItems" unless @ht_item.ocns.empty?
+  end
+
+  def get
+    Retryable.new.run do
+      try_strategies.tap {|c| yield c if block_given? }
+    end
+  end
+
+  private
+
+  def try_strategies
+    Cluster.with_ht_item(@ht_item).first || Cluster.create(ocns: [])
+  end
+end

--- a/spec/ht_item_cluster_getter_spec.rb
+++ b/spec/ht_item_cluster_getter_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ht_item_cluster_getter"
+
+RSpec.describe HtItemClusterGetter do
+  let(:no_ocn) { build(:ht_item, ocns: []) }
+
+  before(:each) do
+    Cluster.each(&:delete)
+  end
+
+  describe "#initialize" do
+    it "raises ArgumentError if given more than one htitem" do
+      expect { described_class.new(double(:item1, ocns: []), double(:item2, ocns: [])) }
+        .to raise_exception(ArgumentError)
+    end
+
+    it "raises ArgumentError if given an htitem with ocns" do
+      expect { described_class.new(double(:item1, ocns: [1, 2, 3])) }
+        .to raise_exception(ArgumentError)
+    end
+
+    it "returns when given a single OCNless htitem" do
+      expect(described_class.new(double(:item1, ocns: [])))
+        .not_to be(nil)
+    end
+  end
+
+  describe "#get" do
+    context "when a cluster with the htitem exists" do
+      it "returns that cluster" do
+        cluster = create(:cluster, ocns: [], ht_items: [no_ocn])
+
+        expect(described_class.new(no_ocn).get).to eq(cluster)
+      end
+    end
+
+    context "when there is no cluster with that htitem" do
+      it "returns a new cluster" do
+        expect { described_class.new(no_ocn).get }.to change(Cluster, :count).from(0).to(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Don't delete and create a new cluster when updating an OCNless HTItem
- Don't recluster if the old OCNs are all covered by concordance rules (one case when they will all still be in the new cluster)

This doesn't address:

- Optimizing when to recluster when removing an HTItem from a cluster entirely (although again, we shouldn't need to recluster if the old OCNs are covered by concordance rules)

- Any optimization for reclustering around concordance rules - hopefully, concordance deletes are rare enough this won't matter
- More generally, only reclustering if the last thing gluing two OCNs together was removed from the cluster - this is potentially brittle and difficult to determine
- Any optimizations of reclustering itself (i.e. batching updates to a particular cluster)