### PR TITLE
update shared print commitments

### DIFF
--- a/config/environments/test.yml
+++ b/config/environments/test.yml
@@ -5,4 +5,5 @@ loading_flag_path: /tmp/loading_flag
 slack_endpoint: http://slack.test/endpoint
 cost_report_freq_path: /tmp/cost_report_freq
 deprecation_report_path: /tmp/deprecation_report
+shared_print_update_report_path: /tmp/shared_print_update_report
 etas_overlap_batch_size: 50

--- a/lib/shared_print/finder.rb
+++ b/lib/shared_print/finder.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "cluster"
+require "services"
+
+Services.mongo!
+
+module SharedPrint
+  # Pass criteria to new(), and
+  # * call clusters()    to yield the matching clusters,
+  # * call commitments() to yield the matching commitments.
+  class Finder
+    attr_reader :organization, :ocn, :local_id, :deprecated, :query
+    def initialize(organization: [], ocn: [], local_id: [], deprecated: false)
+      @organization = organization
+      @ocn = ocn
+      @local_id = local_id
+      @deprecated = deprecated
+
+      # Put together a query based on the criteria gathered.
+      @query = build_query
+    end
+
+    # Yield matching clusters.
+    def clusters
+      return enum_for(:clusters) unless block_given?
+
+      Cluster.where(@query).no_timeout.each do |cluster|
+        yield cluster
+      end
+    end
+
+    # Yield matching commitments in matching clusters.
+    def commitments
+      return enum_for(:commitments) unless block_given?
+
+      clusters do |cluster|
+        cluster.commitments.each do |commitment|
+          yield commitment if match?(commitment)
+        end
+      end
+    end
+
+    private
+
+    # Build a hash that can be used as arg to Cluster.where().
+    # This query returns whole clusters.
+    def build_query
+      q = {"commitments.0": {"$exists": 1}}
+      if @organization.any?
+        q["commitments.organization"] = {"$in": @organization}
+      end
+      if @ocn.any?
+        q["commitments.ocn"] = {"$in": @ocn}
+      end
+      if @local_id.any?
+        q["commitments.local_id"] = {"$in": @local_id}
+      end
+
+      q
+    end
+
+    # The Cluster.where() query returns whole clusters,
+    # so we can iterate over the commitments of those clusters
+    # and return only the commitments that match.
+    def match?(commitment)
+      @deprecated == commitment.deprecated? &&
+        empty_or_include?(@organization, commitment.organization) &&
+        empty_or_include?(@ocn, commitment.ocn) &&
+        empty_or_include?(@local_id, commitment.local_id)
+    end
+
+    # A commitment matches e.g. the @ocn acriterion if @ocn == []
+    # or if @ocn contains commitment.ocn.
+    def empty_or_include?(arr, val)
+      arr.empty? || arr.include?(val)
+    end
+  end
+end

