### PR TITLE
HT-3216: bugfix write report only for org reqd

### DIFF
--- a/lib/reports/etas_organization_overlap_report.rb
+++ b/lib/reports/etas_organization_overlap_report.rb
@@ -55,6 +55,8 @@ module Reports
     # @param access  [String] 'allow' or 'deny' for the associated item
     # @param rights  [String] the rights for the associated item
     def write_record(holding, format, access, rights)
+      return unless organization.nil? || organization == holding[:organization]
+
       etas_record = Overlap::ETASOverlap.new(ocn: holding[:ocn],
                       local_id: holding[:local_id],
                       item_type: format,

--- a/spec/reports/etas_organization_overlap_report_spec.rb
+++ b/spec/reports/etas_organization_overlap_report_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe Reports::EtasOrganizationOverlapReport do
       end
     end
 
+    it "only has a file for the organization given" do
+      new_h = build(:holding, ocn: h2.ocn)
+      Clustering::ClusterHolding.new(new_h).cluster.tap(&:save)
+      rpt = described_class.new(orgs.last)
+      rpt.run
+      expect(rpt.reports.keys).to eq([orgs.last])
+    end
+
     it "has a line for each ht_item in the holding organization rpt" do
       rpt = described_class.new
       rpt.run


### PR DESCRIPTION
Incomplete ETAS overlap reports were being generated for organizations when a different organization was requested. When a particular organization was NOT requested, all were being generated correctly.  