### PR TITLE
Change location of concordance diffs to concordance/diffs

### DIFF
--- a/lib/ocn_concordance_diffs.rb
+++ b/lib/ocn_concordance_diffs.rb
@@ -21,7 +21,7 @@ class OCNConcordanceDiffs
     @logger = logger
   end
 
-  def load(loader: Loader::FileLoader.new(batch_loader: OCNResolutionLoader.new,
+  def load(loader: Loader::FileLoader.new(batch_loader: Loader::OCNResolutionLoader.new,
                                           batch_size: BATCH_SIZE))
     begin
       logger.info("Started loading #{delete_filename}")
@@ -55,7 +55,7 @@ class OCNConcordanceDiffs
 
   def filename_for(date)
     # see date handling from https://github.com/hathitrust/oclc_concordance_validator/pull/5/files
-    Pathname.new(Settings.concordance_path) + "comm_diff_#{date.strftime("%Y-%m-%d")}.txt"
+    Pathname.new(Settings.concordance_path) + "diffs/comm_diff_#{date.strftime("%Y-%m-%d")}.txt"
   end
 
   def add_filename

--- a/spec/ocn_concordance_diffs_spec.rb
+++ b/spec/ocn_concordance_diffs_spec.rb
@@ -6,9 +6,9 @@ require "ocn_concordance_diffs"
 RSpec.describe OCNConcordanceDiffs, type: "loaded_file" do
   let(:logger) { double(:logger, info: true) }
   let(:concordance_diffs) { described_class.new(Date.parse("2021-04-02")) }
-  let(:expected_filename) { Pathname.new("/tmp/concordance/comm_diff_2021-04-02.txt") }
-  let(:expected_adds) { Pathname.new("/tmp/concordance/comm_diff_2021-04-02.txt.adds") }
-  let(:expected_deletes) { Pathname.new("/tmp/concordance/comm_diff_2021-04-02.txt.deletes") }
+  let(:expected_filename) { Pathname.new("/tmp/concordance/diffs/comm_diff_2021-04-02.txt") }
+  let(:expected_adds) { Pathname.new("/tmp/concordance/diffs/comm_diff_2021-04-02.txt.adds") }
+  let(:expected_deletes) { Pathname.new("/tmp/concordance/diffs/comm_diff_2021-04-02.txt.deletes") }
 
   it "computes the path to concordance diffs" do
     expect(concordance_diffs.filename).to eq(expected_filename)


### PR DESCRIPTION
Also fixes a namespace bug that was not caught by the specs.