--- a/lib/shared_print/update_record.rb
+++ b/lib/shared_print/update_record.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module SharedPrint
+  # An individual update record. Consists of find-fields and update-fields
+  class UpdateRecord
+    attr_reader :fields
+    def initialize(input_fields = {})
+      @err = []
+      @input_fields = validate(input_fields)
+    end
+
+    # Validate:
+    # the presence of required fields,
+    # the optional presence of optional fields,
+    # and the presence of nothing else.
+    def validate(input_fields)
+      validated = {}
+
+      # Required, used to find record
+      req_fields.keys.each do |k|
+        unless input_fields.key?(k)
+          @err << "Missing required field #{k}"
+        end
+        validated[k] = [cast(k, input_fields.delete(k))]
+      end
+
+      # Optional, used to update record
+      input_fields.each do |k, v|
+        if opt_fields.key?(k)
+          validated[k] = cast(k, input_fields.delete(k))
+        else
+          @err << "Unrecognized field #{k}:#{v}"
+        end
+      end
+
+      if @err.any?
+        raise ArgumentError, @err.join("\n")
+      end
+
+      validated
+    end
+
+    # When read from file, all vals are strings,
+    # and may need to get cast before becoming the new val
+    def cast(key, val)
+      cast_to = all_fields[key]
+      case cast_to
+      when :string
+        val # Do nothing, is already string
+      when :integer
+        val.to_i
+      when :date_time
+        DateTime.parse(val)
+      when :bool
+        {"true" => true, "false" => false}[val]
+      when :array
+        val.split(",").map(&:strip)
+      else
+        raise ArgumentError, "Did not know how to cast #{key} (= #{val})"
+      end
+    end
+
+    # These are the fields an UpdateRecord uses to find a matching commitment,
+    # and what they cast to.
+    # A record must have all of these.
+    # And this is how they must be called in the UpdateFile.
+    def req_fields
+      {
+        local_id: :string,
+        ocn: :integer,
+        organization: :string
+      }
+    end
+
+    # These are the fields that an UpdateRecord can update, and what they cast to.
+    # A record should have at least 1+ of these.
+    # And this is how they must be called in the UpdateFile.
+    def opt_fields
+      {
+        committed_date: :date_time,
+        facsimile: :bool,
+        policies: :array, # spec probably calls these lending_policy/scanning_repro_policy
+        local_bib_id: :string,
+        local_item_id: :string,
+        local_item_location: :string,
+        local_shelving_type: :string,
+        oclc_sym: :string, # might be called oclc_symbol in places, TODO: check that.
+        retention_date: :date_time
+      }
+    end
+
+    def all_fields
+      @all_fields ||= req_fields.merge(opt_fields)
+    end
+
+    # Expose the keys and values that SharedPrint::Finder uses to find commitments.
+    def finder_fields
+      @input_fields.slice(*req_fields.keys)
+    end
+
+    # Expose the keys and values of the things that are being updated.
+    def updater_fields
+      keys = opt_fields.keys & @input_fields.keys
+      @input_fields.slice(*keys)
+    end
+  end
+end

--- a/lib/shared_print/updater.rb
+++ b/lib/shared_print/updater.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "shared_print/finder"
+require "shared_print/update_record"
+require "utils/tsv_reader"
+
+Services.mongo!
+
+module SharedPrint
+  # Takes update records, tries to find them and applies updates when successful.
+  class Updater
+    attr_reader :file, :report_path
+    def initialize(file)
+      @file = file
+    end
+
+    # Process each record in @file.
+    def run
+      report "Update commitments based on update records in #{file}"
+      Utils::TSVReader.new(@file).run do |rec|
+        report "{"
+        process_record(rec)
+        report "}"
+      end
+      report "Done with #{file}."
+    end
+
+    # Report to file, set up if not set up.
+    def report(msg)
+      if @report.nil?
+        report_dir = Settings.shared_print_update_report_path
+        FileUtils.mkdir_p(report_dir)
+        in_base = File.basename(@file, ".*")
+        in_ext = File.extname(@file)
+        rand_str = SecureRandom.hex(8)
+        iso_stamp = Time.now.strftime("%Y%m%d-%H%M%S")
+        @report_path = "#{report_dir}/#{in_base}_#{iso_stamp}_#{rand_str}#{in_ext}"
+        @report = File.open(@report_path, "w")
+      end
+      @report.puts msg
+    end
+
+    # Takes a single update record...
+    def process_record(update_hash)
+      @update_record = SharedPrint::UpdateRecord.new(update_hash)
+      # ... and tries to find commitments that match.
+      report "Using #{@update_record.finder_fields}, find & update #{@update_record.updater_fields}"
+      @finder = SharedPrint::Finder.new(**@update_record.finder_fields)
+      @commitments = @finder.commitments.to_a
+      apply
+    end
+
+    # Applies the updates found in the update record onto the commitment.
+    def apply
+      case @commitments.size
+      when 1
+        apply_single_update
+      when 0
+        relax_search
+      else
+        too_many_hits
+      end
+    end
+
+    # Apply a set of changes from 1 SharedPrint::UpdateRecord to one Clusterable::Commitment.
+    def apply_single_update
+      commitment = @commitments.first
+      @update_record.updater_fields.each do |k, v|
+        report "updating #{k}=#{v}"
+        commitment.send("#{k}=", v)
+      end
+      report "OK."
+      commitment.save
+    end
+
+    # Removes local_id from search and tries finding commitments again.
+    def relax_search
+      report "Can only apply updates to 1 commitment. Full search found #{@commitments.size}."
+      if @finder.local_id.any?
+        report "Full search:\t#{@update_record.finder_fields.inspect}"
+        relaxed_search = @update_record.finder_fields.except(:local_id)
+        report "Relaxed:\t#{relaxed_search.inspect}"
+        relaxed_finder = SharedPrint::Finder.new(**relaxed_search)
+        relaxed_commitments = relaxed_finder.commitments.to_a
+        report "Relaxed search found #{relaxed_commitments.size} commitments."
+        if relaxed_commitments.any?
+          relaxed_commitments.each do |rc|
+            # could call apply here and be done with it.
+            report rc.inspect
+          end
+        end
+      end
+    end
+
+    def too_many_hits
+      report "Can only apply updates to 1 commitment. Full search found #{@commitments.size}:"
+      @commitments.each do |cm|
+        report cm.inspect
+      end
+    end
+  end
+end

