### PR TITLE
added scripts for generating cross-costreport comparisons

### DIFF
--- a/bin/append_sheets.pl
+++ b/bin/append_sheets.pl
@@ -1,0 +1,193 @@
+use strict;
+use warnings;
+
+=pod
+
+Take any number of tsv files greater than or equal to 2.
+For each row in file x, add all cols to a corresponding row
+in a combined sheet.
+Assuming that all rows in a file has the same number of cols.
+Number of cols may be different between files.
+Also assuming an identifier in the first col, in all files,
+which is not constantly reappended to the combined sheet.
+
+So given the files:
+
+  (file1.txt)
+  a 1 3 5
+
+and
+
+  (file2.txt)
+  a 8 9
+  b 5 5
+
+Calling
+
+  $ perl append_sheets.pl --na='0' --d=' ' file1.txt file2.txt
+
+... will result in:
+
+  a 1 3 5 8 9
+  b N/A N/A N/A 5 5
+
+Flags:
+
+Use --na=<value> to override the default value of $na ('N/A').
+
+  perl append_sheets.pl --na='-' --d=' ' file1.txt file2.txt
+  a 1 3 5 8 9
+  b - - - 5 5
+
+Use --d=<value> to override the default value of $delim ("\t").
+    The same $delim is used to split input and join output.
+
+Use --header to sneak in the filenames in the appended sheet.
+    This way you can (sort of, if lucky) see which col came
+    from which file.
+
+Use --op=<operator> to choose operator to compare cells with.
+    Supported: - and %. If omitted, values are copied as-is.
+
+Use --f=<fields> to specify which fields in the input sheet to use.
+    <fields> is a comma-sep index list, like --f=1,3,5
+    The first field in the list will be assumed to be line_key.
+    Zero-indexed, unlike "cut -f". For the last field, do -1.
+
+=cut
+
+my $fi = 0;
+# Separate input files from --flags, assign an index to each file and put in $files.
+my $files = {map {++$fi => $_} grep {$_ !~ /^--/} @ARGV};
+
+die "Need at least 2 infiles.\n" if keys %$files < 2;
+my $lines      = {};
+my $delim      = "\t";  # Value separator, change with --d=.
+my $na         = 'N/A'; # The default for missing values. Change with --na.
+my $header     = 0;     # Whether to use a header. Change with --header.
+my $operator   = '';    # Choose operator to compare cells with, if any, with --op=
+my $fields     = [];    # Specify which fields to take from sheet. Sort of like cut -f<fields>.
+my $line_keys = {};
+my $file_cols  = {};
+my $number_rx  = qr/^[0-9]+(\.[0-9]+)?$/;
+
+# Get/set all flags.
+foreach my $m (grep {$_ =~ /^--/} @ARGV) {
+    if ($m =~ /--na=(.+)/) {
+	$na = $1;
+    } elsif ($m =~ /^--d=(.+)/) {
+	$delim = $1;
+    } elsif ($m =~ /--header/) {
+	$header = 1;
+    } elsif ($m =~ /--op=(.+)/) {
+	my $test_op = $1;
+	if ($test_op eq '-') {
+	    $operator = '-';
+ 	} elsif ($test_op eq '%') {
+	    $operator = '%';
+	}
+    } elsif ($m =~ /--f=((-?[0-9]+,?)+)/) {
+	$fields = [split(',', $1)];
+    }
+}
+
+# For each file, read in its contents line per line.
+foreach my $k (sort {$a<=>$b} keys %$files) {
+    open(F, $files->{$k});
+    # Store lines here, with the first cell value as key (assuming no dups)
+    my $lines_in_file = {};
+    if ($header) {
+	# If --header set, fake a line_key called _header with the file as val.
+	# This way you can see which value came from which file.
+	$lines_in_file->{'_header'} = [$files->{$k}];
+	$line_keys->{'_header'} = 1;
+    }
+    while (<F>) {
+	my $line = $_;
+	chomp $line;
+	my @cols = split($delim, $line);
+	# If --f, extract desired cols.
+	if (@$fields) {
+	    @cols = @cols[@$fields];
+	}
+	# Save first cell value for hash key.
+	my $line_key = shift @cols;
+	# The other cells to array ref, store as hash value.
+	$lines_in_file->{$line_key} = [@cols];
+	$line_keys->{$line_key}    = 1;
+	if (!defined $file_cols->{$k} || @cols > $file_cols->{$k}) {
+	    $file_cols->{$k} = @cols;
+	}
+    }
+    # Store entire hash in file hash.
+    $lines->{$files->{$k}} = $lines_in_file;
+    close(F);
+}
+
+my $combined = {map {$_ => []} keys %$line_keys};
+
+# For each file in the file hash:
+foreach my $k (sort {$a<=>$b} keys %$files) {
+    # Check if there is a next file-hash to compare with
+    my $h = $lines->{$files->{$k}};
+    foreach my $m (sort {$a cmp $b} keys %$line_keys) {
+	# Make sure each file has a row for each member in any row,
+	# that has as many cols as any row in that file should.
+	$h->{$m} ||= [($na) x $file_cols->{$k}];
+	if (@{$h->{$m}} < $file_cols->{$k}) {
+	    my $missing_vals = $file_cols->{$k} - @{$h->{$m}};
+	    push(@{$h->{$m}}, $na) for (1 .. $missing_vals);
+	}
+	foreach my $cell (@{$h->{$m}}) {
+	    push(@{$combined->{$m}}, $cell);
+	}
+    }
+}
+
+# Apply $operator if given one.
+# Print the combined sheet using the same delimiter.
+foreach my $m (sort keys %$combined) {
+    if ($operator eq '-') {
+	my @vals = @{$combined->{$m}};
+	print $m . $delim . join(
+	    $delim,
+	    map {
+		diff($vals[$_], $vals[$_+1])
+	    } (0 .. @vals - 1)
+	) . "\n";
+    } elsif ($operator eq '%') {
+	my @vals = @{$combined->{$m}};
+	print $m . $delim . join(
+	    $delim,
+	    map {
+		diff_percent($vals[$_], $vals[$_+1])
+	    } (0 .. @vals - 1)
+	) . "\n";
+    } else {
+	print $m . $delim . (join($delim, @{$combined->{$m}})) . "\n";
+    }
+}
+
+sub diff {
+    # Get the y-x diff for each 2 cells.
+    my $x = shift;
+    my $y = shift;
+    return '' if !defined $y;
+    if ($x =~ $number_rx && $y =~ $number_rx) {
+	return $y - $x;
+    } else {
+	return $x;
+    }
+}
+
+sub diff_percent {
+    # Get the y-x diff% for each 2 cells.
+    my $x = shift;
+    my $y = shift;
+    return '' if !defined $y;
+    if ($x =~ $number_rx && $y =~ $number_rx) {
+	return (100 * ($y - $x) / $x) . "%";
+    } else {
+	return $x;
+    }
+}

