### PR TITLE
add less and entr to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG UID=1000
 ARG GID=1000
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
-  nodejs netcat
+  nodejs netcat less entr
 
 WORKDIR /usr/src/app
 ENV BUNDLE_PATH /gems


### PR DESCRIPTION
I've been using `entr` for developing, Sandi Metz style, but have had to keep it in a local modified Dockerfile.
Also I find it super frustrating to not have `less` available.
Can we just add them to the Dockerfile?