--- a/lib/utils/tsv_reader.rb
+++ b/lib/utils/tsv_reader.rb
@@ -1,0 +1,60 @@
+module Utils
+  class TSVReader
+    # Takes a .tsv file with a header and turns it into hashes,
+    # where the keys are from the header and the values from the body cells.
+    # E.g.:
+    #   ocn <tab> local_id
+    #   11 <tab> i11
+    #   ...
+    #   99 <tab> i99
+    # ... into:
+    # [{ocn: 11, local_id: i11} ... {ocn: 99, local_id: i99}]
+    attr_reader :path, :header, :header_index
+    def initialize(path, delim = "\t")
+      @path = path
+      @delim = delim
+    end
+
+    def run
+      @inf = File.open(@path, "r")
+      process_header
+      records do |r|
+        yield r
+      end
+      @inf.close
+    end
+
+    def process_header(line = @inf.gets.strip)
+      @header = line
+      @header_hash = {}
+      @header_index = {}
+      # Set up header_index  = {0: ocn, 1: local_id}
+      # and header_hash = {ocn: nil, local_id: nil}
+      @header.split(@delim).each_with_index do |col_head, i|
+        @header_index[i] = col_head.to_sym
+        @header_hash[col_head.to_sym] = nil
+      end
+    end
+
+    def records
+      # For each line, get a copy of header_hash and populate it using header_index
+      # so that cols_hash = {ocn: 11, local_id: i11}
+      @inf.each_line do |line|
+        yield line_to_hash(line.strip)
+      end
+    end
+
+    def line_to_hash(line)
+      cols = line.split(@delim)
+      if cols.size != @header_hash.keys.size
+        raise IndexError, "Line cols: #{cols.size}, header cols: (#{@header_hash.keys.size})."
+      end
+      col_hash = @header_hash.clone
+      cols.each_with_index do |col_val, i|
+        col_hash[@header_index[i]] = col_val
+      end
+
+      col_hash.compact
+    end
+  end
+end

--- a/spec/fixtures/test_sp_update_file.tsv
+++ b/spec/fixtures/test_sp_update_file.tsv
@@ -1,0 +1,4 @@
+organization	ocn	local_id	local_bib_id
+umich	1	i1	updated
+umich	3	i3	updated
+umich	9	i9	updated

