### PR TITLE
Ht 2940 load overlap reports for etas

### DIFF
--- a/bin/export_etas_overlap_report.rb
+++ b/bin/export_etas_overlap_report.rb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "services"
-
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+require "services"
+require "settings"
 require "bundler/setup"
 require "utils/waypoint"
 require "utils/ppnum"

--- a/bin/export_overlap_report.rb
+++ b/bin/export_overlap_report.rb
@@ -12,6 +12,8 @@ require "utils/waypoint"
 require "utils/ppnum"
 require "zinzout"
 require "cluster_overlap"
+require "pry"
+require "pp"
 
 Mongoid.load!("mongoid.yml", :test)
 
@@ -30,7 +32,7 @@ def overlap_line(overlap_hash)
    overlap_hash[:access_count]].join("\t")
 end
 
-def full_report(org)
+def report(org)
   waypoint = Utils::Waypoint.new(BATCH_SIZE)
   logger = Services.logger
   logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
@@ -46,6 +48,19 @@ def full_report(org)
 end
 
 if __FILE__ == $PROGRAM_NAME
+  require 'optparse'
+  
+  options = {}
+  OptionParser.new do |opts|
+    opts.on("-f", "--full",
+      "Produce overlap records for all matching clusters. Default: Clusters modified in last 36 hours") do |f|
+      options.full = f
+    end
+    opts.on("-o", "--organization", "Limit overlap records to a particular organization.") do |org|
+      options.organization = org || ''
+    end
+  end
+
   org = ARGV.shift
-  full_report(org).join("\n")
+  report(org)
 end

--- a/bin/export_overlap_report.rb
+++ b/bin/export_overlap_report.rb
@@ -48,16 +48,19 @@ def report(org)
 end
 
 if __FILE__ == $PROGRAM_NAME
-  require 'optparse'
-  
+  require "optparse"
+
   options = {}
   OptionParser.new do |opts|
-    opts.on("-f", "--full",
-      "Produce overlap records for all matching clusters. Default: Clusters modified in last 36 hours") do |f|
+    opts.on(
+      "-f",
+      "--full",
+      "Produce overlaps for all matching clusters. Default: Clusters modified last 36 hours"
+    ) do |f|
       options.full = f
     end
     opts.on("-o", "--organization", "Limit overlap records to a particular organization.") do |org|
-      options.organization = org || ''
+      options.organization = org || ""
     end
   end
 

--- a/bin/export_overlap_report.rb
+++ b/bin/export_overlap_report.rb
@@ -35,19 +35,17 @@ def full_report(org)
   logger = Services.logger
   logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
 
-  report = []
   ClusterOverlap.matching_clusters(org).each do |c|
     ClusterOverlap.new(c, org).each do |overlap|
       waypoint.incr
-      report << overlap_line(overlap.to_hash)
+      puts overlap_line(overlap.to_hash)
       waypoint.on_batch {|wp| logger.info wp.batch_line }
     end
   end
   logger.info waypoint.final_line
-  report
 end
 
 if __FILE__ == $PROGRAM_NAME
   org = ARGV.shift
-  puts full_report(org).join("\n")
+  full_report(org).join("\n")
 end

--- a/bin/update_overlap_report_database.rb
+++ b/bin/update_overlap_report_database.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "pathname"
+$LOAD_PATH.unshift(Pathname.new(__dir__).parent + "lib")
+
+require "bundler/setup"
+require "cluster"
+require "cluster_overlap"
+require "logger"
+require "services"
+require "utils/waypoint"
+require "date"
+
+Services.mongo!
+
+TABLENAME = :holdings_htitem_htmember
+def overlap_table
+  Services.holdings_db[TABLENAME]
+end
+
+# At some future date we might want to update a single org's overlaps
+def org
+  nil
+end
+
+def upsert(overlap)
+  rec = overlap_table.where(:volume_id => overlap[:volume_id], :member_id => overlap[:member_id])
+  if 1 != rec.update(overlap)
+    overlap_table.insert(overlap)
+  end
+end
+
+# Default: Now - 36 hours 
+cutoff_date = Date.today - 1.5
+
+unless ARGV.empty?
+  cutoff_date = Date.parse(ARGV.shift)
+end
+
+puts "Upserting clusters last_modified after #{cutoff_date.strftime("%Y-%m-%d %H:%M:%S")}"
+
+BATCH_SIZE = 1_000
+waypoint = Utils::Waypoint.new(BATCH_SIZE)
+
+logger = Services.logger
+Cluster.where("ht_items.0": { "$exists": 1},
+              last_modified: {"$gt":cutoff_date}).no_timeout.each do |c|
+  ClusterOverlap.new(c, org).each do |overlap|
+    waypoint.incr
+    upsert(overlap)
+    waypoint.on_batch {|wp| logger.info wp.batch_line }
+  end
+end
+logger.info waypoint.final_line 

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -19,6 +19,7 @@ class Cluster
   include Mongoid::Document
   store_in collection: "clusters"
   field :ocns
