### PR TITLE
Fix requires in ht items loaders

### DIFF
--- a/bin/add_ht_items.rb
+++ b/bin/add_ht_items.rb
@@ -3,12 +3,14 @@
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "bundler/setup"
-require "file_loader"
-require "ht_item_loader"
+require "loader/file_loader"
+require "loader/ht_item_loader"
 require "services"
 
 Services.mongo!
 Services.logger.info "Updating HT Items."
 
-filename = ARGV[0]
-FileLoader.new(batch_loader: HtItemLoader.new).load(filename)
+if __FILE__ == $PROGRAM_NAME
+  filename = ARGV[0]
+  FileLoader.new(batch_loader: HtItemLoader.new).load(filename)
+end

--- a/bin/daily_add_ht_items.rb
+++ b/bin/daily_add_ht_items.rb
@@ -4,7 +4,7 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "bundler/setup"
 require "services"
-require "hathifile_manager"
+require "loader/hathifile_manager"
 require "utils/multi_logger"
 
 Services.mongo!
@@ -16,4 +16,6 @@ Services.register(:logger) do
   Utils::MultiLogger.new(default_logger, Logger.new(Services.slack_writer, level: Logger::INFO))
 end
 
-HathifileManager.new.try_load
+if __FILE__ == $PROGRAM_NAME
+  Loader::HathifileManager.new.try_load
+end

--- a/spec/loader/add_ht_items_spec.rb
+++ b/spec/loader/add_ht_items_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../bin/add_ht_items"
+require_relative "../../bin/daily_add_ht_items"


### PR DESCRIPTION
Simple changes to the `requires` and addition of a spec file that doesn't do anything beside load the two bin scripts.
I am not sure how this fits into the other clean up efforts, but it allows the loading to get started again ASAP.