--- a/spec/shared_print/finder_spec.rb
+++ b/spec/shared_print/finder_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_print/finder"
+
+RSpec.describe SharedPrint::Finder do
+  let(:ocn1) { 1 }
+  let(:org1) { "umich" }
+  let(:loc1) { "i111" }
+  let(:spc1) { build(:commitment, ocn: ocn1, organization: org1, local_id: loc1) }
+
+  let(:ocn2) { 2 }
+  let(:org2) { "yale" }
+  let(:loc2) { "i222" }
+  let(:spc2) { build(:commitment, ocn: ocn2, organization: org2, local_id: loc2) }
+
+  let(:ocn999) { 999 }
+
+  before(:each) do
+    Cluster.collection.find.delete_many
+  end
+
+  describe "return types" do
+    it "#clusters yields Cluster values" do
+      cluster_tap_save [spc1]
+      expect(described_class.new(ocn: [ocn1]).clusters).to be_a Enumerator
+      described_class.new(ocn: [ocn1]).clusters do |cluster|
+        expect(cluster).to be_a Cluster
+      end
+    end
+    it "#commitments yields Clusterable::Commitment values" do
+      cluster_tap_save [spc1]
+      expect(described_class.new(ocn: [ocn1]).commitments).to be_a Enumerator
+      described_class.new(ocn: [ocn1]).commitments do |commitment|
+        expect(commitment).to be_a Clusterable::Commitment
+      end
+    end
+    it "#clusters.to_a returns an array of Cluster values" do
+      cluster_tap_save [spc1]
+      res = described_class.new(ocn: [ocn1]).clusters.to_a
+      expect(res.map(&:class)).to eq [Cluster]
+    end
+    it "#commitments.to_a returns an array of Clusterable::Commitment values" do
+      cluster_tap_save [spc1]
+      res = described_class.new(ocn: [ocn1]).commitments.to_a
+      expect(res.map(&:class)).to eq [Clusterable::Commitment]
+    end
+  end
+
+  describe "search criteria" do
+    it "finds nothing if there is nothing to find" do
+      res = described_class.new.commitments.to_a
+      expect(res.empty?).to be true
+    end
+    it "finds nothing if the criteria matches nothing" do
+      cluster_tap_save [spc1, spc2]
+      res = described_class.new(ocn: [ocn999]).commitments.to_a
+      expect(res.empty?).to be true
+    end
+    it "returns all if given no further search criteria" do
+      cluster_tap_save [spc1, spc2]
+      res = described_class.new.commitments.to_a
+      expect(res.size).to eq 2
+    end
+    it "can search by single OCN" do
+      cluster_tap_save [spc1, spc2]
+      res = described_class.new(ocn: [ocn1]).commitments.to_a
+      expect(res.map(&:ocn)).to eq [ocn1]
+    end
+    it "can search by multiple OCNs" do
+      cluster_tap_save [spc1, spc2]
+      res = described_class.new(ocn: [ocn1, ocn2]).commitments.to_a
+      expect(res.map(&:ocn)).to eq [ocn1, ocn2]
+    end
+    it "can search by single org" do
+      cluster_tap_save [spc1, spc2]
+      res = described_class.new(organization: [org1]).commitments.to_a
+      expect(res.map(&:organization)).to eq [org1]
+    end
+    it "can search by multiple orgs" do
+      cluster_tap_save [spc1, spc2]
+      res = described_class.new(organization: [org1, org2]).commitments.to_a
+      expect(res.map(&:organization)).to eq [org1, org2]
+    end
+    it "can search by single local_id" do
+      cluster_tap_save [spc1, spc2]
+      res = described_class.new(local_id: [loc1]).commitments.to_a
+      expect(res.map(&:local_id)).to eq [loc1]
+    end
+    it "can search by multiple local_ids" do
+      cluster_tap_save [spc1, spc2]
+      res = described_class.new(local_id: [loc1, loc2]).commitments.to_a
+      expect(res.map(&:local_id)).to eq [loc1, loc2]
+    end
+    it "ignores deprecated commitments by default" do
+      spc2.deprecate(status: "E")
+      cluster_tap_save [spc1, spc2]
+      res = described_class.new.commitments.to_a
+      expect(res.map(&:ocn)).to eq [ocn1]
+    end
+    it "can search deprecated commitments if told to" do
+      spc2.deprecate(status: "E")
+      cluster_tap_save [spc1, spc2]
+      res = described_class.new(deprecated: true).commitments.to_a
+      expect(res.map(&:ocn)).to eq [ocn2]
+    end
+  end
+end

