### PR TITLE
file transfer class for DEV-358

### DIFF
--- a/config/environments/test.yml
+++ b/config/environments/test.yml
@@ -8,3 +8,4 @@ deprecation_report_path: /tmp/deprecation_report
 replace_commitment_report_path: /tmp/replace_commitment_report
 shared_print_update_report_path: /tmp/shared_print_update_report
 etas_overlap_batch_size: 50
+rclone_config_path: /tmp/rclone.conf

--- a/lib/utils/file_transfer.rb
+++ b/lib/utils/file_transfer.rb
@@ -31,7 +31,7 @@ module Utils
       make_call("#{call_prefix} ls \"#{dir}\"")
     end
 
-    def mkdir(dir)
+    def mkdir_p(dir)
       make_call("#{call_prefix} mkdir \"#{dir}\"")
     end
 

--- a/lib/utils/file_transfer.rb
+++ b/lib/utils/file_transfer.rb
@@ -36,7 +36,7 @@ module Utils
     end
 
     # Return parsed JSON ls output
-    def ls_remote_dir(remote_dir)
+    def lsjson(remote_dir)
       # Never parse ls output, let rclone do it for us.
       call = "#{call_prefix} lsjson \"#{remote_dir}\""
       puts "call #{call}"

--- a/lib/utils/file_transfer.rb
+++ b/lib/utils/file_transfer.rb
@@ -43,8 +43,8 @@ module Utils
       response = `#{call}`
       puts "response #{response}"
       JSON.parse(response)
-    rescue JSON::ParserError => _err
-      raise Utils::FileTransferError, "could not ls #{remote_dir}"
+    rescue JSON::ParserError => err
+      raise Utils::FileTransferError, "Could not ls #{remote_dir}... #{err}"
     end
 
     private

--- a/lib/utils/file_transfer.rb
+++ b/lib/utils/file_transfer.rb
@@ -1,0 +1,76 @@
+require "services"
+require "utils/file_transfer_error"
+
+module Utils
+  # Use rclone system calls to transfer files between
+  # local and remote storage (and vice versa).
+  class FileTransfer
+    def initialize
+      # Check that config is set...
+      if Settings.rclone_config_path.nil?
+        raise "Settings.rclone_config_path missing from Settings"
+      end
+      # ... and points to an actual file.
+      unless File.exist?(Settings.rclone_config_path)
+        raise "Settings.rclone_config_path points to " \
+              "#{Settings.rclone_config_path}, which does not exist"
+      end
+    end
+
+    # Really just an alias for transfer
+    def upload(local_file, remote_dir)
+      transfer(local_file, remote_dir)
+    end
+
+    # Really just an alias for transfer
+    def download(remote_file, local_dir)
+      transfer(remote_file, local_dir)
+    end
+
+    def exists?(dir)
+      make_call("#{call_prefix} ls \"#{dir}\"")
+    end
+
+    def mkdir(dir)
+      make_call("#{call_prefix} mkdir \"#{dir}\"")
+    end
+
+    # Return parsed JSON ls output
+    def ls_remote_dir(remote_dir)
+      # Never parse ls output, let rclone do it for us.
+      call = "#{call_prefix} lsjson \"#{remote_dir}\""
+      puts "call #{call}"
+      response = `#{call}`
+      puts "response #{response}"
+      JSON.parse(response)
+    rescue JSON::ParserError => _err
+      raise Utils::FileTransferError, "could not ls #{remote_dir}"
+    end
+
+    private
+
+    def make_call(sys_call)
+      puts sys_call
+      # returns true/false based on exit code of the executed system call
+      system sys_call
+    end
+
+    # Any call will start with:
+    def call_prefix
+      "rclone --config #{Settings.rclone_config_path}"
+    end
+
+    def transfer(file, dir)
+      unless exists?(file)
+        raise Utils::FileTransferError, "file #{file} does not exist"
+      end
+
+      unless exists?(dir)
+        raise Utils::FileTransferError, "dir #{dir} does not exist"
+      end
+
+      puts "transfer #{file} to #{dir}"
+      make_call("#{call_prefix} copy #{file} #{dir}")
+    end
+  end
+end

--- a/lib/utils/file_transfer_error.rb
+++ b/lib/utils/file_transfer_error.rb
@@ -1,0 +1,5 @@
+module Utils
+  class FileTransferError < StandardError
+    # for when Utils::FileTransfer does an error
+  end
+end

