### PR TITLE
Clusterable Shared Print Commitments and loader

### DIFF
--- a/bin/add_shared_print_commitments.rb
+++ b/bin/add_shared_print_commitments.rb
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "loader/file_loader"
+require "loader/shared_print_loader"
+require "services"
+
+Services.mongo!
+Services.logger.info "Updating Shared Print Commitments."
+
+if __FILE__ == $PROGRAM_NAME
+  filename = ARGV[0]
+  Loader::FileLoader.new(batch_loader: Loader::SharedPrintLoader.new).load(filename)
+end

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -67,6 +67,10 @@ class Cluster
     push_to_field(:ocn_resolutions, items.flatten)
   end
 
+  def add_commitments(*items)
+    push_to_field(:commitments, items.flatten)
+  end
+
   def format
     @format ||= CalculateFormat.new(self).cluster_format
   end

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -55,16 +55,17 @@ class Cluster
     ht_items.to_a.find {|h| h.item_id == item_id }
   end
 
+  UPDATE_LAST_MODIFIED = { "$currentDate" => { 'last_modified': true } }.freeze
   def add_holdings(*items)
-    push_to_field(:holdings, items.flatten)
+    push_to_field(:holdings, items.flatten, UPDATE_LAST_MODIFIED)
   end
 
   def add_ht_items(*items)
-    push_to_field(:ht_items, items.flatten)
+    push_to_field(:ht_items, items.flatten, UPDATE_LAST_MODIFIED)
   end
 
   def add_ocn_resolutions(*items)
-    push_to_field(:ocn_resolutions, items.flatten)
+    push_to_field(:ocn_resolutions, items.flatten, UPDATE_LAST_MODIFIED)
   end
 
   def add_commitments(*items)
@@ -144,14 +145,12 @@ class Cluster
     @holdings_by_org ||= holdings.group_by(&:organization)
   end
 
-  def push_to_field(field, items)
+  def push_to_field(field, items, extra_ops = {})
     return if items.empty?
 
-    ops = { "$push" => { field => { "$each" => items.map(&:as_document) } } }
-    ops["$currentDate"] = { 'last_modified': true } unless field == :commitments
     result = collection.update_one(
       { _id: _id },
-      ops,
+      { "$push" => { field => { "$each" => items.map(&:as_document) } } }.merge(extra_ops),
       session: Mongoid::Threaded.get_session
     )
     raise ClusterError, "#{inspect} deleted before update" unless result.modified_count > 0

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -147,12 +147,11 @@ class Cluster
   def push_to_field(field, items)
     return if items.empty?
 
+    ops = { "$push" => { field => { "$each" => items.map(&:as_document) } } }
+    ops["$currentDate"] = { 'last_modified': true } unless field == :commitments
     result = collection.update_one(
       { _id: _id },
-      {
-        "$push"        => { field => { "$each" => items.map(&:as_document) } },
-        "$currentDate" => { 'last_modified': true }
-      },
+      ops,
       session: Mongoid::Threaded.get_session
     )
     raise ClusterError, "#{inspect} deleted before update" unless result.modified_count > 0

--- a/lib/clusterable/commitment.rb
+++ b/lib/clusterable/commitment.rb
@@ -4,19 +4,50 @@ require "mongoid"
 
 module Clusterable
 
-  # A commitment
+  # A shared print commitment
   class Commitment
     include Mongoid::Document
-    field :ocn, type: Integer # , type: OCLCNumber
+    field :uuid, type: String
     field :organization, type: String
+    field :ocn, type: Integer
+    field :local_id, type: String
+    field :oclc_sym, type: String
+    field :committed_date, type: DateTime
+    field :retention_date, type: DateTime
+    field :local_bib_id, type: String
+    field :local_item_id, type: String
+    field :local_item_location, type: String
+    field :local_shelving_type, type: String
+    field :policies, type: Array, default: []
+    field :facsimile, type: Boolean, default: false
+    field :other_program, type: String
+    field :other_retention_date, type: DateTime
+    field :deprecation_status, type: String
+    field :deprecation_date, type: DateTime
+    field :deprecation_replaced_by, type: String
 
     embedded_in :cluster
 