--- a/spec/shared_print/update_record_spec.rb
+++ b/spec/shared_print/update_record_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "shared_print/update_record"
+require "spec_helper"
+
+RSpec.describe SharedPrint::UpdateRecord do
+  let(:org) { "umich" }
+  let(:ocn) { 5 }
+  let(:loc) { "i123" }
+  let(:arg) { {organization: org, ocn: ocn, local_id: loc} }
+
+  it "Accepts minimal OK required fields" do
+    expect { described_class.new(arg) }.not_to raise_error
+  end
+  it "Casts non-string field values" do
+    rec = described_class.new(arg)
+    expect(rec.cast(:ocn, "5")).to be_a Integer
+    expect(rec.cast(:committed_date, "2020-01-01")).to be_a DateTime
+    expect(rec.cast(:policies, "a,b,c")).to eq ["a", "b", "c"]
+    expect(rec.cast(:facsimile, "true")).to be true
+    expect(rec.cast(:facsimile, "false")).to be false
+  end
+  it "Raises ArgumentError if missing any required fields" do
+    fields1 = {organization: org, ocn: ocn}
+    fields2 = {organization: org, local_id: loc}
+    fields3 = {ocn: ocn, local_id: loc}
+    expect { described_class.new(fields1) }.to raise_error ArgumentError
+    expect { described_class.new(fields2) }.to raise_error ArgumentError
+    expect { described_class.new(fields3) }.to raise_error ArgumentError
+  end
+  it "Raises ArgumentError if unrecognized field" do
+    fields = {organization: org, ocn: ocn, local_id: loc, lunch_time: "soon"}
+    expect { described_class.new(fields) }.to raise_error ArgumentError
+  end
+end

--- a/spec/shared_print/updater_spec.rb
+++ b/spec/shared_print/updater_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_print/finder"
+require "shared_print/updater"
+
+RSpec.describe SharedPrint::Updater do
+  let(:ocn1) { 1 }
+  let(:org1) { "umich" }
+  let(:loc1) { "i111" }
+  let(:loc2) { "i222" }
+  let(:bib1) { "a" }
+  let(:bib2) { "z" }
+
+  # only local_bib_id differs between spc1 and spc2
+  let(:spc1) {
+    build(:commitment, ocn: ocn1, organization: org1, local_id: loc1, local_bib_id: bib1)
+  }
+  let(:spc2) {
+    build(:commitment, ocn: ocn1, organization: org1, local_id: loc1, local_bib_id: bib2)
+  }
+
+  # only local_id differs between upd1 and upd2
+  let(:upd1) { {ocn: ocn1, organization: org1, local_id: loc1, local_bib_id: bib2} }
+  let(:upd2) { {ocn: ocn1, organization: org1, local_id: loc2, local_bib_id: bib2} }
+
+  let(:updater) { described_class.new("/dev/null") }
+
+  before(:each) do
+    Cluster.collection.find.delete_many
+  end
+
+  it "Updates a field on a commitment if Finder finds 1 commitment." do
+    cluster_tap_save [spc1]
+    expect(spc1.local_bib_id).to eq "a"
+    # Should update local_bib_id on 1 record.
+    updater.process_record(upd1)
+    # spc1 is stale at this point, so gotta look it up again.
+    refresh_spc1 = SharedPrint::Finder.new(ocn: [ocn1]).commitments.to_a.first
+    # Confirm they are the same ...
+    expect(spc1.uuid).to eq refresh_spc1.uuid
+    # ... but that local_bib_id changed.
+    expect(refresh_spc1.local_bib_id).to eq "z"
+  end
+
+  it "If Finder finds 0 committments, relax search and report finds but do not update." do
+    cluster_tap_save [spc1]
+    expect(spc1.local_bib_id).to eq "a"
+    # Should not update local_bib_id, because local_id mismatch
+    updater.process_record(upd2)
+    refresh_spc1 = SharedPrint::Finder.new(ocn: [ocn1]).commitments.to_a.first
+    expect(refresh_spc1.local_bib_id).to eq "a"
+  end
+
+  it "If Finder finds multiple committments, report finds but do not update." do
+    cluster_tap_save [spc1, spc2]
+    expect(spc1.local_bib_id).to eq "a"
+    # Should not update local_bib_id, because multiple matches
+    updater.process_record(upd1)
+    refresh_spc1 = SharedPrint::Finder.new(ocn: [ocn1]).commitments.to_a.first
+    expect(refresh_spc1.local_bib_id).to eq "a"
+  end
+
+  it "Full integration test" do
+    single_match = build(:commitment, ocn: 1, organization: "umich", local_id: "i1", local_bib_id: "a")
+    multi_match_1 = build(:commitment, ocn: 9, organization: "umich", local_id: "i9", local_bib_id: "b")
+    multi_match_2 = build(:commitment, ocn: 9, organization: "umich", local_id: "i9", local_bib_id: "c")
+    zero_match = build(:commitment, ocn: 999, organization: "yale", local_id: "i999", local_bib_id: "d")
+    cluster_tap_save [single_match, multi_match_1, multi_match_2, zero_match]
+    # This fixture wants to make 4 updates but only matches the commitment in single_match.
+    described_class.new("spec/fixtures/test_sp_update_file.tsv").run
+    # Only single_match should have an updated local_bib_id.
+    arr = SharedPrint::Finder.new.commitments.to_a
+    expect(arr.map(&:local_bib_id).sort).to eq ["b", "c", "d", "updated"]
+  end
+end

