### PR TITLE
Increase length limit on holdings_htitem_htmember table

### DIFF
--- a/sql/003_holdings_htitem_htmember.sql
+++ b/sql/003_holdings_htitem_htmember.sql
@@ -1,10 +1,10 @@
 USE `ht_repository`;
 
 CREATE TABLE IF NOT EXISTS `holdings_htitem_htmember` (
-  `lock_id` varchar(100) NOT NULL,
+  `lock_id` varchar(300) NOT NULL,
   `cluster_id` varchar(25) NOT NULL,
   `volume_id` varchar(50) NOT NULL,
-  `n_enum` varchar(50) DEFAULT '',
+  `n_enum` varchar(250) DEFAULT '',
   `member_id` varchar(20) NOT NULL,
   `copy_count` int(11) DEFAULT NULL,
   `lm_count` smallint(6) DEFAULT NULL,

--- a/sql/003_holdings_htitem_htmember.sql
+++ b/sql/003_holdings_htitem_htmember.sql
@@ -14,4 +14,4 @@ CREATE TABLE IF NOT EXISTS `holdings_htitem_htmember` (
   PRIMARY KEY (`volume_id`, `member_id`),
   KEY (`member_id`),
   KEY (`cluster_id`)
-  ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
The n_enum column was defined as VARCHAR(50). In the hathifiles there are ~24k unique description fields longer than that. The max length in the Hathifiles is 200 characters; probably some other system truncating there. 

At one point the holdings_htitem_htmember table was truncating long n_enums and presumably lock_ids. I suspect recent updates have turned strict mysql on, resulting in errors rather than truncating and warning. 

This will of course need to be applied to the actual database, something like. 
ALTER TABLE ht_repository.holdings_htitem_htmember MODIFY lockid VARCHAR(300);
ALTER TABLE ht_repository.holdings_htitem_htmember MODIFY n_enum VARCHAR(250);

I don't know what the implications are for the lock_ids not matching. Was that a problem before? Does fixing them introduce a new problem? As far as updates from holdings, the table is updated using volume_id and member_id so changing lockid won't matter.