### PR TITLE
Autoscrub multi OCN

### DIFF
--- a/bin/inspect_ocn.rb
+++ b/bin/inspect_ocn.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# For manual/ocular inspection of a single OCN.
+# Takes an OCN and outputs a pretty-printed matching cluster.
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+require "cluster"
+require "services"
+require "json"
+
+Services.mongo!
+
+def look_up(ocn)
+  cluster = Cluster.find_by(ocns: ocn.to_i)
+  if cluster.nil?
+    "No cluster found for OCN #{ocn}."
+  else
+    JSON.pretty_generate(cluster.as_document)
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ocn = ARGV.shift
+  puts look_up(ocn)
+end

--- a/lib/member_holding.rb
+++ b/lib/member_holding.rb
@@ -8,10 +8,10 @@ require "custom_errors"
 
 # Represents the information in one line from a member holding file
 class MemberHolding
-  attr_accessor :organization, :mono_multi_serial
+  attr_accessor :organization, :mono_multi_serial, :ocn, :uuid
 
-  attr_reader :ocn, :local_id, :status, :condition, :enum_chron, :issn,
-              :gov_doc_flag, :uuid, :date_received, :n_enum, :n_chron,
+  attr_reader :local_id, :status, :condition, :enum_chron, :issn,
+              :gov_doc_flag, :date_received, :n_enum, :n_chron,
               :violations
 
   def initialize(col_map = {})
@@ -85,6 +85,24 @@ class MemberHolding
     end
   end
   # rubocop:enable Metrics/MethodLength
+
+  # In case a MemberHolding.ocn has more than one value, we need to
+  # explode into 1 MemberHolding per ocn.
+  def explode_ocn
+    siblings = []
+
+    return [self] if ocn.size == 1
+
+    log("Exploding OCNs: #{ocn.join(",")}")
+    @ocn.each do |ocn|
+      doppel      = clone
+      doppel.ocn  = ocn
+      doppel.uuid = SecureRandom.uuid
+      siblings << doppel
+    end
+
+    siblings
+  end
 
   def to_json(*_args)
     {

--- a/lib/member_holding.rb
+++ b/lib/member_holding.rb
@@ -91,7 +91,10 @@ class MemberHolding
   def explode_ocn
     siblings = []
 
-    return [self] if ocn.size == 1
+    if ocn.size == 1
+      @ocn = ocn.first
+      return [self]
+    end
 
     log("Exploding OCNs: #{ocn.join(",")}")
     @ocn.each do |ocn|

--- a/spec/member_holding_file_spec.rb
+++ b/spec/member_holding_file_spec.rb
@@ -69,14 +69,17 @@ RSpec.describe MemberHoldingFile do
     end
   end
 
-  it "turns a line into a MemberHolding" do
-    expect(
-      ok_header_mhf.item_from_line("123\t123", ok_col_map)
-    ).to be_a(MemberHolding)
+  it "turns a line into an array of MemberHolding(s)" do
+    value = ok_header_mhf.item_from_line("123\t123", ok_col_map)
+    expect(value).to be_a(Array)
+    expect(value.first).to be_a(MemberHolding)
+    expect(value.first.violations).to eq([])
+  end
 
-    expect(
-      ok_header_mhf.item_from_line("123\t123", ok_col_map).violations
-    ).to eq([])
+  it "explodes a line with multiple ocns into one MemberHolding per ocn" do
+    value = ok_header_mhf.item_from_line("1,2,3\t123", ok_col_map)
+    expect(value).to be_a(Array)
+    expect(value.size).to be(3)
   end
 
   it "can read a file and yield MemberHolding records" do

--- a/spec/member_holding_spec.rb
+++ b/spec/member_holding_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe MemberHolding do
 
   let(:bad_min_str) { "FAIL_ME\t456" }
 
+  let(:explode_ocn_str) { "1,2,3\t456" }
+
   it "creates a MemberHolding (min fields example)" do
     expect(ok_min_hold).to be_a(described_class)
   end
@@ -91,5 +93,15 @@ RSpec.describe MemberHolding do
     # because those are not reason enough to reject the record, just the value
     # and should show up as warnings in the log
     expect(ok_max_hold.parse(bad_max_str)).to be(true)
+  end
+
+  it "explodes a line with multiple OCNs to a corresponding number of objects" do
+    # 1 ocn, does not explode
+    ok_min_hold.parse(ok_min_str)
+    expect(ok_min_hold.explode_ocn.size).to be(1)
+
+    # 3 ocns, explodes into 3
+    ok_min_hold.parse(explode_ocn_str)
+    expect(ok_min_hold.explode_ocn.size).to be(3)
   end
 end


### PR DESCRIPTION
Based on:
https://tools.lib.umich.edu/confluence/display/HAT/Print+Holdings%3A+Options+for+Multiple+OCNs
https://github.com/hathitrust/holdings-backend/blob/master/adr/0004-order-independence.md

... and the fact that a submitted holdings record with multiple OCNs previous to this fix comes through as an array of numbers, which upon loading gets interpreted as 0 and eventually causing a Mongo::Error::MaxBSONSize

It used to be:
```
Autoscrub input:  ocn1,ocn2 \t ...
Autoscrub output: {"ocn":[1,2], ...} <<-- root of problem
Loader internal: {"_id"=>BSON::ObjectId(...), "ocn"=>0, ...}
```

But now it is:
```
Autoscrub input:  ocn1,ocn2 \t ...
Autoscrub output: {"ocn":1, ...}
Autoscrub output: {"ocn":2, ...}
Loader internal: {"_id"=>BSON::ObjectId(...), "ocn"=>1, ...}
Loader internal: {"_id"=>BSON::ObjectId(...), "ocn"=>2, ...}
```

Also added bin/inspect_ocn.rb as a utility/debug tool, unrelated to the multi OCN issue.