### PR TITLE
HT-1944

### DIFF
--- a/bin/reports/compile_commitment_replacements_report.rb
+++ b/bin/reports/compile_commitment_replacements_report.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-require "reports/eligible_commitments"
+require "reports/commitment_replacements"
 
 # Cmdline input: a list of ocns,
 # STDOUT output: a report of which of the input ocns are eligible for commitments.
 # Invoke thusly:
-# $ bundle exec ruby compile_eligible_commitments_report.rb <list_of_ocns>
+# $ bundle exec ruby bin/compile_commitments_replacements_report.rb <list_of_ocns>
 # e.g.
-# $ bundle exec ruby compile_eligible_commitments_report.rb 1 2 3
+# $ bundle exec ruby bin/compile_commitments_replacements_report.rb 1 2 3
 
 if $PROGRAM_NAME == __FILE__
-  report = Reports::EligibleCommitments.new
+  report = Reports::CommitmentReplacements.new
   puts report.header.join("\t")
   report.for_ocns(ARGV.map(&:to_i)) do |row|
     puts row.join("\t")

--- a/bin/reports/compile_uncommitted_holdings.rb
+++ b/bin/reports/compile_uncommitted_holdings.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "reports/uncommitted_holdings"
+require "optparse"
+require "services"
+
+Services.mongo!
+
+def main(args)
+  criteria = parse_opts(args)
+  report = Reports::UncommittedHoldings.new(**criteria)
+  puts report.header.join("\t")
+  report.run do |record|
+    puts record.to_s
+  end
+end
+
+def parse_opts(args)
+  criteria = {}
+  help_str = "Restrict search to clusters matching"
+  OptionParser.new do |opts|
+    opts.on("--ocn [INT]", Array, "#{help_str} OCN(s)") do |ocns|
+      ocns.map!(&:to_i)
+    end
+    opts.on("--organization [STR]", Array, "#{help_str} org(s)")
+    opts.on("--all", "Search across all clusters.")
+    opts.on("--verbose")
+    opts.on("--noop")
+    opts.on("--help", "You're looking at it.") do |help|
+      puts opts
+      exit
+    end
+  end.parse!(args, into: criteria)
+
+  criteria
+end
+
+main(ARGV) if __FILE__ == $PROGRAM_NAME

--- a/lib/reports/commitment_replacements.rb
+++ b/lib/reports/commitment_replacements.rb
@@ -4,12 +4,13 @@ require "services"
 require "overlap/holding_commitment"
 
 module Reports
+  # User wants to find holdings for replacing shared print commitments.
   # Given criteria, pull up all clusters that  match those criteria
   # AND have holdings,
   # AND have ht_items,
   # AND for those clusters, report holdings that don't have a commitment.
-  # Invoke via bin/reports/compile_eligible_commitments_report.rb
-  class EligibleCommitments
+  # Invoke via bin/reports/compile_commitment_replacements_report.rb
+  class CommitmentReplacements
     def header
       ["organization", "oclc_sym", "ocn", "local_id"]
     end

--- a/lib/reports/uncommitted_holdings.rb
+++ b/lib/reports/uncommitted_holdings.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "services"
+require "reports/uncommitted_holdings_record"
+require "overlap/holding_commitment"
+
+module Reports
+  # Get holdings from spm clusters where there are items & holdings but no active commitments.
+  # Allow to optionally filter by OCN(s) and/or organization(s).
+  # "I want to know which items in HTDL lack commitments,
+  #  so I can seek new titles to secure commitments on"
+  # Invoke via bin/reports/compile_uncommitted_holdings.rb
+  class UncommittedHoldings
+    def initialize(all: false, ocn: [], organization: [], verbose: false, noop: false)
+      # Get query criteria:
+      @all = all
+      @ocn = ocn
+      @organization = organization
+      raise ArgumentError if no_criteria?
+
+      # Get any non-query flags.
+      @verbose = verbose
+      @noop = noop
+      @query = {"ht_items.0": {"$exists": 1}, "holdings.0": {"$exists": 1}}
+    end
+
+    def no_criteria?
+      !@all && @ocn.empty? && @organization.empty?
+    end
+
+    def run
+      refine_query
+      warn "Query: #{@query}" if @verbose
+
+      if @noop
+        warn "Returning before executing query, because @noop==true" if @verbose
+        return
+      end
+
+      Cluster.where(@query).no_timeout.each do |cluster|
+        next unless cluster.format == "spm"
+        next if cluster.commitments.reject(&:deprecated?).any?
+        cluster.holdings.each do |holding|
+          yield Reports::UncommittedHoldingsRecord.new(holding)
+        end
+      end
+    end
+
+    def refine_query
+      unless @all # @all == true means no more query building
+        if @ocn.any?
+          @query["ocns"] = {"$in": @ocn}
+        end
+        if @organization.any?
+          @query["holdings.organization"] = {"$in": @organization}
+        end
+      end
+    end
+
+    def header
+      ["organization", "oclc_sym", "ocn", "local_id"]
+    end
+  end
+end

