### PR TITLE
Ht 3115 refactor reports

### DIFF
--- a/bin/reports/compile_cost_reports.rb
+++ b/bin/reports/compile_cost_reports.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
 require "services"
 require "bundler/setup"
 require "utils/waypoint"

--- a/bin/reports/compile_estimated_IC_costs.rb
+++ b/bin/reports/compile_estimated_IC_costs.rb
@@ -3,80 +3,32 @@
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "bundler/setup"
-require "utils/waypoint"
-require "utils/ppnum"
 require "zinzout"
-require "ht_item_overlap"
-require "report/cost_report"
 require "services"
+require "report/estimate_ic"
 
 Services.mongo!
 
 # Given a file of unique OCNs, generate a cost estimate.
 
 if __FILE__ == $PROGRAM_NAME
-  BATCH_SIZE = 10_000
-  waypoint = Utils::Waypoint.new(BATCH_SIZE)
-  logger = Logger.new($stderr)
-  cost_report = Report::CostReport.new
-  logger.info "Target Cost: #{cost_report.target_cost}"
-  logger.info "Cost per volume: #{cost_report.cost_per_volume}"
-  logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
+  BATCH_SIZE = 100_000
 
-  ocns = []
   ocn_file = ARGV.shift
-  h_share_total = 0.0
-  clusters_seen = Set.new
-  num_ocns_matched = 0
-  num_items_matched = 0
-  num_items_pd = 0
-  num_items_ic = 0
+  ocns = File.open(ocn_file).map(&:to_i)
+  est = EstimateIC.new(ocns, BATCH_SIZE)
 
-  File.open(ocn_file).each do |line|
-    ocn = line.to_i
-    ocns << ocn
-    waypoint.incr
+  Services.logger.info "Target Cost: #{est.cost_report.target_cost}"
+  Services.logger.info "Cost per volume: #{est.cost_report.cost_per_volume}"
+  Services.logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
 
-    # Find a cluster
-    cluster = Cluster.find_by(ocns: ocn.to_i,
-                            "ht_items.0": { "$exists": 1 })
-    next if cluster.nil?
+  est.run
 
-    num_ocns_matched += 1
-
-    # Multiple OCLCs can map to the same cluster, but we only want them once
-    next if clusters_seen.include?(cluster._id)
-
-    clusters_seen << cluster._id
-
-    num_items_matched += cluster.ht_items.count
-
-    cluster.ht_items.each do |ht_item|
-      if ht_item.access == "allow"
-        num_items_pd += 1
-        next
-      end
-      # next unless ht_item.access == "deny"
-      num_items_ic += 1
-
-      overlap = HtItemOverlap.new(ht_item)
-      # Insert a placeholder for the prospective member
-      overlap.matching_orgs << "prospective_member"
-      h_share_total += overlap.h_share("prospective_member")
-    end
-    waypoint.on_batch {|wp| logger.info wp.batch_line }
-  end
-  logger.info waypoint.final_line
-
-  pct_ocns_matched = num_ocns_matched.to_f / ocns.uniq.count * 100
-  pct_items_pd = num_items_pd / num_items_matched.to_f * 100
-  pct_items_ic = num_items_ic / num_items_matched.to_f * 100
-
-  puts "Total Estimated IC Cost:#{h_share_total * cost_report.cost_per_volume}
-In all, we received #{ocns.uniq.count} distinct OCLC numbers.
-Of those distinct OCLC numbers, #{num_ocns_matched} (#{pct_ocns_matched.round(1)}%) match in
-HathiTrust, corresponding to #{num_items_matched} HathiTrust items.
-Of those, #{num_items_pd} ( #{pct_items_pd.round(1)}%) are in the public domain,
-#{num_items_ic} ( #{pct_items_ic} ) are in copyright."
+  puts "Total Estimated IC Cost:#{est.total_estimated_ic_cost}
+In all, we received #{est.ocns.count} distinct OCLC numbers.
+Of those distinct OCLC numbers, #{est.num_ocns_matched} (#{est.pct_ocns_matched.round(1)}%) match in
+HathiTrust, corresponding to #{est.num_items_matched} HathiTrust items.
+Of those, #{est.num_items_pd} ( #{est.pct_items_pd.round(1)}%) are in the public domain,
+#{est.num_items_ic} ( #{est.pct_items_ic} ) are in copyright."
 
 end