+  field :last_modified, type: DateTime
   embeds_many :holdings, class_name: "Holding"
   embeds_many :ht_items, class_name: "HtItem"
   embeds_many :ocn_resolutions, class_name: "OCNResolution"
@@ -33,6 +34,8 @@ class Cluster
   }
   scope :for_ocns, ->(ocns) { where(:ocns.in => ocns) }
   scope :with_ht_item, ->(ht_item) { where("ht_items.item_id": ht_item.item_id) }
+
+  before_save {|c| c.last_modified = Time.now.utc }
 
   validates_each :ocns do |record, attr, value|
     value.each do |ocn|

--- a/spec/overlap_report_spec.rb
+++ b/spec/overlap_report_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe "overlap_report" do
     ClusterHtItem.new(ht2).cluster.tap(&:save)
   end
 
-  describe "full_report" do
+  describe "report" do
     it "generates the correct report for the holding org" do
       h2 = h.dup
       h2.condition = "BRT"
       Cluster.first.add_holdings(h2).tap(&:save)
       cid = Cluster.first._id
       expect do
-        full_report(h.organization)
+        report(h.organization)
       end.to output(
         "#{cid}\t#{cid}\t#{ht.item_id}\t#{ht.n_enum}\t#{h.organization}\t2\t1\t0\t0\t1\n"
       ).to_stdout
@@ -36,7 +36,7 @@ RSpec.describe "overlap_report" do
       cid1 = cluster1._id
       cid2 = cluster2._id
       expect do
-        full_report("not_same_as_holding")
+        report("not_same_as_holding")
       end.to output(
         %(#{cid1}\t#{cid1}\t#{ht.item_id}\t#{ht.n_enum}\tnot_same_as_holding\t1\t0\t0\t0\t0
 #{cid2}\t#{cid2}\t#{ht2.item_id}\t#{ht2.n_enum}\tnot_same_as_holding\t1\t0\t0\t0\t0\n)

--- a/spec/overlap_report_spec.rb
+++ b/spec/overlap_report_spec.rb
@@ -23,9 +23,11 @@ RSpec.describe "overlap_report" do
       h2.condition = "BRT"
       Cluster.first.add_holdings(h2).tap(&:save)
       cid = Cluster.first._id
-      expect(full_report(h.organization)).to eq([
-        "#{cid}\t#{cid}\t#{ht.item_id}\t#{ht.n_enum}\t#{h.organization}\t2\t1\t0\t0\t1"
-      ])
+      expect do
+        full_report(h.organization)
+      end.to output(
+        "#{cid}\t#{cid}\t#{ht.item_id}\t#{ht.n_enum}\t#{h.organization}\t2\t1\t0\t0\t1\n"
+      ).to_stdout
     end
 
     it "generates the correct report for the billing entity" do
@@ -33,10 +35,12 @@ RSpec.describe "overlap_report" do
       cluster2 = Cluster.find_by(ocns: ht2.ocns)
       cid1 = cluster1._id
       cid2 = cluster2._id
-      expect(full_report("not_same_as_holding")).to eq([
-        "#{cid1}\t#{cid1}\t#{ht.item_id}\t#{ht.n_enum}\tnot_same_as_holding\t1\t0\t0\t0\t0",
-        "#{cid2}\t#{cid2}\t#{ht2.item_id}\t#{ht2.n_enum}\tnot_same_as_holding\t1\t0\t0\t0\t0"
-      ])
+      expect do
+        full_report("not_same_as_holding")
+      end.to output(
+        %(#{cid1}\t#{cid1}\t#{ht.item_id}\t#{ht.n_enum}\tnot_same_as_holding\t1\t0\t0\t0\t0
+#{cid2}\t#{cid2}\t#{ht2.item_id}\t#{ht2.n_enum}\tnot_same_as_holding\t1\t0\t0\t0\t0\n)
+      ).to_stdout
     end
   end
 end


### PR DESCRIPTION
Overlap records for ETAS purposes need to make it to the MySQL database incrementally. This means upserts, which also means we need to know the unique identifiers for the records in the `holdings_htitem_htmember` table. I *think* those are `volume_id` and `member_id`, but they might also include `n_enum`? Anyway, this is described, if not successfully accomplished in `bin/update_overlap_report_database.rb`

These aren't print holdings operations and shouldn't really be a concern here. If ETAS needs an overlap computation saved in a SQL database, that seems like a problem for ETAS. However, it seems we're stuck with prior practice.
