### PR TITLE
Load concordance diffs

### DIFF
--- a/bin/load_concordance_diffs.rb
+++ b/bin/load_concordance_diffs.rb
@@ -6,6 +6,7 @@ require "bundler/setup"
 require "services"
 require "ocn_concordance_diffs"
 require "utils/multi_logger"
+require "date"
 
 Services.mongo!
 
@@ -16,8 +17,10 @@ date_to_load = ARGV[0]
 
 raise "Usage: #{$PROGRAM_NAME} YYYY-mm-dd" unless date_to_load
 
+BATCH_SIZE = 250_000
+
 Services.register(:logger) do
   Utils::MultiLogger.new(default_logger, Logger.new(Services.slack_writer, level: Logger::INFO))
 end
 
-OCNConcordanceDiffs.new(date_to_load).try_load
+OCNConcordanceDiffs.new(Date.parse(date_to_load)).load

--- a/lib/ocn_concordance_diffs.rb
+++ b/lib/ocn_concordance_diffs.rb
@@ -4,7 +4,7 @@ require "services"
 require "settings"
 require "loaded_file"
 require "file_loader"
-require "ht_item_loader"
+require "ocn_resolution_loader"
 
 # Responsible for locating and loading a pair of diffs from an OCN concordance.
 # Both files contain OCNResolutions represented as deprecated, resolved pairs
@@ -21,7 +21,7 @@ class OCNConcordanceDiffs
     @logger = logger
   end
 
-  def load(loader: FileLoader.new(batch_loader: OCNResolutionLoader.new))
+  def load(loader: FileLoader.new(batch_loader: OCNResolutionLoader.new, batch_size: BATCH_SIZE))
     begin
       logger.info("Started loading #{delete_filename}")
       loader.load_deletes(delete_filename)


### PR DESCRIPTION
There were a few bugs in `bin/load_concordance_diffs.rb`. Also needed to set a larger batch size for logging.