--- a/bin/reports/compile_estimated_IC_costs.rb
+++ b/bin/reports/compile_estimated_IC_costs.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
 require "bundler/setup"
 require "zinzout"
 require "services"

--- a/bin/reports/export_etas_overlap_report.rb
+++ b/bin/reports/export_etas_overlap_report.rb
@@ -1,98 +1,17 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
 require "services"
 require "settings"
 require "bundler/setup"
-require "cluster_overlap"
-require "etas_overlap"
+require "report/etas_member_overlap_report"
 
 Services.mongo!
-
-# Generates overlap reports for 1 or all members
-class EtasMemberOverlapReport
-  attr_accessor :reports, :date_of_report, :report_path, :organization
-
-  def initialize(organization = nil)
-    @reports = {}
-    @date_of_report = Time.now.strftime("%Y-%m-%d")
-    @report_path = Settings.etas_overlap_reports_path || "tmp_reports"
-    Dir.mkdir(@report_path) unless File.exist?(@report_path)
-    @organization = organization
-  end
-
-  def open_report(org, date)
-    File.open("#{report_path}/#{org}_#{date}.tsv", "w")
-  end
-
-  def report_for_org(org)
-    unless reports.key?(org)
-      reports[org] = open_report(org, date_of_report)
-    end
-    reports[org]
-  end
-
-  def clusters_with_holdings
-    if organization.nil?
-      Cluster.where("holdings.0": { "$exists": 1 }).no_timeout
-    else
-      Cluster.where("holdings.organization": organization).no_timeout
-    end
-  end
-
-  def missed_holdings(cluster, holdings_matched)
-    if organization.nil?
-      cluster.holdings - holdings_matched.to_a
-    else
-      cluster.holdings.group_by(&:organization)[organization] - holdings_matched.to_a
-    end
-  end
-
-  # Creates an overlap record and writes to the appropriate org file
-  #
-  # @param holding [Holding] the holdings provides the ocn, local_id, and organization
-  # @param format  [String] the cluster format, 'mpm', 'spm', 'ser', or 'ser/spm'
-  # @param access  [String] 'allow' or 'deny' for the associated item
-  # @param rights  [String] the rights for the associated item
-  def write_record(holding, format, access, rights)
-    etas_record = ETASOverlap.new(ocn: holding[:ocn],
-                    local_id: holding[:local_id],
-                    item_type: format,
-                    access: access,
-                    rights: rights)
-    report_for_org(holding[:organization]).puts etas_record
-  end
-
-  def write_overlaps(cluster, organization)
-    holdings_matched = Set.new
-    ClusterOverlap.new(cluster, organization).each do |overlap|
-      overlap.matching_holdings.each do |holding|
-        holdings_matched << holding
-        write_record(holding, cluster.format, overlap.ht_item.access, overlap.ht_item.rights)
-      end
-    end
-    holdings_matched
-  end
-
-  def run
-    clusters_with_holdings.each do |c|
-      # No ht_items means an empty line for each holding
-      unless c.ht_items.any?
-        c.holdings.each {|holding| write_record(holding, c.format, "", "") }
-        next
-      end
-      holdings_matched = write_overlaps(c, organization)
-      missed_holdings(c, holdings_matched).each do |holding|
-        write_record(holding, c.format, "", "")
-      end
-    end
-  end
-end
 
 if __FILE__ == $PROGRAM_NAME
   # optional
   org = ARGV.shift
-  rpt = EtasMemberOverlapReport.new(org)
+  rpt = Report::EtasMemberOverlapReport.new(org)
   rpt.run
 end

--- a/bin/reports/export_overlap_report.rb
+++ b/bin/reports/export_overlap_report.rb
@@ -4,48 +4,14 @@
 require "dotenv"
 Dotenv.load(".env")
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
 require "bundler/setup"
-require "clusterable/ocn_resolution"
-require "clusterable/holding"
-require "utils/waypoint"
-require "utils/ppnum"
 require "zinzout"
-require "cluster_overlap"
-require "pry"
-require "pp"
+require "report/overlap_report"
 
 Mongoid.load!("mongoid.yml", :test)
 
 BATCH_SIZE = 10_000