--- a/spec/utils/file_transfer_spec.rb
+++ b/spec/utils/file_transfer_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "utils/file_transfer"
+require "utils/file_transfer_error"
+require "spec_helper"
+require "services"
+
+# Since rclone does not care what the remote location is,
+# and since we do not have a separate test dropbox,
+# these tests use directories under /tmp/ as a fake remote location.
+#
+# So, CAVEAT EMPTOR, it does not truly test rclone's ability to
+# transfer files to a remote location, just that the wrapper code
+# (Utils::FileTransfer) does what it promises.
+
+RSpec.describe Utils::FileTransfer do
+  let(:ft) { described_class.new }
+  # Do not change local_dir or remote_dir to something important,
+  # as they WILL be deleted during these tests.
+  let(:local_dir) { "/tmp/file_transfer_test/local" }
+  let(:remote_dir) { "/tmp/file_transfer_test/remote" }
+  let(:local_file_name) { "test_file_a.txt" }
+  let(:remote_file_name) { "test_file_b.txt" }
+  let(:local_file_path) { "#{local_dir}/#{local_file_name}" }
+  let(:remote_file_path) { "#{remote_dir}/#{remote_file_name}" }
+  let(:conf) { "config/rclone.conf" }
+  let(:missing_dir) { "/dev/null/foo" }
+  let(:missing_file) { "/dev/null/foo.txt" }
+
+  # Clean up temporary files and directories
+  before(:each) do
+    Settings.rclone_config_path = conf
+    FileUtils.mkdir_p local_dir
+    FileUtils.mkdir_p remote_dir
+    FileUtils.rm("#{local_dir}/*", force: true)
+    FileUtils.rm("#{remote_dir}/*", force: true)
+    FileUtils.touch local_file_path
+    FileUtils.touch remote_file_path
+    FileUtils.touch conf # if it does not exist FileTransfer complains
+  end
+
+  after(:each) do
+    FileUtils.rm_rf local_dir
+    FileUtils.rm_rf remote_dir
+  end
+
+  context "initialize" do
+    it "requires conf file to be set in Settings" do
+      expect { described_class.new }.not_to raise_error
+      Settings.rclone_config_path = nil
+      expect { described_class.new }.to raise_error RuntimeError
+    end
+    it "requires conf file to exist" do
+      expect { described_class.new }.not_to raise_error
+      FileUtils.rm conf
+      expect { described_class.new }.to raise_error RuntimeError
+    end
+  end
+
+  context "listing remote files" do
+    it "ls_remote_dir" do
+      parsed_json = ft.ls_remote_dir(remote_dir)
+      expect(parsed_json).to be_a Array
+      expect(parsed_json.size).to eq 1
+      expect(parsed_json.first).to be_a Hash
+      expect(parsed_json.first.keys.sort).to eq %w[IsDir MimeType ModTime Name Path Size]
+      expect(parsed_json.first["Name"]).to eq remote_file_name
+    end
+    it "throws an error if dir does not exist" do
+      expect(ft.exists?(remote_dir)).to be true
+      expect { ft.ls_remote_dir(remote_dir) }.not_to raise_error
+      expect(ft.exists?(missing_dir)).to be false
+      expect { ft.ls_remote_dir(missing_dir) }.to raise_error Utils::FileTransferError
+    end
+  end
+
+  context "#mkdir" do
+    it "can make a dir that does not exist" do
+      new_dir = "#{local_dir}/nope"
+      expect(ft.exists?(new_dir)).to be false
+      ft.mkdir(new_dir)
+      expect(ft.exists?(new_dir)).to be true
+    end
+    it "makes the whole path even if missing, like mkdir -p" do
+      new_dir = "#{local_dir}/nope1/nope2/nope3"
+      expect(ft.exists?(new_dir)).to be false
+      ft.mkdir(new_dir)
+      expect(ft.exists?(new_dir)).to be true
+    end
+  end
+
+  context "transferring files" do
+    it "upload" do
+      expect(ft.ls_remote_dir(remote_dir).count { |h| h["Name"] == local_file_name }).to eq 0
+      ft.upload(local_file_path, remote_dir)
+      expect(ft.ls_remote_dir(remote_dir).count { |h| h["Name"] == local_file_name }).to eq 1
+    end
+    it "download" do
+      expect(File.exist?("#{local_dir}/#{remote_file_name}")).to be false
+      ft.download(remote_file_path, local_dir)
+      expect(File.exist?("#{local_dir}/#{remote_file_name}")).to be true
+    end
+    it "raises if file does not exist" do
+      expect { ft.upload(missing_file, remote_dir) }.to raise_error Utils::FileTransferError
+      expect { ft.download(missing_file, remote_dir) }.to raise_error Utils::FileTransferError
+    end
+    it "raises if dir does not exist" do
+      expect { ft.upload(local_file_path, missing_dir) }.to raise_error Utils::FileTransferError
+      expect { ft.download(local_file_path, missing_dir) }.to raise_error Utils::FileTransferError
+    end
+  end
+end

