### PR TITLE
New class Utils::SessionKeepAlive: for keeping sessions alive

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -54,11 +54,12 @@ Metrics/BlockLength:
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
   Exclude:
-    - 'lib/scrub/autoscrub.rb'
-    - 'lib/enum_chron_parser.rb'
-    - 'lib/scrub/scrub_fields.rb'
-    - 'lib/reports/cost_report.rb'
+    - 'bin/holdings_deleter.rb'
     - 'lib/cluster.rb'
+    - 'lib/enum_chron_parser.rb'
+    - 'lib/reports/cost_report.rb'
+    - 'lib/scrub/autoscrub.rb'
+    - 'lib/scrub/scrub_fields.rb'
 
 # Offense count: 6
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/lib/utils/session_keep_alive.rb
+++ b/lib/utils/session_keep_alive.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "services"
+require "cluster"
+
+Services.mongo!
+
+module Utils
+  # Lets you wrap a session around a potentially long running query,
+  # and that session is kept alive by a refresh-loop in a separate thread.
+  # The actual test of keeping session/cursor alive is TODO.
+  # Intended usage:
+  # require "utils.session_keep_alive"
+  # ska = Utils::SessionKeepAlive.new(60)
+  # ska.run do
+  #   # Mongo operation at risk of timing out:
+  #   Cluster.where(long_q).no_timeout.each do |cluster|
+  #     {...}
+  #   end
+  # end
+  class SessionKeepAlive
+    attr_reader :seconds, :refresh_count, :refresher_thread
+
+    def initialize(seconds = 120)
+      @seconds          = seconds # refresh freq, can be a float if you want to go below 1s.
+      @refresh_count    = 0       # For testing purposes, mostly.
+      @refresher_thread = nil     # The thread that refreshes the session.
+    end
+
+    def run(&_block)
+      Cluster.with_session do |session|
+        begin
+          @refresher_thread = start_refresh_thread(session)
+          yield # i.e. execute _block
+        ensure
+          @refresher_thread.kill
+        end
+      end
+    end
+
+    private
+
+    def start_refresh_thread(session)
+      Thread.new do
+        loop do
+          sleep @seconds
+          session.client.command(refreshSessions: [session.session_id])
+          @refresh_count += 1
+        end
+      end
+    end
+  end
+end

--- a/spec/holdings_deleter_spec.rb
+++ b/spec/holdings_deleter_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe HoldingsDeleter do
     described_class.new(args)
   end
 
-  def fake_clusters(org)
-    1.upto(10) do |ocn|
+  def fake_clusters(org, count = 10)
+    1.upto(count) do |ocn|
       h1 = build(:holding, ocn: ocn, organization: org)
       Clustering::ClusterHolding.new(h1).cluster.tap(&:save)
     end
@@ -134,6 +134,13 @@ RSpec.describe HoldingsDeleter do
       deleter = neu("--organization", "umich", "--leave_empties")
       deleter.run
       expect(empty_clusters.count).to eq(10)
+      # Call to explicitly delete.
+      deleter.delete_empty_clusters
+      expect(empty_clusters.count).to eq(0)
+    end
+
+    xit "placeholder for actually testing session/cursor timeout" do
+      # todo
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,9 @@ RSpec.configure do |config|
   # Factory Bot
   config.include FactoryBot::Syntax::Methods
 
+  # Ignore tests tagged :slow by default.
+  config.filter_run_excluding slow: true
+
   config.before(:suite) do
     FactoryBot.find_definitions
   end

--- a/spec/utils/session_keep_alive_spec.rb
+++ b/spec/utils/session_keep_alive_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "utils/session_keep_alive"
+
+# These tests require some amount of sleep, but since sleeps are
+# below 1s duration I chose to not tag these as :slow. Feel free
+# to change if tests are starting to take too long.
+
+RSpec.describe Utils::SessionKeepAlive do
+  it "refreshes 0 times if the duration is below than the refresh rate" do
+    keeper = described_class.new(0.5)
+    expect(keeper.seconds).to eq(0.5)
+    expect(keeper.refresh_count).to eq(0)
+    keeper.run do
+      sleep 0.01
+    end
+    expect(keeper.refresh_count).to eq(0)
+  end
+
+  it "refreshes 2 times if the duration is ~2 times the refresh rate" do
+    keeper = described_class.new(0.1)
+    expect(keeper.seconds).to eq(0.1)
+    expect(keeper.refresh_count).to eq(0)
+    keeper.run do
+      sleep 0.25
+    end
+    expect(keeper.refresh_count).to eq(2)
+  end
+
+  it "kills the thread when done" do
+    keeper = described_class.new(1)
+    expect(keeper.refresher_thread).to eq nil
+    keeper.run do
+      sleep 0.01
+      expect(keeper.refresher_thread.alive?).to be true
+    end
+    sleep 0.001 # or thread won't have time to update
+    expect(keeper.refresher_thread.alive?).to be false
+  end
+
+  xit "does not have a test that refreshSessions prevents session/cursor death" do
+    # todo
+  end
+end


### PR DESCRIPTION
Broke out some code from `lib/overlap/overlap_table_update.rb` into new class `lib/utils/session_keep_alive.rb`, since the same thing was needed to keep the holdings deleter from crashing with an expired cursor.

@jsteverman and I tried to think what a (useful && non-production) test for this would look like. `overlap_table_update.rb` does not directly test this behavior.

Any ideas from @aelkiss or the Universe appreciated.