### PR TITLE
cannot load services before /lib/

### DIFF
--- a/bin/compile_cost_reports.rb
+++ b/bin/compile_cost_reports.rb
@@ -1,9 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "services"
-
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+require "services"
 require "bundler/setup"
 require "utils/waypoint"
 require "utils/ppnum"


### PR DESCRIPTION
Couldn't run cost report on k8s because the requires were in the wrong order.