--- a/bin/cost_changes.sh
+++ b/bin/cost_changes.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# MW Nov 2017.
+# Attempting to automate the construction of the cost report so that it
+# takes as little manual work as possible. Re-creates the whole cost
+# history from scratch each time, and outputs 3 separate report files.
+# Be aware that this will slurp up any cost report under <input_dir>
+# so don't let experimental ones sit around when running this.
+
+# Args:
+# Takes a dir where the costreports are located as 1st arg
+# and a dir where to put the outfiles           as 2nd arg.
+
+# Usage:
+# $ bash ./bin/cost_changes.sh <input_dir> <output_dir>
+
+in_dir=$1
+out_dir=$2
+ymd=`date +'%Y-%m-%d'`;
+
+totals_file="$out_dir/append_totals_$ymd.tsv";
+diff_file="$out_dir/diff_totals_$ymd.tsv";
+diffp_file="$out_dir/diff_percent_totals_$ymd.tsv";
+
+# Get all current members.
+member_list=`bundle exec ruby bin/get_all_members.rb | tr '\n' '|'`;
+keep_lines="^($member_list";
+keep_lines+="_header)\t";
+
+# Putting it all together.
+all_reports=`find $in_dir -regex '.*/costreport_[0-9]+.tsv$' | sort -n | tr '\n' ' '`;
+
+# Find all totals files and append them.
+function append_totals () {
+    perl ./bin/append_sheets.pl --f=0,-1 --header $all_reports;
+}
+
+# Compare sheet n with n+1 for diff over builds.
+function diff_totals () {
+    perl ./bin/append_sheets.pl --f=0,-1 --header --op='-' $all_reports;
+}
+
+# Compare sheet n with n+1 for diff% over builds.
+function diff_percent_totals () {
+    perl ./bin/append_sheets.pl --f=0,-1 --header --op='%' $all_reports;
+}
+
+# Header values are full file path. Shorten to just the date part.
+function clean_header () {
+    sed -r 's/[^\t]+?_([0-9]+).tsv/\1/g';
+}
+
+# Output reports.
+append_totals       | clean_header | grep -P $keep_lines > $totals_file;
+diff_totals         | clean_header | grep -P $keep_lines > $diff_file;
+diff_percent_totals | clean_header | grep -P $keep_lines > $diffp_file;
+
+echo "Wrote these files:";
+echo $totals_file;
+echo $diff_file;
+echo $diffp_file;

--- a/bin/get_all_members.rb
+++ b/bin/get_all_members.rb
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Prints all current members to stdout
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+require "ht_members"
+puts HTMembers.new.members.keys


### PR DESCRIPTION
This time without a buncha commits from other branches!

Copied and modified from https://github.com/hathitrust/print_holdings, a couple of scripts that look at old cost reports and generates 3 files:

1. A history of total-cost per member per report
2. A history of total-cost diff (month to month) per member per report
3. A history of total-cost diff percentage (month to month) per member per report

These all go into the finished product, the Google Sheet, as separate tabs.