### PR TITLE
Add cluster last modified

### DIFF
--- a/bin/export_overlap_report.rb
+++ b/bin/export_overlap_report.rb
@@ -35,19 +35,17 @@ def full_report(org)
   logger = Services.logger
   logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
 
-  report = []
   ClusterOverlap.matching_clusters(org).each do |c|
     ClusterOverlap.new(c, org).each do |overlap|
       waypoint.incr
-      report << overlap_line(overlap.to_hash)
+      puts overlap_line(overlap.to_hash)
       waypoint.on_batch {|wp| logger.info wp.batch_line }
     end
   end
   logger.info waypoint.final_line
-  report
 end
 
 if __FILE__ == $PROGRAM_NAME
   org = ARGV.shift
-  puts full_report(org).join("\n")
+  full_report(org).join("\n")
 end

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -19,6 +19,7 @@ class Cluster
   include Mongoid::Document
   store_in collection: "clusters"
   field :ocns
+  field :last_modified, type: DateTime
   embeds_many :holdings, class_name: "Holding"
   embeds_many :ht_items, class_name: "HtItem"
   embeds_many :ocn_resolutions, class_name: "OCNResolution"
@@ -33,6 +34,8 @@ class Cluster
   }
   scope :for_ocns, ->(ocns) { where(:ocns.in => ocns) }
   scope :with_ht_item, ->(ht_item) { where("ht_items.item_id": ht_item.item_id) }
+
+  before_save {|c| c.last_modified = Time.now.utc }
 
   validates_each :ocns do |record, attr, value|
     value.each do |ocn|

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -59,6 +59,28 @@ RSpec.describe Cluster do
     end
   end
 
+  describe "#last_modified" do
+    let(:c1) { build(:cluster) }
+
+    it "doesn't have last_modified if unsaved" do
+      expect(c1.last_modified).to be_nil
+    end
+
+    it "has last_modified if it is saved" do
+      now = Time.now.utc
+      c1.save
+      expect(c1.last_modified).to be > now
+    end
+
+    it "updates last_modified when it is saved" do
+      c1.save
+      first_timestamp = c1.last_modified
+      c1.save
+      second_timestamp = c1.last_modified
+      expect(first_timestamp).to be < second_timestamp
+    end
+  end
+
   describe "#save" do
     let(:c1) { build(:cluster, ocns: [ocn1, ocn2]) }
     let(:c2) { build(:cluster, ocns: [ocn2]) }

--- a/spec/overlap_report_spec.rb
+++ b/spec/overlap_report_spec.rb
@@ -23,9 +23,11 @@ RSpec.describe "overlap_report" do
       h2.condition = "BRT"
       Cluster.first.add_holdings(h2).tap(&:save)
       cid = Cluster.first._id
-      expect(full_report(h.organization)).to eq([
-        "#{cid}\t#{cid}\t#{ht.item_id}\t#{ht.n_enum}\t#{h.organization}\t2\t1\t0\t0\t1"
-      ])
+      expect do
+        full_report(h.organization)
+      end.to output(
+        "#{cid}\t#{cid}\t#{ht.item_id}\t#{ht.n_enum}\t#{h.organization}\t2\t1\t0\t0\t1\n"
+      ).to_stdout
     end
 
     it "generates the correct report for the billing entity" do
@@ -33,10 +35,12 @@ RSpec.describe "overlap_report" do
       cluster2 = Cluster.find_by(ocns: ht2.ocns)
       cid1 = cluster1._id
       cid2 = cluster2._id
-      expect(full_report("not_same_as_holding")).to eq([
-        "#{cid1}\t#{cid1}\t#{ht.item_id}\t#{ht.n_enum}\tnot_same_as_holding\t1\t0\t0\t0\t0",
-        "#{cid2}\t#{cid2}\t#{ht2.item_id}\t#{ht2.n_enum}\tnot_same_as_holding\t1\t0\t0\t0\t0"
-      ])
+      expect do
+        full_report("not_same_as_holding")
+      end.to output(
+        %(#{cid1}\t#{cid1}\t#{ht.item_id}\t#{ht.n_enum}\tnot_same_as_holding\t1\t0\t0\t0\t0
+#{cid2}\t#{cid2}\t#{ht2.item_id}\t#{ht2.n_enum}\tnot_same_as_holding\t1\t0\t0\t0\t0\n)
+      ).to_stdout
     end
   end
 end


### PR DESCRIPTION
This adds the field `last_modified` to Clusters and sets as Time.now.utc with a before_save callback. This may be the wrong name for it, as a save doesn't guarantee modification. 

Without a way to filter clusters of interest, consuming services will need to process the entire database. That's acceptable when we are performing monthly updates, but not so when we are performing updates at much higher frequency. 

edit: I should note that this doesn't deal with deletes, although in practice this shouldn't be too much of an issue. 