--- a/spec/utils/tsv_reader_spec.rb
+++ b/spec/utils/tsv_reader_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "utils/tsv_reader"
+require "spec_helper"
+require "fileutils"
+
+RSpec.describe Utils::TSVReader do
+  let(:reader) { described_class.new("spec/fixtures/test_sp_update_file.tsv") }
+
+  it "#process_header" do
+    header_str = "a\tb\tc"
+    reader.process_header(header_str)
+    expect(reader.header_index).to eq({0 => :a, 1 => :b, 2 => :c})
+  end
+
+  describe "#line_to_hash" do
+    it "parses a line according to header" do
+      # Gotta set the header or line_to_hash don't work
+      reader.process_header("a\tb\tc")
+      # now then
+      expect(reader.line_to_hash("x\ty\tz")).to eq({a: "x", b: "y", c: "z"})
+    end
+    it "error if line column count is different from header column count" do
+      # Set up a header with 3 cols and try to parse lines of different length.
+      reader.process_header("a\tb\tc")
+      # Too short
+      expect { reader.line_to_hash("x\ty") }.to raise_error IndexError
+      # Too long
+      expect { reader.line_to_hash("x\ty\tz\tfoo") }.to raise_error IndexError
+      # Just right!
+      expect { reader.line_to_hash("x\ty\tz") }.not_to raise_error
+    end
+  end
+
+  it "#run" do
+    records = []
+    reader.run do |record|
+      records << record
+    end
+    expect(records.size).to eq 3
+    expect(records).to eq [
+      {local_id: "i1", ocn: "1", organization: "umich", local_bib_id: "updated"},
+      {local_id: "i3", ocn: "3", organization: "umich", local_bib_id: "updated"},
+      {local_id: "i9", ocn: "9", organization: "umich", local_bib_id: "updated"}
+    ]
+  end
+end


### PR DESCRIPTION
New code for updating shared print commitments:
Give a file to `SharedPrint::Updater` and it'll go through each line, turn line into a `SharedPrint::UpdateRecord`, use `SharedPrint::Finder` to find a matching `Clusterable::Commitment` and update it if conditions are right.