-    def move(new_parent)
-      unless new_parent.id == _parent.id
-        new_parent.commitments << dup
-        delete
-      end
+    validates_presence_of :uuid, :organization, :ocn, :local_id, :oclc_sym, :committed_date,
+                          :facsimile
+
+    def matching_holdings
+      cluster = _parent
+      cluster.holdings.select {|h| h.organization == organization && h.local_id == local_id }
+    end
+
+    def batch_with?(other)
+      ocn == other.ocn
+    end
+
+    def deprecated?
+      ["C", "D", "E", "L", "M"].include? deprecation_status
+    end
+
+    def deprecate(status, replacement, date = Date.today)
+      @deprecation_status = status
+      @deprecation_date = date
+      @deprecate_replaced_by = replacement._id
     end
 
   end

--- a/lib/clusterable/commitment.rb
+++ b/lib/clusterable/commitment.rb
@@ -30,6 +30,9 @@ module Clusterable
 
     validates_presence_of :uuid, :organization, :ocn, :local_id, :oclc_sym, :committed_date,
                           :facsimile
+    validates_inclusion_of :local_shelving_type, in: ["cloa", "clca", "sfca", "sfcahm", "sfcaasrs"],
+                           allow_nil: true
+    validate :deprecation_validation
 
     def matching_holdings
       cluster = _parent
@@ -48,6 +51,17 @@ module Clusterable
       @deprecation_status = status
       @deprecation_date = date
       @deprecate_replaced_by = replacement._id
+    end
+
+    private
+
+    # If one of the deprecation fields is set they both must be set
+    def deprecation_validation
+      if deprecation_status && deprecation_date.nil?
+        errors.add(:deprecation_status, "can't be set without a deprecation date.")
+      elsif deprecation_status.nil? && deprecation_date
+        errors.add(:deprecation_date, "can't be set without a deprecation status.")
+      end
     end
 
   end

--- a/lib/clustering/cluster_commitment.rb
+++ b/lib/clustering/cluster_commitment.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "cluster"
+require "clustering/cluster_getter"
+
+module Clustering
+
+  # Services for batch loading Commitments
+  class ClusterCommitment
+
+    def initialize(*commitments)
+      @commitments = commitments.flatten
+      @ocn = @commitments.first.ocn
+      @any_updated = false
+
+      if @commitments.count > 1 && @commitments.any? {|c| !c.batch_with?(@commitments.first) }
+        raise ArgumentError, "OCN for each Commitment in batch must match"
+      end
+
+      if @ocn.nil?
+        raise ArgumentError, "Cannot cluster Commitment without an OCN"
+      end
+
+      if @commitments.pluck(:uuid).uniq.count < @commitments.count
+        raise ArgumentError, "Cannot cluster multiple Commitments with the same UUID"
+      end
+    end
+
+    def cluster(getter: ClusterGetter.new([@ocn]))
+      getter.get do |c|
+        to_add = []
+
+        cluster_uuids = uuids_in_cluster(c)
+        @commitments.each do |commitment|
+          next if cluster_uuids.include? commitment.uuid
+
+          to_add << commitment
+        end
+        c.add_commitments(to_add)
+      end
+    end
+
+    def uuids_in_cluster(cluster)
+      cluster.commitments.pluck(:uuid)
+    end
+
+  end
+end

--- a/lib/loader/shared_print_loader.rb
+++ b/lib/loader/shared_print_loader.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "clusterable/commitment"
+require "clustering/cluster_commitment"
+
+module Loader
+
+  # Constructs batches of Commitments from incoming file data
+  class SharedPrintLoader
+    def item_from_line(json)
+      fields = JSON.parse(json).compact
+
+      Clusterable::Commitment.new(fields)
+    end
+
+    def load(batch)
+      Clustering::ClusterCommitment.new(batch).cluster
+    end
+  end
+end