-
-def overlap_line(overlap_hash)
-  [overlap_hash[:lock_id],
-   overlap_hash[:cluster_id],
-   overlap_hash[:volume_id],
-   overlap_hash[:n_enum],
-   overlap_hash[:member_id],
-   overlap_hash[:copy_count],
-   overlap_hash[:brt_count],
-   overlap_hash[:wd_count],
-   overlap_hash[:lm_count],
-   overlap_hash[:access_count]].join("\t")
-end
-
-def report(org)
-  waypoint = Utils::Waypoint.new(BATCH_SIZE)
-  logger = Services.logger
-  logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
-
-  ClusterOverlap.matching_clusters(org).each do |c|
-    ClusterOverlap.new(c, org).each do |overlap|
-      waypoint.incr
-      puts overlap_line(overlap.to_hash)
-      waypoint.on_batch {|wp| logger.info wp.batch_line }
-    end
-  end
-  logger.info waypoint.final_line
-end
 
 if __FILE__ == $PROGRAM_NAME
   require "optparse"
@@ -55,7 +21,7 @@ if __FILE__ == $PROGRAM_NAME
     opts.on(
       "-f",
       "--full",
-      "Produce overlaps for all matching clusters. Default: Clusters modified last 36 hours"
+      "Produce overlaps for all matching clusters."
     ) do |f|
       options.full = f
     end
@@ -65,5 +31,5 @@ if __FILE__ == $PROGRAM_NAME
   end
 
   org = ARGV.shift
-  report(org)
+  Report::OverlapReport.new(org, BATCH_SIZE).run
 end

--- a/bin/reports/full_etas_overlap.rb
+++ b/bin/reports/full_etas_overlap.rb
@@ -4,7 +4,7 @@
 require "dotenv"
 Dotenv.load(".env")
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
 require "bundler/setup"
 require "services"
 require "settings"

--- a/lib/report/estimate_ic.rb
+++ b/lib/report/estimate_ic.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "ht_item_overlap"
+require "utils/waypoint"
+require "services"
+require "report/cost_report"
+
+module Report
+
+  # Generate IC estimate from a list of OCNS
+  class EstimateIC
+    attr_accessor :ocns, :h_share_total, :num_ocns_matched, :num_items_matched, :num_items_pd,
+                  :num_items_ic, :clusters_seen, :waypoint
+
+    def initialize(ocns, batch_size = 100_000)
+      @ocns = ocns.uniq
+      @h_share_total = 0
+      @num_ocns_matched = 0
+      @num_items_matched = 0
+      @num_items_pd = 0
+      @num_items_ic = 0
+      @clusters_seen = Set.new
+      @waypoint = Utils::Waypoint.new(batch_size)
+    end
+
+    def cost_report
+      @cost_report ||= CostReport.new
+    end
+
+    def run
+      ocns.each do |ocn|
+        waypoint.incr
+        cluster = Cluster.find_by(ocns: ocn.to_i,
+                                  "ht_items.0": { "$exists": 1 })
+        next if cluster.nil?
+
+        @num_ocns_matched += 1
+
+        next if clusters_seen.include?(cluster._id)
+
+        count_matching_items(cluster)
+
+        waypoint.on_batch {|wp| Services.logger.info wp.batch_line }
+      end
+      Services.logger.info waypoint.final_line
+    end
+
+    def pct_ocns_matched
+      @num_ocns_matched.to_f / @ocns.uniq.count * 100
+    end
+
+    def pct_items_pd
+      @num_items_pd / @num_items_matched.to_f * 100
+    end
+
+    def pct_items_ic
+      @num_items_ic / @num_items_matched.to_f * 100
+    end
+
+    def total_estimated_ic_cost
+      @h_share_total * cost_report.cost_per_volume
+    end
+
+    private
+
+    def count_matching_items(cluster)
+      @clusters_seen << cluster._id
+
+      @num_items_matched += cluster.ht_items.count
+      cluster.ht_items.each do |ht_item|
+        if ht_item.access == "allow"
+          @num_items_pd += 1
+          next
+        end
+        @num_items_ic += 1
+
+        overlap = HtItemOverlap.new(ht_item)
+        # Insert a placeholder for the prospective member
+        overlap.matching_orgs << "prospective_member"
+        @h_share_total += overlap.h_share("prospective_member")
+      end
+    end
+
+  end
+end