--- a/lib/reports/uncommitted_holdings_record.rb
+++ b/lib/reports/uncommitted_holdings_record.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "services"
+
+module Reports
+  # Wrapper around a Clusterable::Holding for use in Reports::UncommittedHoldings.
+  class UncommittedHoldingsRecord
+    attr_reader :organization, :oclc_sym, :ocn, :local_id
+    def initialize(holding)
+      @organization = holding.organization
+      @oclc_sym = Services.ht_organizations.members.fetch(@organization)&.oclc_sym || "N/A"
+      @ocn = holding.ocn
+      @local_id = holding.local_id
+    end
+
+    def to_a
+      [organization, oclc_sym, ocn, local_id]
+    end
+
+    def to_s
+      to_a.join("\t")
+    end
+  end
+end

--- a/spec/reports/commitment_replacements_spec.rb
+++ b/spec/reports/commitment_replacements_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "reports/eligible_commitments"
-require_relative "../../bin/reports/compile_eligible_commitments_report"
+require "reports/commitment_replacements"
+require_relative "../../bin/reports/compile_commitment_replacements_report"
 
 # is not required higher up like the others clustering classes?
 require "clustering/cluster_commitment"
 
-RSpec.describe Reports::EligibleCommitments do
+RSpec.describe Reports::CommitmentReplacements do
   def build_h(org, ocn, local_id, status)
     build(
       :holding,

--- a/spec/reports/uncommitted_holdings_record_spec.rb
+++ b/spec/reports/uncommitted_holdings_record_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "reports/uncommitted_holdings_record"
+require "spec_helper"
+
+RSpec.describe Reports::UncommittedHoldingsRecord do
+  let(:ocn) { 5 }
+  let(:org) { "umich" }
+  let(:oclc_sym) { "EYM" }
+  let(:loc) { "i123" }
+  let(:hol) { build(:holding, ocn: ocn, local_id: loc, organization: org) }
+  let(:record) { described_class.new(hol) }
+
+  it "attr_reader" do
+    expect(record.organization).to eq hol.organization
+    expect(record.oclc_sym).to eq oclc_sym
+    expect(record.ocn).to eq hol.ocn
+    expect(record.local_id).to eq hol.local_id
+  end
+
+  it "to_a" do
+    expect(record.to_a).to eq [org, oclc_sym, ocn, loc]
+  end
+
+  it "to_s" do
+    expect(record.to_s).to eq "#{org}\t#{oclc_sym}\t#{ocn}\t#{loc}"
+  end
+end

--- a/spec/reports/uncommitted_holdings_spec.rb
+++ b/spec/reports/uncommitted_holdings_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "clustering/cluster_commitment"
+require "reports/uncommitted_holdings"
+require "spec_helper"
+require_relative "../../bin/reports/compile_uncommitted_holdings"
+
+RSpec.describe Reports::UncommittedHoldings do
+  let(:report_all) { described_class.new(all: true) }
+
+  let(:ocn1) { 5 }
+  let(:org1) { "umich" }
+  let(:loc1) { "i123" }
+  let(:ht_spm1) { build(:ht_item, :spm, ocns: [ocn1]) }
+  let(:hol1) { build(:holding, ocn: ocn1, local_id: loc1, organization: org1) }
+  let(:com1) { build(:commitment, ocn: ocn1, local_id: loc1, organization: org1) }
+
+  let(:ocn2) { 6 }
+  let(:org2) { "smu" }
+  let(:loc2) { "i456" }
+  let(:ht_spm2) { build(:ht_item, :spm, ocns: [ocn2]) }
+  let(:hol2) { build(:holding, ocn: ocn2, local_id: loc2, organization: org2) }
+  let(:com2) { build(:commitment, ocn: ocn2, local_id: loc2, organization: org2) }
+
+  let(:mpm) { build(:ht_item, :mpm, ocns: [ocn1]) }
+  let(:ser) { build(:ht_item, :ser, ocns: [ocn1]) }
+
+  # Runs report, returns records. Run, report. Run!
+  def run_report(report)
+    returned_records = []
+    report.run do |record|
+      returned_records << record
+    end
+    returned_records
+  end
+
+  before(:each) do
+    Cluster.collection.find.delete_many
+  end
+
+  describe "basic stuff" do
+    it "has a header" do
+      expect(report_all.header).to eq ["organization", "oclc_sym", "ocn", "local_id"]
+    end
+    it "returns an array of UncommittedHoldingsRecord" do
+      cluster_tap_save [hol1, ht_spm1]
+      results = run_report(report_all)
+      expect(results).to be_a Array
+      expect(results.first).to be_a Reports::UncommittedHoldingsRecord
+      expect(results.first.ocn).to eq ocn1
+    end
+    it "does nothing if :noop=true" do
+      cluster_tap_save [hol1, ht_spm1]
+      results = run_report(described_class.new(all: true, noop: true))
+      expect(results).to be_a Array
+      expect(results.size).to eq 0
+    end
+    it "raises error if given empty criteria" do
+      expect { described_class.new }.to raise_exception(ArgumentError)
+    end
+  end
+
+  describe "all search" do
+    it "can search the whole collection" do
+      cluster_tap_save [hol1, ht_spm1, hol2, ht_spm2]
+      expect(run_report(report_all).size).to eq 2
+    end
+    it "returns holdings for clusters that do not have commitments" do
+      cluster_tap_save [hol1, ht_spm1]
+      expect(run_report(report_all).size).to eq 1
+    end
+    it "returns no holdings from clusters that have active commitments" do
+      cluster_tap_save [hol1, ht_spm1, com1]
+      expect(run_report(report_all).size).to eq 0
+    end
+    it "returns holdings from clusters that have deprecated commitments" do
+      com1.deprecate(status: "E")
+      cluster_tap_save [hol1, ht_spm1, com1]
+      expect(run_report(report_all).size).to eq 1
+    end
+    it "ignores mpm" do
+      cluster_tap_save [hol1, mpm]
+      expect(run_report(report_all).size).to eq 0
+    end
+    it "ignores ser" do
+      cluster_tap_save [hol1, ser]
+      expect(run_report(report_all).size).to eq 0
+    end
+  end
+
+  describe "search by OCN(s)" do
+    it "can search by a single OCN" do
+      cluster_tap_save [hol1, ht_spm1, hol2, ht_spm2]
+      results = run_report(described_class.new(ocn: [ocn1]))
+      expect(results.size).to eq 1
+      expect(results.first.ocn).to eq ocn1
+    end
+    it "can search by multiple OCNs" do
+      cluster_tap_save [hol1, ht_spm1, hol2, ht_spm2]
+      results = run_report(described_class.new(ocn: [ocn1, ocn2]))
+      expect(results.size).to eq 2
+    end
+  end
+
+  describe "search by organization(s)" do
+    it "can search by a single organization" do
+      cluster_tap_save [hol1, ht_spm1, hol2, ht_spm2]
+      results = run_report(described_class.new(organization: [org1]))
+      expect(results.size).to eq 1
+      expect(results.first.organization).to eq org1
+    end
+    it "can search by multiple organizations" do
+      cluster_tap_save [hol1, ht_spm1, hol2, ht_spm2]
+      results = run_report(described_class.new(organization: [org1, org2]))
+      expect(results.size).to eq 2
+    end
+  end
+
+  describe "combined search" do
+    it "can do a combined search using both a single OCN and a single organization" do
+      cluster_tap_save [hol1, ht_spm1, hol2, ht_spm2]
+      results = run_report(described_class.new(ocn: [ocn1], organization: [org1]))
+      expect(results.size).to eq 1
+      expect(results.first.ocn).to eq ocn1
+    end
+    it "can do a combined search using both multiple OCNs and multiple organizations" do
+      cluster_tap_save [hol1, ht_spm1, hol2, ht_spm2]
+      results = run_report(described_class.new(ocn: [ocn1, ocn2], organization: [org1, org2]))
+      expect(results.size).to eq 2
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,3 +82,19 @@ RSpec.configure do |config|
     end
   end
 end
+
+# Clusters and saves each element in an array of clusterables
+# DRY for the many times the tests need to do something like:
+# Clustering::ClusterXYZ.new(xyz).cluster.tap(&:save)
+def cluster_tap_save(clusterables)
+  clusterables.each do |clusterable|
+    case clusterable.class
+    when Clusterable::Holding
+      Clustering::ClusterHolding
+    when Clusterable::HtItem
+      Clustering::ClusterHtItem
+    when Clusterable::Commitment
+      Clustering::ClusterCommitment
+    end.new(clusterable).cluster.tap(&:save)
+  end
+end


### PR DESCRIPTION
Allows for a combination of ocn and organization search terms, or all.
For all matching clusters, return holdings.
"Matching clusters" have at baseline holdings, htitems but no (active) commitments, and then filtered further based on ocn and/or organization. 

Thrown in is also a renaming of "eligible_commitments" to "commitment_replacements", as I kept getting annoyed at the inaccuracy of the name.