### PR TITLE
Cluster ids can be stale by time of cluster retrieval

### DIFF
--- a/lib/reports/etas_organization_overlap_report.rb
+++ b/lib/reports/etas_organization_overlap_report.rb
@@ -92,6 +92,7 @@ module Reports
     def run
       clusters_with_holdings.each do |c|
         cluster = Cluster.find_by(_id: c)
+        next if cluster.nil?
         holdings_matched = write_overlaps(cluster, organization)
         write_records_for_unmatched_holdings(cluster, holdings_matched)
       end


### PR DESCRIPTION
We had previously merged in the collection of cluster ids to then generate ETAS overlap reports. I forgot these could disappear between collection and actually processing the cluster.