--- a/lib/report/etas_member_overlap_report.rb
+++ b/lib/report/etas_member_overlap_report.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "services"
+require "cluster"
+
+module Report
+
+  # Generates overlap reports for 1 or all members
+  class EtasMemberOverlapReport
+    attr_accessor :reports, :date_of_report, :report_path, :organization
+
+    def initialize(organization = nil)
+      @reports = {}
+      @date_of_report = Time.now.strftime("%Y-%m-%d")
+      @report_path = Settings.etas_overlap_reports_path || "tmp_reports"
+      Dir.mkdir(@report_path) unless File.exist?(@report_path)
+      @organization = organization
+    end
+
+    def open_report(org, date)
+      File.open("#{report_path}/#{org}_#{date}.tsv", "w")
+    end
+
+    def report_for_org(org)
+      unless reports.key?(org)
+        reports[org] = open_report(org, date_of_report)
+      end
+      reports[org]
+    end
+
+    def clusters_with_holdings
+      if organization.nil?
+        Cluster.where("holdings.0": { "$exists": 1 }).no_timeout
+      else
+        Cluster.where("holdings.organization": organization).no_timeout
+      end
+    end
+
+    def missed_holdings(cluster, holdings_matched)
+      if organization.nil?
+        cluster.holdings - holdings_matched.to_a
+      else
+        cluster.holdings.group_by(&:organization)[organization] - holdings_matched.to_a
+      end
+    end
+
+    # Creates an overlap record and writes to the appropriate org file
+    #
+    # @param holding [Holding] the holdings provides the ocn, local_id, and organization
+    # @param format  [String] the cluster format, 'mpm', 'spm', 'ser', or 'ser/spm'
+    # @param access  [String] 'allow' or 'deny' for the associated item
+    # @param rights  [String] the rights for the associated item
+    def write_record(holding, format, access, rights)
+      etas_record = ETASOverlap.new(ocn: holding[:ocn],
+                      local_id: holding[:local_id],
+                      item_type: format,
+                      access: access,
+                      rights: rights)
+      report_for_org(holding[:organization]).puts etas_record
+    end
+
+    def write_overlaps(cluster, organization)
+      holdings_matched = Set.new
+      ClusterOverlap.new(cluster, organization).each do |overlap|
+        overlap.matching_holdings.each do |holding|
+          holdings_matched << holding
+          write_record(holding, cluster.format, overlap.ht_item.access, overlap.ht_item.rights)
+        end
+      end
+      holdings_matched
+    end
+
+    def run
+      clusters_with_holdings.each do |c|
+        # No ht_items means an empty line for each holding
+        unless c.ht_items.any?
+          c.holdings.each {|holding| write_record(holding, c.format, "", "") }
+          next
+        end
+        holdings_matched = write_overlaps(c, organization)
+        missed_holdings(c, holdings_matched).each do |holding|
+          write_record(holding, c.format, "", "")
+        end
+      end
+    end
+  end
+end

--- a/lib/report/overlap_report.rb
+++ b/lib/report/overlap_report.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "services"
+require "cluster"
+require "utils/waypoint"
+
+module Report
+
+  # Generates an overlap for a given member including copy counts
+  class OverlapReport
+    attr_accessor :org, :waypoint
+
+    def initialize(org = nil, batch_size = 100_000)
+      @org = org
+      @waypoint = Utils::Waypoint.new(batch_size)
+    end
+
+    def overlap_line(overlap_hash)
+      [overlap_hash[:lock_id],
+       overlap_hash[:cluster_id],
+       overlap_hash[:volume_id],
+       overlap_hash[:n_enum],
+       overlap_hash[:member_id],
+       overlap_hash[:copy_count],
+       overlap_hash[:brt_count],
+       overlap_hash[:wd_count],
+       overlap_hash[:lm_count],
+       overlap_hash[:access_count]].join("\t")
+    end
+
+    def run
+      logger = Services.logger
+      logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum BATCH_SIZE}"
+
+      ClusterOverlap.matching_clusters(@org).each do |c|
+        ClusterOverlap.new(c, @org).each do |overlap|
+          @waypoint.incr
+          puts overlap_line(overlap.to_hash)
+          @waypoint.on_batch {|wp| logger.info wp.batch_line }
+        end
+      end
+      logger.info @waypoint.final_line
+    end
+  end
+end

