### PR TITLE
Allow comparing clusterables of different classes

### DIFF
--- a/lib/clusterable/holding.rb
+++ b/lib/clusterable/holding.rb
@@ -86,8 +86,8 @@ module Clusterable
     #
     # @param other, another holding
     def ==(other)
-      (fields.keys - EQUALITY_EXCLUDED_FIELDS)
-        .all? { |attr| public_send(attr) == other.public_send(attr) }
+      self.class == other.class &&
+        (fields.keys - EQUALITY_EXCLUDED_FIELDS).all? { |attr| public_send(attr) == other.public_send(attr) }
     end
 
     # Is true when all fields match except for _id

--- a/lib/clusterable/ocn_resolution.rb
+++ b/lib/clusterable/ocn_resolution.rb
@@ -22,7 +22,7 @@ module Clusterable
     }
 
     def ==(other)
-      deprecated == other.deprecated && resolved == other.resolved
+      self.class == other.class && deprecated == other.deprecated && resolved == other.resolved
     end
 
     def initialize(params = nil)


### PR DESCRIPTION
mongoid 7.4.0 has a couple of changes that require this:
https://github.com/mongodb/mongoid/commit/8a821e44bf8279890cab5012c2dda7f8e5dbb34f (change in how === works)
https://github.com/mongodb/mongoid/commit/a8f4484a35c4ad0e362c218668f4f81844453e38 (change in how it's collecting embedded documents for change tracking when persisting)

Both of these together mean that when saving a document, it checks with
== against other embedded documents to see if it's already encountered
it, and their classes might not match, so our overridden == should
return false in such a case rather than throwing an exception.