--- a/spec/clusterable/commitment_spec.rb
+++ b/spec/clusterable/commitment_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clusterable/commitment"
+require "cluster"
+require "clustering/cluster_commitment"
+
+RSpec.describe Clusterable::Commitment do
+  let(:c) { create(:cluster) }
+  let(:comm) { build(:commitment) }
+
+  it "does not have a parent" do
+    expect(build(:commitment)._parent).to be_nil
+  end
+
+  it "has a parent cluster" do
+    c.commitments << build(:commitment)
+    expect(c.commitments.first._parent).to be(c)
+  end
+
+  describe "deprecated?" do
+    it "is deprecated if it has a deprecation status" do
+      expect(comm.deprecated?).to be false
+      expect(build(:commitment, :deprecated).deprecated?).to be true
+    end
+  end
+
+  describe "batch_with?" do
+    let(:comm1) { build(:commitment, ocn: 123) }
+    let(:comm2) { build(:commitment, ocn: 123) }
+    let(:comm3) { build(:commitment, ocn: 456) }
+
+    it "batches with a commitment with the same ocn" do
+      expect(comm1.batch_with?(comm2)).to be true
+    end
+
+    it "doesn't batch with a commitment with a different ocn" do
+      expect(comm1.batch_with?(comm3)).to be false
+    end
+  end
+
+  describe "matching_holdings" do
+    before(:each) do
+      Cluster.each(&:delete)
+    end
+
+    let(:h) do
+      build(:holding, ocn: comm.ocn, organization: comm.organization, local_id: comm.local_id)
+    end
+
+    it "finds holdings matching this commitment" do
+      Clustering::ClusterHolding.new(h).cluster
+      Clustering::ClusterCommitment.new(comm).cluster
+      expect(Cluster.first.commitments.first.matching_holdings).to eq([h])
+    end
+  end
+end

--- a/spec/clusterable/commitment_spec.rb
+++ b/spec/clusterable/commitment_spec.rb
@@ -18,10 +18,24 @@ RSpec.describe Clusterable::Commitment do
     expect(c.commitments.first._parent).to be(c)
   end
 
+  it "validates local_shelving_type" do
+    expect(comm.valid?).to be true
+    comm.local_shelving_type = "invalid"
+    expect(comm.valid?).to be false
+    comm.local_shelving_type = "cloa"
+    expect(comm.valid?).to be true
+  end
+
   describe "deprecated?" do
     it "is deprecated if it has a deprecation status" do
       expect(comm.deprecated?).to be false
       expect(build(:commitment, :deprecated).deprecated?).to be true
+    end
+
+    it "validates deprecation" do
+      expect(comm.valid?).to be true
+      comm.deprecation_status = "C"
+      expect(comm.valid?).to be false
     end
   end
 

--- a/spec/clustering/cluster_commitment_spec.rb
+++ b/spec/clustering/cluster_commitment_spec.rb
@@ -22,8 +22,10 @@ RSpec.describe Clustering::ClusterCommitment do
         expect(Cluster.count).to eq(1)
       end
 
-      xit "does NOT update cluster last modified date" do
+      it "does NOT update cluster last modified date" do
+        c.reload
         orig_last_modified = c.last_modified
+        sleep(1)
         cluster = described_class.new(comm).cluster
         expect(cluster.last_modified).to eq(orig_last_modified)
       end

--- a/spec/clustering/cluster_commitment_spec.rb
+++ b/spec/clustering/cluster_commitment_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clustering/cluster_commitment"
+
+RSpec.describe Clustering::ClusterCommitment do
+  let(:comm) { build(:commitment) }
+  let(:batch) { [comm, build(:commitment, ocn: comm.ocn)] }
+  let(:c) { create(:cluster, ocns: [comm.ocn]) }
+
+  describe "#cluster" do
+    before(:each) do
+      Cluster.each(&:delete)
+      c.save
+    end
+
+    context "when adding a new commitment" do
+      it "adds a commitment to an existing cluster" do
+        cluster = described_class.new(comm).cluster
+        expect(cluster.commitments.first._parent.id).to eq(c.id)
+        expect(cluster.commitments.count).to eq(1)
+        expect(Cluster.count).to eq(1)
+      end
+
+      xit "does NOT update cluster last modified date" do
+        orig_last_modified = c.last_modified
+        cluster = described_class.new(comm).cluster
+        expect(cluster.last_modified).to eq(orig_last_modified)
+      end
+
+      it "creates a new cluster if no match is found" do
+        expect(described_class.new(build(:commitment)).cluster.id).not_to eq(c.id)
+        expect(Cluster.count).to eq(2)
+      end
+
+      it "can add a batch of commitments" do
+        described_class.new(batch).cluster
+
+        expect(Cluster.count).to eq(1)
+        expect(Cluster.first.commitments.count).to eq(2)
+      end
+    end
+
+    context "when re-adding an existing commitment" do
+      it "doesn't add a commitment that already exists" do
+        comm2 = comm.dup
+        described_class.new(comm).cluster
+        described_class.new(comm2).cluster
+        expect(Cluster.count).to eq(1)
+        expect(Cluster.first.commitments.count).to eq(1)
+      end
+
+      it "raises an error when two commitments with same uuid are in same batch" do
+        comm2 = comm.dup
+        expect { described_class.new([comm, comm2]).cluster }.to raise_exception(/same UUID/)
+      end
+    end
+  end
+
+  describe "#uuids_in_cluster" do
+    it "gets a list of uuids in the cluster" do
+      cc = described_class.new([comm, build(:commitment, ocn: comm.ocn)])
+      cluster = cc.cluster
+      expect(cc.uuids_in_cluster(cluster).count).to eq(2)
+      expect(cc.uuids_in_cluster(cluster)).to include(comm.uuid)
+    end
+  end
+end