--- a/spec/report/estimate_ic_spec.rb
+++ b/spec/report/estimate_ic_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "report/estimate_ic"
+require "clustering/cluster_ht_item"
+
+RSpec.describe Report::EstimateIC do
+  let(:ht_allow) { build(:ht_item, access: "allow") }
+  let(:ht_deny) { build(:ht_item, access: "deny") }
+  let(:ocns) { [1, 2, ht_allow.ocns, ht_deny.ocns].flatten }
+  let(:rpt) { described_class.new(ocns) }
+
+  before(:each) do
+    Settings.target_cost = 20
+    Cluster.each(&:delete)
+    Clustering::ClusterHtItem.new(ht_allow).cluster.tap(&:save)
+    Clustering::ClusterHtItem.new(ht_deny).cluster.tap(&:save)
+  end
+
+  describe "#cost_report" do
+    it "creates an empty CR for target_cost reasons" do
+      expect(rpt.cost_report.target_cost).to eq(20)
+      expect(rpt.cost_report.cost_per_volume).to eq(10)
+    end
+  end
+
+  describe "#run" do
+    it "sets num_items_pd" do
+      rpt.run
+      expect(rpt.num_items_pd).to eq(1)
+    end
+
+    it "sets num_items_ic" do
+      rpt.run
+      expect(rpt.num_items_ic).to eq(1)
+    end
+
+    it "compiles h_share_total" do
+      rpt.run
+      # the contributor gets the other half of the IC item
+      expect(rpt.h_share_total).to eq(0.5)
+    end
+  end
+
+  describe "#total_estimate_ic_cost" do
+    it "calculates total from h_share_total and cost_per_volume" do
+      rpt.run
+      expect(rpt.total_estimated_ic_cost).to eq(5)
+    end
+  end
+end

--- a/spec/report/etas_member_overlap_report_spec.rb
+++ b/spec/report/etas_member_overlap_report_spec.rb
@@ -2,9 +2,9 @@
 
 require "spec_helper"
 require "pp"
-require_relative "../../bin/reports/export_etas_overlap_report"
+require "report/etas_member_overlap_report"
 
-RSpec.describe EtasMemberOverlapReport do
+RSpec.describe Report::EtasMemberOverlapReport do
   let(:h) { build(:holding) }
   let(:h2) { build(:holding, organization: "ualberta") }
   let(:ht) { build(:ht_item, ocns: [h.ocn], access: "deny") }

--- a/spec/report/overlap_report_spec.rb
+++ b/spec/report/overlap_report_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "clustering/cluster_ht_item"
 require "clustering/cluster_holding"
-require_relative "../../bin/reports/export_overlap_report"
+require "report/overlap_report"
 
 RSpec.describe "overlap_report" do
   let(:h) { build(:holding) }
@@ -17,14 +17,14 @@ RSpec.describe "overlap_report" do
     Clustering::ClusterHtItem.new(ht2).cluster.tap(&:save)
   end
 
-  describe "report" do
+  describe "run" do
     it "generates the correct report for the holding org" do
       h2 = h.dup
       h2.condition = "BRT"
       Cluster.first.add_holdings(h2).tap(&:save)
       cid = Cluster.first._id
       expect do
-        report(h.organization)
+        Report::OverlapReport.new(h.organization).run
       end.to output(
         "#{cid}\t#{cid}\t#{ht.item_id}\t#{ht.n_enum}\t#{h.organization}\t2\t1\t0\t0\t1\n"
       ).to_stdout
@@ -36,7 +36,7 @@ RSpec.describe "overlap_report" do
       cid1 = cluster1._id
       cid2 = cluster2._id
       expect do
-        report("not_same_as_holding")
+        Report::OverlapReport.new("not_same_as_holding").run
       end.to output(
         %(#{cid1}\t#{cid1}\t#{ht.item_id}\t#{ht.n_enum}\tnot_same_as_holding\t1\t0\t0\t0\t0
 #{cid2}\t#{cid2}\t#{ht2.item_id}\t#{ht2.n_enum}\tnot_same_as_holding\t1\t0\t0\t0\t0\n)


### PR DESCRIPTION
Pulling logic out of bins into lib/report and adding some specs. 

lib/report/overlap_report.rb and bin/reports/export_overlap_report.rb appear to be unnecessary. They are the single member special case of the full_etas_overlap. I didn't do much with full_etas_overlap as it is already very simple. 