### PR TITLE
Ht 3095 automate etas overlap

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,7 +51,7 @@ Metrics/BlockLength:
     - 'spec/**/*_spec.rb'
     - 'spec/spec_helper.rb'
 
-# Offense count: 5
+# Offense count: 7
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
   Exclude:
@@ -61,6 +61,7 @@ Metrics/ClassLength:
     - 'lib/reports/cost_report.rb'
     - 'lib/scrub/autoscrub.rb'
     - 'lib/scrub/scrub_fields.rb'
+    - 'lib/reports/etas_organization_overlap_report.rb'
 
 # Offense count: 7
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG UID=1000
 ARG GID=1000
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
-  nodejs netcat
+  nodejs netcat rclone
 
 WORKDIR /usr/src/app
 ENV BUNDLE_PATH /gems

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -6,7 +6,7 @@ ARG UID=1000
 ARG GID=1000
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
-  nodejs
+  nodejs rclone
 
 RUN gem install bundler
 RUN groupadd -g $GID -o $UNAME

--- a/bin/add_print_holdings.rb
+++ b/bin/add_print_holdings.rb
@@ -13,6 +13,11 @@ def main
   holding_loader = Loader::HoldingLoader.for(filename)
   Loader::FileLoader.new(batch_loader: holding_loader).load(filename, skip_header_match: /\A\s*OCN/)
   holding_loader.final_line
+
+  organization = holding_loader.instance_variable_get("@organization")
+  rpt = Reports::EtasOrganizationOverlapReport.new(organization)
+  rpt.run
+  rpt.move_reports_to_remote
 end
 
 main if __FILE__ == $PROGRAM_NAME

--- a/bin/reports/export_etas_overlap_report.rb
+++ b/bin/reports/export_etas_overlap_report.rb
@@ -14,6 +14,7 @@ def main
   org = ARGV.shift
   rpt = Reports::EtasOrganizationOverlapReport.new(org)
   rpt.run
+  rpt.move_reports_to_remote
 end
 
 main if $PROGRAM_NAME == __FILE__

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,6 +8,8 @@ mongodb:
   password: <%= ENV["MONGODB_PASSWORD"] %>
 target_cost: <%= ENV["TARGET_COST"] %>
 etas_overlap_reports_path: <%= ENV["ETAS_OVERLAP_REPORTS_PATH"] %>
+etas_overlap_reports_remote_path: <%= ENV["ETAS_OVERLAP_REPORTS_REMOTE_PATH"] %>
 loading_flag_path: <%= ENV["LOADING_FLAG_PATH"] %>
 cost_report_freq_path: <%= ENV["COST_REPORT_FREQ_PATH"] %>
 pushgateway: <%= ENV["PUSHGATEWAY"] %>
+rclone_config_path: <%= ENV["RCLONE_CONFIG_PATH"] %>

--- a/lib/reports/etas_organization_overlap_report.rb
+++ b/lib/reports/etas_organization_overlap_report.rb
@@ -15,13 +15,14 @@ module Reports
       @reports = {}
       @date_of_report = Time.now.strftime("%Y-%m-%d")
       @report_path = Settings.etas_overlap_reports_path || "tmp_reports"
+      @remote_report_path = Settings.etas_overlap_reports_remote_path || "tmp_remote_path"
       Dir.mkdir(@report_path) unless File.exist?(@report_path)
       @organization = organization
     end
 
     def open_report(org, date)
       nonus = Services.ht_organizations[org]&.country_code == "us" ? "" : "_nonus"
-      File.open("#{report_path}/#{org}_#{date}#{nonus}.tsv", "w")
+      File.open("#{report_path}/etas_overlap_#{org}_#{date}#{nonus}.tsv", "w")
     end
 
     def report_for_org(org)
@@ -115,6 +116,37 @@ module Reports
         write_record(etas_record)
       end
     end
+
+    def gzip_report(rpt)
+      rpt.close
+      zipped = File.path(rpt) + ".gz"
+      Zlib::GzipWriter.open(zipped) do |gz|
+        File.open(rpt) do |file|
+          gz.mtime = File.mtime(file)
+          while (chunk = file.read(16*1024))
+            gz.write(chunk)
+          end
+        end
+      end
+      zipped
+    end
+
+    # Gzips and rclones the reports
+    def move_reports_to_remote
+      reports.each do |org, file|
+        next unless org == organization || organization.nil?
+
+        gz = gzip_report(file)
+        system(rclone_move(gz, org))
+      end
+    end
+
+    def rclone_move(file, org)
+      ["rclone", "--config", Settings.rclone_config_path, "move",
+       File.path(file),
+       "#{@remote_report_path}/#{org}-hathitrust-member-data/analysis"]
+    end
+
   end
 
 end


### PR DESCRIPTION
bin/add_print_holdings.rb and bin/reports/export_etas_overlap_report.rb will fail in production.

They need the environment variable RCLONE_CONFIG_PATH set to rclone.conf secret? 