### PR TITLE
Write ETAS rpts local, cp .gz to persistent storage

### DIFF
--- a/bin/phctl.rb
+++ b/bin/phctl.rb
@@ -108,7 +108,7 @@ module PHCTL
     def etas_overlap(org=nil)
       rpt = Reports::EtasOrganizationOverlapReport.new(org)
       rpt.run
-      rpt.move_reports_to_remote
+      rpt.move_reports
     end
 
     desc "eligible-commitments OCNS", "Find eligible commitments"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,7 @@ mongodb:
 target_cost: <%= ENV["TARGET_COST"] %>
 etas_overlap_reports_path: <%= ENV["ETAS_OVERLAP_REPORTS_PATH"] %>
 etas_overlap_reports_remote_path: <%= ENV["ETAS_OVERLAP_REPORTS_REMOTE_PATH"] %>
+local_report_path: <%= ENV["LOCAL_REPORT_PATH"] %>
 etas_overlap_batch_size: <%= ENV["ETAS_OVERLAP_BATCH_SIZE"] %>
 loading_flag_path: <%= ENV["LOADING_FLAG_PATH"] %>
 cost_report_freq_path: <%= ENV["COST_REPORT_FREQ_PATH"] %>


### PR DESCRIPTION
Adds a step to the generation of the ETAS overlap reports. It now writes to a local directory by default. Once completed, the gz files are copied to the /htprep and dropbox locations.