### PR TITLE
log every 50K lines instead of every 1k lines

### DIFF
--- a/bin/reports/compile_cost_reports.rb
+++ b/bin/reports/compile_cost_reports.rb
@@ -28,7 +28,7 @@ def to_tsv(report)
 end
 
 def main
-  batch_size = 1_000
+  batch_size = 50_000
   marker = Services.progress_tracker.new(batch_size)
   logger = Services.logger
   logger.info "Starting #{Pathname.new(__FILE__).basename}. Batches of #{ppnum batch_size}"


### PR DESCRIPTION
One line change.
I just think it's too much having the progress tracker log something every 1K lines.
Costreport logs are all:

> I, [2022-02-14T20:36:18.565935 #7]  INFO -- :  10_609_000. This batch 1_000 in  0.5s (2_019 r/s). Overall 766 r/s.
> I, [2022-02-14T20:36:19.038463 #7]  INFO -- :  10_610_000. This batch 1_000 in  0.5s (2_115 r/s). Overall 766 r/s.
> I, [2022-02-14T20:36:19.362272 #7]  INFO -- :  10_611_000. This batch 1_000 in  0.3s (3_088 r/s). Overall 766 r/s.
> I, [2022-02-14T20:36:19.699485 #7]  INFO -- :  10_612_000. This batch 1_000 in  0.3s (2_965 r/s). Overall 766 r/s.
> I, [2022-02-14T20:36:20.010105 #7]  INFO -- :  10_613_000. This batch 1_000 in  0.3s (3_219 r/s). Overall 766 r/s.