--- a/spec/utils/file_transfer_spec.rb
+++ b/spec/utils/file_transfer_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Utils::FileTransfer do
   end
 
   describe "listing remote files" do
-    it "lsjson" do
+    it "provides json file listing" do
       parsed_json = ft.lsjson(remote_dir)
       expect(parsed_json).to be_a Array
       expect(parsed_json.size).to eq 1

--- a/spec/utils/file_transfer_spec.rb
+++ b/spec/utils/file_transfer_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Utils::FileTransfer do
     FileUtils.rm_rf remote_dir
   end
 
-  context "initialize" do
+  describe "initialize" do
     it "requires conf file to be set in Settings" do
       expect { described_class.new }.not_to raise_error
       Settings.rclone_config_path = nil
@@ -57,7 +57,7 @@ RSpec.describe Utils::FileTransfer do
     end
   end
 
-  context "listing remote files" do
+  describe "listing remote files" do
     it "ls_remote_dir" do
       parsed_json = ft.ls_remote_dir(remote_dir)
       expect(parsed_json).to be_a Array
@@ -74,7 +74,7 @@ RSpec.describe Utils::FileTransfer do
     end
   end
 
-  context "#mkdir_p" do
+  describe "#mkdir_p" do
     it "can make a dir that does not exist" do
       new_dir = "#{local_dir}/nope"
       expect(ft.exists?(new_dir)).to be false
@@ -89,7 +89,7 @@ RSpec.describe Utils::FileTransfer do
     end
   end
 
-  context "transferring files" do
+  describe "transferring files" do
     it "upload" do
       expect(ft.ls_remote_dir(remote_dir).count { |h| h["Name"] == local_file_name }).to eq 0
       ft.upload(local_file_path, remote_dir)

--- a/spec/utils/file_transfer_spec.rb
+++ b/spec/utils/file_transfer_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe Utils::FileTransfer do
   end
 
   describe "listing remote files" do
-    it "ls_remote_dir" do
-      parsed_json = ft.ls_remote_dir(remote_dir)
+    it "lsjson" do
+      parsed_json = ft.lsjson(remote_dir)
       expect(parsed_json).to be_a Array
       expect(parsed_json.size).to eq 1
       expect(parsed_json.first).to be_a Hash
@@ -68,9 +68,9 @@ RSpec.describe Utils::FileTransfer do
     end
     it "throws an error if dir does not exist" do
       expect(ft.exists?(remote_dir)).to be true
-      expect { ft.ls_remote_dir(remote_dir) }.not_to raise_error
+      expect { ft.lsjson(remote_dir) }.not_to raise_error
       expect(ft.exists?(missing_dir)).to be false
-      expect { ft.ls_remote_dir(missing_dir) }.to raise_error Utils::FileTransferError
+      expect { ft.lsjson(missing_dir) }.to raise_error Utils::FileTransferError
     end
   end
 
@@ -91,9 +91,9 @@ RSpec.describe Utils::FileTransfer do
 
   describe "transferring files" do
     it "upload" do
-      expect(ft.ls_remote_dir(remote_dir).count { |h| h["Name"] == local_file_name }).to eq 0
+      expect(ft.lsjson(remote_dir).count { |h| h["Name"] == local_file_name }).to eq 0
       ft.upload(local_file_path, remote_dir)
-      expect(ft.ls_remote_dir(remote_dir).count { |h| h["Name"] == local_file_name }).to eq 1
+      expect(ft.lsjson(remote_dir).count { |h| h["Name"] == local_file_name }).to eq 1
     end
     it "download" do
       expect(File.exist?("#{local_dir}/#{remote_file_name}")).to be false

--- a/spec/utils/file_transfer_spec.rb
+++ b/spec/utils/file_transfer_spec.rb
@@ -74,17 +74,17 @@ RSpec.describe Utils::FileTransfer do
     end
   end
 
