### PR TITLE
proof of concept

### DIFF
--- a/lib-finder-test/a/b/c/d/e/f/lib_finder.rb
+++ b/lib-finder-test/a/b/c/d/e/f/lib_finder.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "digest"
+
+this_finder   = __FILE__
+this_checksum = Digest::MD5.file(this_finder)
+dir           = File.dirname(this_finder)
+
+if File.exist?(File.join(dir, "lib"))
+  # We found lib in the current dir and we're done.
+  $LOAD_PATH.unshift(File.join(dir, "lib"))
+elsif File.exist?(File.join(dir, "..", "lib_finder.rb"))
+  # No lib/ in this dir but there's another lib_finder above, so recurse upwards.
+  up_finder   = File.join(dir, "..", "lib_finder.rb")
+  up_checksum = Digest::MD5.file(up_finder)
+  # But only if the up_finder is identical to this_finder
+  if this_checksum == up_checksum
+    require_relative "../lib_finder"
+  else
+    raise [
+      "Lib finder checksum mismatch!",
+      "#{this_checksum}\t#{this_finder}",
+      "!=",
+      "#{up_checksum}\t#{up_finder}"
+    ].join("\n")
+  end
+end

--- a/lib-finder-test/a/b/c/d/e/f/test.rb
+++ b/lib-finder-test/a/b/c/d/e/f/test.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require_relative "lib_finder"
+require "services"
+
+Services.logger.info("Found logger!")

--- a/lib-finder-test/a/b/c/d/e/lib_finder.rb
+++ b/lib-finder-test/a/b/c/d/e/lib_finder.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "digest"
+
+this_finder   = __FILE__
+this_checksum = Digest::MD5.file(this_finder)
+dir           = File.dirname(this_finder)
+
+if File.exist?(File.join(dir, "lib"))
+  # We found lib in the current dir and we're done.
+  $LOAD_PATH.unshift(File.join(dir, "lib"))
+elsif File.exist?(File.join(dir, "..", "lib_finder.rb"))
+  # No lib/ in this dir but there's another lib_finder above, so recurse upwards.
+  up_finder   = File.join(dir, "..", "lib_finder.rb")
+  up_checksum = Digest::MD5.file(up_finder)
+  # But only if the up_finder is identical to this_finder
+  if this_checksum == up_checksum
+    require_relative "../lib_finder"
+  else
+    raise [
+      "Lib finder checksum mismatch!",
+      "#{this_checksum}\t#{this_finder}",
+      "!=",
+      "#{up_checksum}\t#{up_finder}"
+    ].join("\n")
+  end
+end

--- a/lib-finder-test/a/b/c/d/lib_finder.rb
+++ b/lib-finder-test/a/b/c/d/lib_finder.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "digest"
+
+this_finder   = __FILE__
+this_checksum = Digest::MD5.file(this_finder)
+dir           = File.dirname(this_finder)
+
+if File.exist?(File.join(dir, "lib"))
+  # We found lib in the current dir and we're done.
+  $LOAD_PATH.unshift(File.join(dir, "lib"))
+elsif File.exist?(File.join(dir, "..", "lib_finder.rb"))
+  # No lib/ in this dir but there's another lib_finder above, so recurse upwards.
+  up_finder   = File.join(dir, "..", "lib_finder.rb")
+  up_checksum = Digest::MD5.file(up_finder)
+  # But only if the up_finder is identical to this_finder
+  if this_checksum == up_checksum
+    require_relative "../lib_finder"
+  else
+    raise [
+      "Lib finder checksum mismatch!",
+      "#{this_checksum}\t#{this_finder}",
+      "!=",
+      "#{up_checksum}\t#{up_finder}"
+    ].join("\n")
+  end
+end

--- a/lib-finder-test/a/b/c/lib_finder.rb
+++ b/lib-finder-test/a/b/c/lib_finder.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "digest"
+
+this_finder   = __FILE__
+this_checksum = Digest::MD5.file(this_finder)
+dir           = File.dirname(this_finder)
+
+if File.exist?(File.join(dir, "lib"))
+  # We found lib in the current dir and we're done.
+  $LOAD_PATH.unshift(File.join(dir, "lib"))
+elsif File.exist?(File.join(dir, "..", "lib_finder.rb"))
+  # No lib/ in this dir but there's another lib_finder above, so recurse upwards.
+  up_finder   = File.join(dir, "..", "lib_finder.rb")
+  up_checksum = Digest::MD5.file(up_finder)
+  # But only if the up_finder is identical to this_finder
+  if this_checksum == up_checksum
+    require_relative "../lib_finder"
+  else
+    raise [
+      "Lib finder checksum mismatch!",
+      "#{this_checksum}\t#{this_finder}",
+      "!=",
+      "#{up_checksum}\t#{up_finder}"
+    ].join("\n")
+  end
+end

