### PR TITLE
Overlap report revisions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -103,6 +103,7 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Exclude:
     - 'spec/autoscrub_spec.rb'
+    - 'spec/etas_overlap_spec.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:

--- a/lib/etas_overlap.rb
+++ b/lib/etas_overlap.rb
@@ -11,7 +11,7 @@ class ETASOverlap
   def initialize(ocn:, local_id:, item_type:, rights:, access:)
     @ocn = ocn
     @local_id = local_id
-    @item_type = item_type
+    @item_type = convert_format(item_type)
     @rights = rights
     @access = access
   end
@@ -22,5 +22,16 @@ class ETASOverlap
      item_type,
      rights,
      access].join("\t")
+  end
+
+  def convert_format(item_type=nil)
+    case item_type || @item_type
+    when "spm"
+      "mono"
+    when "mpm"
+      "multi"
+    when "ser", "ser/spm"
+      "serial"
+    end
   end
 end

--- a/lib/etas_overlap.rb
+++ b/lib/etas_overlap.rb
@@ -6,21 +6,21 @@
 # - access
 # - rights
 class ETASOverlap
-  attr_accessor :ocn, :local_id, :item_type, :access, :rights
+  attr_accessor :ocn, :local_id, :item_type, :rights, :access
 
-  def initialize(ocn:, local_id:, item_type:, access:, rights:)
+  def initialize(ocn:, local_id:, item_type:, rights:, access:)
     @ocn = ocn
     @local_id = local_id
     @item_type = item_type
-    @access = access
     @rights = rights
+    @access = access
   end
 
   def to_s
     [ocn,
      local_id,
      item_type,
-     access,
-     rights].join("\t")
+     rights,
+     access].join("\t")
   end
 end

--- a/lib/etas_overlap.rb
+++ b/lib/etas_overlap.rb
@@ -24,7 +24,7 @@ class ETASOverlap
      access].join("\t")
   end
 
-  def convert_format(item_type=nil)
+  def convert_format(item_type = nil)
     case item_type || @item_type
     when "spm"
       "mono"

--- a/lib/reports/etas_organization_overlap_report.rb
+++ b/lib/reports/etas_organization_overlap_report.rb
@@ -50,7 +50,7 @@ module Reports
     # Creates an overlap record and writes to the appropriate org file
     #
     # @param holding [Holding] the holdings provides the ocn, local_id, and organization
-    # @param format  [String] the cluster format, 'mpm', 'spm', 'ser', or 'ser/spm'
+    # @param format  [String] the cluster format, 'mono', 'multi', 'serial', or 'ser/spm'
     # @param access  [String] 'allow' or 'deny' for the associated item
     # @param rights  [String] the rights for the associated item
     def write_record(holding, format, access, rights)

--- a/lib/reports/etas_organization_overlap_report.rb
+++ b/lib/reports/etas_organization_overlap_report.rb
@@ -26,6 +26,7 @@ module Reports
     def report_for_org(org)
       unless reports.key?(org)
         reports[org] = open_report(org, date_of_report)
+        reports[org].puts header
       end
       reports[org]
     end
@@ -56,8 +57,8 @@ module Reports
       etas_record = ETASOverlap.new(ocn: holding[:ocn],
                       local_id: holding[:local_id],
                       item_type: format,
-                      access: access,
-                      rights: rights)
+                      rights: rights,
+                      access: access)
       report_for_org(holding[:organization]).puts etas_record
     end
 
@@ -84,6 +85,10 @@ module Reports
           write_record(holding, c.format, "", "")
         end
       end
+    end
+
+    def header
+      ["oclc", "local_id", "item_type", "rights", "access"].join("\t")
     end
   end
 end

--- a/spec/etas_overlap_spec.rb
+++ b/spec/etas_overlap_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe ETASOverlap do
     described_class.new(ocn: rand(1_000_000),
               local_id: rand(1_000_000).to_s,
               item_type: "spm",
-              access: "deny",
-              rights: "ic")
+              rights: "ic",
+              access: "deny")
   end
 
   describe "#initialize" do
@@ -35,8 +35,8 @@ RSpec.describe ETASOverlap do
   end
 
   describe "#to_s" do
-    it "creates a report record" do
-      expect(eo.to_s).to eq("#{eo.ocn}\t#{eo.local_id}\tspm\tdeny\tic")
+    it "creates a report record in order: ocn, local_id, item_type, rights, access" do
+      expect(eo.to_s).to eq("#{eo.ocn}\t#{eo.local_id}\tspm\tic\tdeny")
     end
   end
 end

--- a/spec/etas_overlap_spec.rb
+++ b/spec/etas_overlap_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ETASOverlap do
     end
 
     it "has an item_type" do
-      expect(eo.item_type).to be_in(["spm", "mpm", "ser"])
+      expect(eo.item_type).to be_in(["mono", "multi", "serial"])
     end
 
     it "has an access" do