-  context "#mkdir" do
+  context "#mkdir_p" do
     it "can make a dir that does not exist" do
       new_dir = "#{local_dir}/nope"
       expect(ft.exists?(new_dir)).to be false
-      ft.mkdir(new_dir)
+      ft.mkdir_p(new_dir)
       expect(ft.exists?(new_dir)).to be true
     end
     it "makes the whole path even if missing, like mkdir -p" do
       new_dir = "#{local_dir}/nope1/nope2/nope3"
       expect(ft.exists?(new_dir)).to be false
-      ft.mkdir(new_dir)
+      ft.mkdir_p(new_dir)
       expect(ft.exists?(new_dir)).to be true
     end
   end

--- a/spec/utils/file_transfer_spec.rb
+++ b/spec/utils/file_transfer_spec.rb
@@ -23,20 +23,19 @@ RSpec.describe Utils::FileTransfer do
   let(:remote_file_name) { "test_file_b.txt" }
   let(:local_file_path) { "#{local_dir}/#{local_file_name}" }
   let(:remote_file_path) { "#{remote_dir}/#{remote_file_name}" }
-  let(:conf) { "config/rclone.conf" }
+  let(:conf) { Settings.rclone_config_path }
   let(:missing_dir) { "/dev/null/foo" }
   let(:missing_file) { "/dev/null/foo.txt" }
 
   # Clean up temporary files and directories
   before(:each) do
-    Settings.rclone_config_path = conf
+    FileUtils.touch conf # if it does not exist FileTransfer complains
     FileUtils.mkdir_p local_dir
     FileUtils.mkdir_p remote_dir
     FileUtils.rm("#{local_dir}/*", force: true)
     FileUtils.rm("#{remote_dir}/*", force: true)
     FileUtils.touch local_file_path
     FileUtils.touch remote_file_path
-    FileUtils.touch conf # if it does not exist FileTransfer complains
   end
 
   after(:each) do
@@ -47,8 +46,10 @@ RSpec.describe Utils::FileTransfer do
   describe "initialize" do
     it "requires conf file to be set in Settings" do
       expect { described_class.new }.not_to raise_error
+      original_path = Settings.rclone_config_path
       Settings.rclone_config_path = nil
       expect { described_class.new }.to raise_error RuntimeError
+      Settings.rclone_config_path = original_path
     end
     it "requires conf file to exist" do
       expect { described_class.new }.not_to raise_error

--- a/spec/utils/file_transfer_spec.rb
+++ b/spec/utils/file_transfer_spec.rb
@@ -89,23 +89,30 @@ RSpec.describe Utils::FileTransfer do
     end
   end
 
-  describe "transferring files" do
-    it "upload" do
+  describe "#upload" do
+    it "puts a file in the expected location" do
       expect(ft.lsjson(remote_dir).count { |h| h["Name"] == local_file_name }).to eq 0
       ft.upload(local_file_path, remote_dir)
       expect(ft.lsjson(remote_dir).count { |h| h["Name"] == local_file_name }).to eq 1
     end
-    it "download" do
+    it "raises if file does not exist" do
+      expect { ft.upload(missing_file, remote_dir) }.to raise_error Utils::FileTransferError
+    end
+    it "raises if dir does not exist" do
+      expect { ft.upload(local_file_path, missing_dir) }.to raise_error Utils::FileTransferError
+    end
+  end
+
+  describe "#download" do
+    it "puts a file in the expected location" do
       expect(File.exist?("#{local_dir}/#{remote_file_name}")).to be false
       ft.download(remote_file_path, local_dir)
       expect(File.exist?("#{local_dir}/#{remote_file_name}")).to be true
     end
     it "raises if file does not exist" do
-      expect { ft.upload(missing_file, remote_dir) }.to raise_error Utils::FileTransferError
       expect { ft.download(missing_file, remote_dir) }.to raise_error Utils::FileTransferError
     end
     it "raises if dir does not exist" do
-      expect { ft.upload(local_file_path, missing_dir) }.to raise_error Utils::FileTransferError
       expect { ft.download(local_file_path, missing_dir) }.to raise_error Utils::FileTransferError
     end
   end


### PR DESCRIPTION
For https://hathitrust.atlassian.net/browse/DEV-358, a child task of DEV-299.
A file transfer class that simplifies uploading/downloading to/from local storage and dropbox.
Essentially just a wrapper for `rclone` system calls.