### PR TITLE
test and fix for broken invocation of prometheus pushgateway in Services

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -36,7 +36,7 @@ Services.register(:scrub_stats) { {} }
 Services.register(:large_clusters) { DataSources::LargeClusters.new }
 Services.register(:loading_flag) { FileMutex.new(Settings.loading_flag_path) }
 
-Services.register(:pushgateway) { Prometheus::Client::Push.new(File.basename($PROGRAM_NAME), nil, Settings.pushgateway) }
+Services.register(:pushgateway) { Prometheus::Client::Push.new(job: File.basename($PROGRAM_NAME), gateway: Settings.pushgateway) }
 Services.register(:prometheus_registry) { Prometheus::Client.registry }
 Services.register(:prometheus_metrics) do
   {

--- a/spec/utils/push_metrics_marker_spec.rb
+++ b/spec/utils/push_metrics_marker_spec.rb
@@ -2,6 +2,7 @@
 
 require "utils/push_metrics_marker"
 require "prometheus/client/push"
+require "services"
 
 RSpec.describe Utils::PushMetricsMarker do
   let(:batch_size) { rand(100) }
@@ -145,6 +146,12 @@ RSpec.describe Utils::PushMetricsMarker do
     it "delegates to marker" do
       expect(marker).to receive(:count)
       pm_marker.count
+    end
+  end
+
+  describe "Services.pushgateway" do
+    it "initiates OK" do
+      expect{ spg = Services.pushgateway }.not_to raise_error
     end
   end
 end

--- a/spec/utils/push_metrics_marker_spec.rb
+++ b/spec/utils/push_metrics_marker_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Utils::PushMetricsMarker do
 
   describe "Services.pushgateway" do
     it "initiates OK" do
-      expect{ spg = Services.pushgateway }.not_to raise_error
+      expect { Services.pushgateway }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
Noticed that the invocation for `Prometheus::Client::Push` had changed when trying to load new holdings.

This change came with the bumping of prometheus-client from 2.1.0 to 4.0.0 (https://github.com/hathitrust/holdings-backend/commit/89df3f1f08fd6356e21bd2ac614d80b16a19033a#diff-89cade48462044ee1b672dc5f4c3ec250fbd29effcd8932096a23c1283c6731fL59)