@@ -36,7 +36,16 @@ RSpec.describe ETASOverlap do
 
   describe "#to_s" do
     it "creates a report record in order: ocn, local_id, item_type, rights, access" do
-      expect(eo.to_s).to eq("#{eo.ocn}\t#{eo.local_id}\tspm\tic\tdeny")
+      expect(eo.to_s).to eq("#{eo.ocn}\t#{eo.local_id}\tmono\tic\tdeny")
+    end
+  end
+
+  describe "convert_format" do
+    it "maps spm to mono, mpm to multi, ser and ser/spm to serial" do
+      expect(eo.convert_format("spm")).to eq("mono")
+      expect(eo.convert_format("mpm")).to eq("multi")
+      expect(eo.convert_format("ser")).to eq("serial")
+      expect(eo.convert_format("ser/spm")).to eq("serial")
     end
   end
 end

--- a/spec/reports/etas_organization_overlap_report_spec.rb
+++ b/spec/reports/etas_organization_overlap_report_spec.rb
@@ -37,8 +37,13 @@ RSpec.describe Reports::EtasOrganizationOverlapReport do
   describe "#report_for_org" do
     it "gives us a filehandle for the org" do
       rpt = described_class.new
-      expect(rpt.report_for_org("test")).to be_a(File)
-      expect(rpt.report_for_org("test").path).to eq("#{tmp_dir}/test_#{rpt.date_of_report}.tsv")
+      expect(rpt.report_for_org("smu")).to be_a(File)
+      expect(rpt.report_for_org("smu").path).to eq("#{tmp_dir}/smu_#{rpt.date_of_report}.tsv")
+    end
+
+    it "gives us a 'nonus' filehandle for non-us orgs" do
+      rpt = described_class.new
+      expect(rpt.report_for_org("uct").path).to eq("#{tmp_dir}/uct_#{rpt.date_of_report}_nonus.tsv")
     end
   end
 
@@ -99,6 +104,28 @@ RSpec.describe Reports::EtasOrganizationOverlapReport do
       end
       rpt = described_class.new("umich")
       rpt.run
+    end
+  end
+
+  describe "#convert_access" do
+    it "returns whatever it was given for US orgs" do
+      rpt = described_class.new
+      expect(rpt.convert_access(nil, "given", "smu")).to eq("given")
+    end
+
+    it "returns 'deny' if rights is 'pdus' for non-US orgs" do
+      rpt = described_class.new
+      expect(rpt.convert_access("pdus", "allow", "uct")).to eq("deny")
+    end
+
+    it "returns 'allow' if rights is 'icus' for non-US orgs" do
+      rpt = described_class.new
+      expect(rpt.convert_access("icus", "deny", "uct")).to eq("allow")
+    end
+
+    it "returns whatever it was given if rights is not 'icus' or 'pdus' for non-US orgs" do
+      rpt = described_class.new
+      expect(rpt.convert_access(nil, "given", "uct")).to eq("given")
     end
   end
 end

--- a/spec/reports/etas_organization_overlap_report_spec.rb
+++ b/spec/reports/etas_organization_overlap_report_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Reports::EtasOrganizationOverlapReport do
       f = rpt.report_for_org(h.organization)
       f.close
       lines = File.open(f.path).to_a
-      expect(lines.size).to eq(2)
+      expect(lines.size).to eq(3)
     end
 
     it "has 1 line with empty rights/access for the non-matching organization" do
@@ -66,8 +66,8 @@ RSpec.describe Reports::EtasOrganizationOverlapReport do
       f = rpt.report_for_org(h2.organization)
       f.close
       lines = File.open(rpt.report_for_org(h2.organization).path).to_a
-      expect(lines.size).to eq(1)
-      rec = lines.first.split("\t")
+      expect(lines.size).to eq(2)
+      rec = lines.last.split("\t")
       expect(rec[3]).to eq("")
       expect(rec[4]).to eq("\n")
     end
@@ -76,8 +76,19 @@ RSpec.describe Reports::EtasOrganizationOverlapReport do
       rpt = described_class.new
       rpt.run
       orgs.each do |org|
+        rpt.report_for_org(org).close
         lines = File.open(rpt.report_for_org(org).path).to_a.map {|x| x.split("\t") }
         expect(lines.map(&:size)).to all(be == 5)
+      end
+    end
+
+    it "has a header line" do
+      rpt = described_class.new
+      rpt.run
+      orgs.each do |org|
+        rpt.report_for_org(org).close
+        header = File.open(rpt.report_for_org(org).path, &:readline).chomp
+        expect(header).to eq("oclc\tlocal_id\titem_type\trights\taccess")
       end
     end
 


### PR DESCRIPTION
HT-3198 through HT-3201. This will fail specs until it is rebased. HT-3061 makes changes to ht_organizations vs ht_members so merging that first will save some duplicative work here.