### PR TITLE
ETAS Overlap: Limit batch size to avoid CursorNotFound

### DIFF
--- a/config/environments/test.yml
+++ b/config/environments/test.yml
@@ -4,3 +4,4 @@ large_cluster_ocns: /tmp/large_cluster_ocns.txt
 loading_flag_path: /tmp/loading_flag
 slack_endpoint: http://slack.test/endpoint
 cost_report_freq_path: /tmp/cost_report_freq
+etas_overlap_batch_size: 50

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,7 @@ mongodb:
 target_cost: <%= ENV["TARGET_COST"] %>
 etas_overlap_reports_path: <%= ENV["ETAS_OVERLAP_REPORTS_PATH"] %>
 etas_overlap_reports_remote_path: <%= ENV["ETAS_OVERLAP_REPORTS_REMOTE_PATH"] %>
+etas_overlap_batch_size: <%= ENV["ETAS_OVERLAP_BATCH_SIZE"] %>
 loading_flag_path: <%= ENV["LOADING_FLAG_PATH"] %>
 cost_report_freq_path: <%= ENV["COST_REPORT_FREQ_PATH"] %>
 pushgateway: <%= ENV["PUSHGATEWAY"] %>

--- a/lib/reports/etas_organization_overlap_report.rb
+++ b/lib/reports/etas_organization_overlap_report.rb
@@ -37,9 +37,11 @@ module Reports
     def clusters_with_holdings
       Utils::SessionKeepAlive.new(120).run do
         if organization.nil?
-          Cluster.where("holdings.0": { "$exists": 1 }).no_timeout
+          Cluster.batch_size(Settings.etas_overlap_batch_size)
+            .where("holdings.0": { "$exists": 1 }).no_timeout
         else
-          Cluster.where("holdings.organization": organization).no_timeout
+          Cluster.batch_size(Settings.etas_overlap_batch_size)
+            .where("holdings.organization": organization).no_timeout
         end
       end
     end


### PR DESCRIPTION
I put `50` in the settings mostly on a whim.  