--- a/spec/clustering/cluster_getter_spec.rb
+++ b/spec/clustering/cluster_getter_spec.rb
@@ -63,13 +63,6 @@ RSpec.describe Clustering::ClusterGetter do
       c2.ht_items.create(htitem2)
       expect(merged_cluster.ht_items.count).to eq(2)
     end
-
-    xit "combines and dedupes commitments" do
-      c1.commitments.create(organization: "nypl")
-      c2.commitments.create(organization: "nypl")
-      c2.commitments.create(organization: "miu")
-      expect(merged_cluster.commitments.count).to eq(2)
-    end
   end
 
   context "when merging >2 clusters" do

--- a/spec/factories/commitment.rb
+++ b/spec/factories/commitment.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "clusterable/commitment"
+require "faker"
+
+FactoryBot.define do
+  factory :commitment, class: "Clusterable::Commitment" do
+    uuid  { SecureRandom.uuid }
+    organization { ["umich", "upenn", "smu"].sample }
+    ocn { rand(1_000_000) }
+    local_id { "lid_" + rand(100).to_s }
+    oclc_sym { ["zcu", "UAB", "uiu", "mbb"].sample }
+    committed_date { Faker::Date.between(from: 3.year.ago, to: 1.year.ago) }
+    facsimile { [true, false].sample }
+
+    trait :deprecated do
+      deprecation_status { ["C", "D", "E", "L", "M"].sample }
+      deprecation_date { Faker::Date.between(from: 1.year.ago, to: 3.week.ago) }
+    end
+  end
+end

--- a/spec/loader/shared_print_loader_spec.rb
+++ b/spec/loader/shared_print_loader_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "loader/shared_print_loader"
+
+RSpec.describe Loader::SharedPrintLoader do
+  let(:json) do
+    '{"uuid":"e78047da-1193-43c7-aab0-492067d13f9c","organization":"ucsd","ocn":2,
+      "local_id":"i6536255x","oclc_sym":"CUS","committed_date":"2019-02-28","retention_date":null,
+      "local_bib_id":null,"local_item_id":null,"local_item_location":null,
+      "local_shelving_type":null,"policies":[],"facsimile":0,"other_program":null,
+      "other_retention_date":null,"deprecation_status":null,"deprecation_date":null}'
+  end
+
+  describe "#item_from_line" do
+    let(:comm) { described_class.new.item_from_line(json) }
+
+    it { expect(comm).to be_a(Clusterable::Commitment) }
+    it { expect(comm.organization).to eq("ucsd") }
+    it { expect(comm.ocn).to be(2) }
+    it { expect(comm.local_id).to eq("i6536255x") }
+    it { expect(comm.oclc_sym).to eq("CUS") }
+    it { expect(comm.committed_date).to eq(DateTime.parse("2019-02-28")) }
+    it { expect(comm.retention_date).to be_nil }
+    it { expect(comm.local_bib_id).to be_nil }
+    it { expect(comm.local_item_id).to be_nil }
+    it { expect(comm.local_item_location).to be_nil }
+    it { expect(comm.local_shelving_type).to be_nil }
+    it { expect(comm.policies).to eq([]) }
+    it { expect(comm.facsimile).to be(false) }
+    it { expect(comm.other_program).to be_nil }
+    it { expect(comm.other_retention_date).to be_nil }
+    it { expect(comm.deprecation_status).to be_nil }
+    it { expect(comm.deprecation_date).to be_nil }
+  end
+end


### PR DESCRIPTION
Doesn't address updates or deprecations, or even identity (there are a lot of duplicates in the existing database). 

My only concern before loading is the setting of `cluster.last_modified` when adding commitments, which seems unnecessary.