--- a/lib-finder-test/a/b/lib_finder.rb
+++ b/lib-finder-test/a/b/lib_finder.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "digest"
+
+this_finder   = __FILE__
+this_checksum = Digest::MD5.file(this_finder)
+dir           = File.dirname(this_finder)
+
+if File.exist?(File.join(dir, "lib"))
+  # We found lib in the current dir and we're done.
+  $LOAD_PATH.unshift(File.join(dir, "lib"))
+elsif File.exist?(File.join(dir, "..", "lib_finder.rb"))
+  # No lib/ in this dir but there's another lib_finder above, so recurse upwards.
+  up_finder   = File.join(dir, "..", "lib_finder.rb")
+  up_checksum = Digest::MD5.file(up_finder)
+  # But only if the up_finder is identical to this_finder
+  if this_checksum == up_checksum
+    require_relative "../lib_finder"
+  else
+    raise [
+      "Lib finder checksum mismatch!",
+      "#{this_checksum}\t#{this_finder}",
+      "!=",
+      "#{up_checksum}\t#{up_finder}"
+    ].join("\n")
+  end
+end

--- a/lib-finder-test/a/lib_finder.rb
+++ b/lib-finder-test/a/lib_finder.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "digest"
+
+this_finder   = __FILE__
+this_checksum = Digest::MD5.file(this_finder)
+dir           = File.dirname(this_finder)
+
+if File.exist?(File.join(dir, "lib"))
+  # We found lib in the current dir and we're done.
+  $LOAD_PATH.unshift(File.join(dir, "lib"))
+elsif File.exist?(File.join(dir, "..", "lib_finder.rb"))
+  # No lib/ in this dir but there's another lib_finder above, so recurse upwards.
+  up_finder   = File.join(dir, "..", "lib_finder.rb")
+  up_checksum = Digest::MD5.file(up_finder)
+  # But only if the up_finder is identical to this_finder
+  if this_checksum == up_checksum
+    require_relative "../lib_finder"
+  else
+    raise [
+      "Lib finder checksum mismatch!",
+      "#{this_checksum}\t#{this_finder}",
+      "!=",
+      "#{up_checksum}\t#{up_finder}"
+    ].join("\n")
+  end
+end

--- a/lib-finder-test/lib_finder.rb
+++ b/lib-finder-test/lib_finder.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "digest"
+
+this_finder   = __FILE__
+this_checksum = Digest::MD5.file(this_finder)
+dir           = File.dirname(this_finder)
+
+if File.exist?(File.join(dir, "lib"))
+  # We found lib in the current dir and we're done.
+  $LOAD_PATH.unshift(File.join(dir, "lib"))
+elsif File.exist?(File.join(dir, "..", "lib_finder.rb"))
+  # No lib/ in this dir but there's another lib_finder above, so recurse upwards.
+  up_finder   = File.join(dir, "..", "lib_finder.rb")
+  up_checksum = Digest::MD5.file(up_finder)
+  # But only if the up_finder is identical to this_finder
+  if this_checksum == up_checksum
+    require_relative "../lib_finder"
+  else
+    raise [
+      "Lib finder checksum mismatch!",
+      "#{this_checksum}\t#{this_finder}",
+      "!=",
+      "#{up_checksum}\t#{up_finder}"
+    ].join("\n")
+  end
+end

--- a/lib_finder.rb
+++ b/lib_finder.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "digest"
+
+this_finder   = __FILE__
+this_checksum = Digest::MD5.file(this_finder)
+dir           = File.dirname(this_finder)
+
+if File.exist?(File.join(dir, "lib"))
+  # We found lib in the current dir and we're done.
+  $LOAD_PATH.unshift(File.join(dir, "lib"))
+elsif File.exist?(File.join(dir, "..", "lib_finder.rb"))
+  # No lib/ in this dir but there's another lib_finder above, so recurse upwards.
+  up_finder   = File.join(dir, "..", "lib_finder.rb")
+  up_checksum = Digest::MD5.file(up_finder)
+  # But only if the up_finder is identical to this_finder
+  if this_checksum == up_checksum
+    require_relative "../lib_finder"
+  else
+    raise [
+      "Lib finder checksum mismatch!",
+      "#{this_checksum}\t#{this_finder}",
+      "!=",
+      "#{up_checksum}\t#{up_finder}"
+    ].join("\n")
+  end
+end


### PR DESCRIPTION
Instead of requiring each file to be aware of the relative path to `lib/`, I propose a class that is repeated in each ruby dir that recursively:

- adds `lib/` to `$LOAD_PATH` if `lib/` is in the current dir
- or asks its clone in the dir above to try

In this example, `lib-finder-test/a/b/c/d/e/f/test.rb` can get `Services.logger` by virtue of `require_relative "lib_finder"`. 
`test.rb` can be moved to any other dir (as long as they all have a clone of `lib_finder.rb`).