### PR TITLE
faster lookup of holdings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,6 @@ group :development do
   gem "rubocop"
   gem "rubocop-performance"
   gem "rubocop-rspec"
-  gem "yard"
   gem "ruby-prof"
+  gem "yard"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -32,4 +32,5 @@ group :development do
   gem "rubocop-performance"
   gem "rubocop-rspec"
   gem "yard"
+  gem "ruby-prof"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       rubocop-ast (>= 0.4.0)
     rubocop-rspec (1.43.2)
       rubocop (~> 0.87)
+    ruby-prof (1.4.3)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.4)
     sequel (5.37.0)
@@ -130,6 +131,7 @@ DEPENDENCIES
   rubocop
   rubocop-performance
   rubocop-rspec
+  ruby-prof
   sequel
   simplecov
   webmock
@@ -137,4 +139,4 @@ DEPENDENCIES
   zinzout
 
 BUNDLED WITH
-   2.2.16
+   2.2.20

--- a/lib/cluster_holding.rb
+++ b/lib/cluster_holding.rb
@@ -83,7 +83,11 @@ class ClusterHolding
       # Build a fast lookup for holdings
       # {update_key1: h1, update_key2: h2, ...}
       @cluster_holdings_lookup ||= cluster.holdings.group_by(&:update_key)
-      [@cluster_holdings_lookup[holding.update_key]&.find{|h| h.date_received != holding.date_received}]
+      [
+        @cluster_holdings_lookup[holding.update_key]&.find do |h|
+          h.date_received != holding.date_received
+        end
+      ]
     end
   end
 
@@ -97,7 +101,6 @@ class ClusterHolding
   # Assumes uuids will not be duplicated within either list
   # Common case is that there is no overlap
   def check_for_duplicate_uuids!(existing_holdings, new_holdings)
-
     existing_by_uuid = existing_holdings.group_by(&:uuid)
     new_by_uuid      = new_holdings.group_by(&:uuid)
     common_uuids     = existing_by_uuid.keys & new_by_uuid.keys
@@ -106,8 +109,13 @@ class ClusterHolding
       existing = existing_by_uuid[uuid]
       new_holding = new_by_uuid[uuid]
 
-      raise "There should be EXACTLY one holding with that UUID #{uuid}" unless existing.length == 1
-      raise "There should be EXACTLY one holding with that UUID #{uuid}" unless new_holding.length == 1
+      unless existing.length == 1
+        raise "There should be EXACTLY one holding with that UUID #{uuid}"
+      end
+
+      unless new_holding.length == 1
+        raise "There should be EXACTLY one holding with that UUID #{uuid}"
+      end
 
       unless existing.first.same_as?(new_holding.first)
         raise "Found holding #{existing.first.inspect} with same UUID " \

--- a/lib/cluster_holding.rb
+++ b/lib/cluster_holding.rb
@@ -97,13 +97,21 @@ class ClusterHolding
   # Assumes uuids will not be duplicated within either list
   # Common case is that there is no overlap
   def check_for_duplicate_uuids!(existing_holdings, new_holdings)
-    common_uuids = existing_holdings.map(&:uuid) & new_holdings.map(&:uuid) # set intersection
+
+    existing_by_uuid = existing_holdings.group_by(&:uuid)
+    new_by_uuid      = new_holdings.group_by(&:uuid)
+    common_uuids     = existing_by_uuid.keys & new_by_uuid.keys
+
     common_uuids.each do |uuid|
-      existing = existing_holdings.find {|h| h.uuid == uuid }
-      holding = new_holdings.find {|h| h.uuid == uuid }
-      unless existing.same_as?(holding)
-        raise "Found holding #{existing.inspect} with same UUID " \
-                "but different attributes from update #{holding.inspect}"
+      existing = existing_by_uuid[uuid]
+      new_holding = new_by_uuid[uuid]
+
+      raise "There should be EXACTLY one holding with that UUID #{uuid}" unless existing.length == 1
+      raise "There should be EXACTLY one holding with that UUID #{uuid}" unless new_holding.length == 1
+
+      unless existing.first.same_as?(new_holding.first)
+        raise "Found holding #{existing.first.inspect} with same UUID " \
+                "but different attributes from update #{new_holding.first.inspect}"
       end
     end
   end

--- a/lib/cluster_holding.rb
+++ b/lib/cluster_holding.rb
@@ -30,7 +30,6 @@ class ClusterHolding
         next if common_uuids.include? holding.uuid
 
         old_holdings = find_old_holdings(c, holding)
-
         if old_holdings.any?
           old_holdings.each {|old| update_holding(old, holding) }
         elsif duplicate_large_cluster_holding? c, holding, to_add
@@ -39,7 +38,6 @@ class ClusterHolding
           to_add << holding
         end
       end
-
       c.add_holdings(to_add)
     end
   end
@@ -82,7 +80,10 @@ class ClusterHolding
         h.organization == holding.organization && h.date_received != holding.date_received
       end
     else
-      [cluster.holdings.to_a.find {|h| h == holding && h.date_received != holding.date_received }]
+      # Build a fast lookup for holdings
+      # {update_key1: h1, update_key2: h2, ...}
+      @cluster_holdings_lookup ||= cluster.holdings.group_by(&:update_key)
+      [@cluster_holdings_lookup[holding.update_key]&.find{|h| h.date_received != holding.date_received}]
     end
   end
 

--- a/lib/holding.rb
+++ b/lib/holding.rb
@@ -99,6 +99,12 @@ class Holding
     ocn == other.ocn
   end
 
+  # Turn a holding into a hash key for quick lookup
+  # in e.g. cluster_holding.find_old_holdings.
+  def update_key
+    as_document.slice(*(fields.keys - EQUALITY_EXCLUDED_FIELDS)).hash
+  end
+
   private
 
   def set_member_data


### PR DESCRIPTION
Changes to ClusterHolding, specifically to the methods check_for_duplicate_uuids! and find_old_holdings, in order to improve speed when adding holdings.