### PR TITLE
Make load path / bundle stuff consistent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
 
 WORKDIR /usr/src/app
 ENV BUNDLE_PATH /gems
+ENV RUBYLIB /usr/src/app/lib
 RUN gem install bundler

--- a/bin/add_ht_items.rb
+++ b/bin/add_ht_items.rb
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
-require "bundler/setup"
 require "loader/file_loader"
 require "loader/ht_item_loader"
 require "services"

--- a/bin/add_print_holdings.rb
+++ b/bin/add_print_holdings.rb
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
-require "bundler/setup"
 require "loader/file_loader"
 require "loader/holding_loader"
 require "services"

--- a/bin/compare_clusters.rb
+++ b/bin/compare_clusters.rb
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "dotenv"
-Dotenv.load(".env")
-
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
-require "bundler/setup"
 require "compare_cluster"
 
 Services.mongo!

--- a/bin/concordance_validation/validate.rb
+++ b/bin/concordance_validation/validate.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
 require "settings"
 require "concordance_validation/concordance"
 

--- a/bin/concordance_validation/validate_and_delta.rb
+++ b/bin/concordance_validation/validate_and_delta.rb
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
-require "bundler/setup"
 require "services"
 require "utils/multi_logger"
 require "settings"

--- a/bin/daily_add_ht_items.rb
+++ b/bin/daily_add_ht_items.rb
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
-require "bundler/setup"
 require "services"
 require "loader/hathifile_manager"
 require "utils/multi_logger"

--- a/bin/delete_holdings_by_uuid.rb
+++ b/bin/delete_holdings_by_uuid.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "services"
 require "holding"
 require "cluster"

--- a/bin/get_all_members.rb
+++ b/bin/get_all_members.rb
@@ -2,6 +2,5 @@
 # frozen_string_literal: true
 
 # Prints all current members to stdout
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "data_sources/ht_members"
 puts DataSources::HTMembers.new.members.keys

--- a/bin/get_holdings_uuid_by_org.rb
+++ b/bin/get_holdings_uuid_by_org.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "basic_query_report"
 
 # Get all holdings for a member.

--- a/bin/inspect_ocn.rb
+++ b/bin/inspect_ocn.rb
@@ -2,8 +2,6 @@
 
 # For manual/ocular inspection of a single OCN.
 # Takes an OCN and outputs a pretty-printed matching cluster.
-
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "cluster"
 require "services"
 require "json"

--- a/bin/load_concordance_diffs.rb
+++ b/bin/load_concordance_diffs.rb
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
-require "bundler/setup"
 require "services"
 require "ocn_concordance_diffs"
 require "utils/multi_logger"

--- a/bin/pry_shell.rb
+++ b/bin/pry_shell.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "services"
 require "cluster"
 require "clusterable/holding"

--- a/bin/renormalize_enumchrons.rb
+++ b/bin/renormalize_enumchrons.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "services"
-
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
-require "bundler/setup"
 require "utils/waypoint"
 require "utils/ppnum"
 require "cluster"

--- a/bin/reports/compile_cost_reports.rb
+++ b/bin/reports/compile_cost_reports.rb
@@ -1,9 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
 require "services"
-require "bundler/setup"
 require "utils/waypoint"
 require "utils/ppnum"
 require "reports/cost_report"

--- a/bin/reports/compile_estimated_IC_costs.rb
+++ b/bin/reports/compile_estimated_IC_costs.rb
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
-require "bundler/setup"
 require "zinzout"
 require "services"
 require "reports/estimate_ic"

--- a/bin/reports/compile_member_counts_report.rb
+++ b/bin/reports/compile_member_counts_report.rb
@@ -3,8 +3,6 @@
 # Usage:
 # bundle exec ruby bin/reports/compile_member_counts_report.rb <COST_FREQ> <OUTPUT_DIR>
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
-
 require "reports/member_counts_report"
 require "fileutils"
 

--- a/bin/reports/export_etas_overlap_report.rb
+++ b/bin/reports/export_etas_overlap_report.rb
@@ -1,10 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
 require "services"
 require "settings"
-require "bundler/setup"
 require "reports/etas_member_overlap_report"
 
 Services.mongo!

--- a/bin/reports/export_overlap_report.rb
+++ b/bin/reports/export_overlap_report.rb
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "dotenv"
-Dotenv.load(".env")
-
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
-require "bundler/setup"
 require "zinzout"
 require "reports/overlap_report"
 

--- a/bin/reports/full_etas_overlap.rb
+++ b/bin/reports/full_etas_overlap.rb
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "dotenv"
-Dotenv.load(".env")
-
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
-require "bundler/setup"
 require "services"
 require "settings"
 require "utils/waypoint"

--- a/bin/update_overlap_table.rb
+++ b/bin/update_overlap_table.rb
@@ -2,9 +2,6 @@
 # frozen_string_literal: true
 
 require "pathname"
-$LOAD_PATH.unshift(Pathname.new(__dir__).parent + "lib")
-
-require "bundler/setup"
 require "cluster"
 require "cluster_overlap"
 require "logger"

--- a/lib/basic_query_report.rb
+++ b/lib/basic_query_report.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "services"
 require "cluster"
 

--- a/lib/scrub/autoscrub.rb
+++ b/lib/scrub/autoscrub.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
 require "services"
 require "custom_errors"
 require "scrub/member_holding_file"

--- a/lib/scrub/max_ocn.rb
+++ b/lib/scrub/max_ocn.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../..", "lib"))
 require "json"
 require "open-uri"
 require "services"

--- a/lib/tasks/build_database.rb
+++ b/lib/tasks/build_database.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), ".."))
 require "services"
 require "cluster"
 Services.mongo!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,6 @@
 
 # Note: We don't require our entire project here. This allows us to
 # require only those files we need to run our tests.
-require "bundler/setup"
-
 ENV["MONGOID_ENV"] = "test"
 
 require "factory_bot"


### PR DESCRIPTION
This should ensure we can consistently run scripts under bin as bundle
exec ruby bin/whatever.rb

- Add RUBYLIB to Dockerfile
- Remove $LOAD_PATH manipulation
- Remove bundler/setup -- we were not using it consistently; scripts are
generally started with bundle exec ruby bin/whatever.rb. In the future,
if we have a single CLI wrapper, we may want to make sure we can call it
without needing to use bundle exec.