### PR TITLE
Use pushgateway in dev

### DIFF
--- a/bin/setup/setup_dev.sh
+++ b/bin/setup/setup_dev.sh
@@ -2,7 +2,7 @@
 
 $(dirname ${BASH_SOURCE[0]})/setup_test.sh
 
-docker-compose up -d mongo_dev
+docker-compose up -d mongo_dev pushgateway
 docker-compose run --rm dev bin/setup/wait-for mongo_dev:27017 -- echo "mongo is ready"
 docker-compose exec -T mongo_dev bash /tmp/bin/setup/rs_initiate.sh mongo_dev
 docker-compose run --rm -e MONGOID_ENV=development dev bundle exec ruby lib/tasks/build_database.rb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - gem_cache:/gems
     environment:
       MYSQL_CONNECTION_STRING: "mysql2://ht_repository:ht_repository@mariadb/ht_repository"
+      PUSHGATEWAY: http://pushgateway:9091
 
   mongo_dev:
     image: mongo


### PR DESCRIPTION
Some scripts in dev failed because the pushgateway was not started by
default or referenced by development config. This starts and enables it.