### PR TITLE
HT-3072 add narrative and stat tracking to estimate generation

### DIFF
--- a/bin/compile_estimated_IC_costs.rb
+++ b/bin/compile_estimated_IC_costs.rb
@@ -12,6 +12,8 @@ require "services"
 
 Services.mongo!
 
+# Given a file of unique OCNs, generate a cost estimate.
+
 if __FILE__ == $PROGRAM_NAME
   BATCH_SIZE = 10_000
   waypoint = Utils::Waypoint.new(BATCH_SIZE)
@@ -21,12 +23,18 @@ if __FILE__ == $PROGRAM_NAME
   logger.info "Cost per volume: #{cost_report.cost_per_volume}"
   logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
 
+  ocns = []
   ocn_file = ARGV.shift
   h_share_total = 0.0
-  ht_items_seen = Set.new
+  clusters_seen = Set.new
+  num_ocns_matched = 0
+  num_items_matched = 0
+  num_items_pd = 0
+  num_items_ic = 0
 
   File.open(ocn_file).each do |line|
     ocn = line.to_i
+    ocns << ocn
     waypoint.incr
 
     # Find a cluster
@@ -34,13 +42,22 @@ if __FILE__ == $PROGRAM_NAME
                             "ht_items.0": { "$exists": 1 })
     next if cluster.nil?
 
+    num_ocns_matched += 1
+
+    # Multiple OCLCs can map to the same cluster, but we only want them once
+    next if clusters_seen.include?(cluster._id)
+
+    clusters_seen << cluster._id
+
+    num_items_matched += cluster.ht_items.count
+
     cluster.ht_items.each do |ht_item|
-      next unless ht_item.access == "deny"
-
-      # Multiple OCLCs can map to the same cluster, but we only want them once
-      next if ht_items_seen.include?(ht_item.item_id)
-
-      ht_items_seen << ht_item.item_id
+      if ht_item.access == "allow"
+        num_items_pd += 1
+        next
+      end
+      # next unless ht_item.access == "deny"
+      num_items_ic += 1
 
       overlap = HtItemOverlap.new(ht_item)
       # Insert a placeholder for the prospective member
@@ -51,5 +68,15 @@ if __FILE__ == $PROGRAM_NAME
   end
   logger.info waypoint.final_line
 
-  puts "Total Estimated IC Cost:#{h_share_total * cost_report.cost_per_volume}"
+  pct_ocns_matched = num_ocns_matched.to_f / ocns.uniq.count * 100
+  pct_items_pd = num_items_pd / num_items_matched.to_f * 100
+  pct_items_ic = num_items_ic / num_items_matched.to_f * 100
+
+  puts "Total Estimated IC Cost:#{h_share_total * cost_report.cost_per_volume}
+In all, we received #{ocns.uniq.count} distinct OCLC numbers.
+Of those distinct OCLC numbers, #{num_ocns_matched} (#{pct_ocns_matched.round(1)}%) match in
+HathiTrust, corresponding to #{num_items_matched} HathiTrust items.
+Of those, #{num_items_pd} ( #{pct_items_pd.round(1)}%) are in the public domain,
+#{num_items_ic} ( #{pct_items_ic} ) are in copyright."
+
 end


### PR DESCRIPTION
In addition to the IC cost, this adds information about the number of unique OCNs and the count/percent of matches. In the old system we also reported the number of usable holdings (MPM, SPM, SER), but that is not readily available to `bin/compile_estimated_IC_costs.rb` because it is only given a list of OCNs. 