### PR TITLE
Dev 360, adding DirectoryLocator

### DIFF
--- a/lib/data_sources/directory_locator.rb
+++ b/lib/data_sources/directory_locator.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "utils/file_transfer"
+
+module DataSources
+  # Given a base and and org id, provide paths (strings) to the org's dirs.
+  # Assumes identical structure on the remote and local side,
+  # just with a different base path, and does not know/care if the paths
+  # that it provides actually point to anything real.
+  # E.g.:
+  # remote_d = DataSources::DirectoryLocator.new("dropbox:foo/bar/member_data", "foo")
+  # local_d = DataSources::DirectoryLocator.new("/tmp/member_data", "foo")
+  # remote_holdings = remote_d.holdings_current
+  # local_holdings = local_d.holdings_current
+  class DirectoryLocator
+    attr_reader :root, :organization
+    def initialize(root, organization)
+      @root = root # the part of the file system where the member directories start
+      @organization = organization
+      # In the off chance the object is created 1s before jan 1st,
+      # at least we'll be consistent across the life of this object.
+      @year = Time.new.year.to_s
+    end
+
+    # The base directory for the organization.
+    def base
+      File.join(@root, "#{organization}-hathitrust-member-data")
+    end
+
+    # The holdings parent directory for the organization
+    def holdings
+      File.join(base, "print\ holdings")
+    end
+
+    # The current-year holdings directory
+    def holdings_current
+      File.join(holdings, @year)
+    end
+
+    # The shared print directory (not divided into years like holdings are)
+    def shared_print
+      File.join(base, "shared\ print")
+    end
+
+    # This is where HT uploads reports and such for the member to access.
+    def analysis
+      File.join(base, "analysis")
+    end
+
+    # Ensure that each expected path points to an existing dir (mkdir if not)
+    def ensure!
+      @ft ||= Utils::FileTransfer.new
+      @ft.mkdir_p(holdings_current)
+      @ft.mkdir_p(shared_print)
+      @ft.mkdir_p(analysis)
+    end
+  end
+end

--- a/spec/data_sources/directory_locator_spec.rb
+++ b/spec/data_sources/directory_locator_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "data_sources/directory_locator"
+
+# Conf file must exist, or Utils::FileTransfer raises an error.
+FileUtils.touch(Settings.rclone_config_path)
+
+RSpec.describe DataSources::DirectoryLocator do
+  let(:org) { "test" }
+  let(:root) { "/tmp/directory_locator_test" }
+  let(:dl) { described_class.new(root, org) }
+  let(:year) { Time.new.year.to_s }
+  let(:base_x) { "/tmp/directory_locator_test/test-hathitrust-member-data" }
+  let(:holdings_x) { "/tmp/directory_locator_test/test-hathitrust-member-data/print holdings" }
+  let(:sp_x) { "/tmp/directory_locator_test/test-hathitrust-member-data/shared print" }
+  let(:analysis_x) { "/tmp/directory_locator_test/test-hathitrust-member-data/analysis" }
+
+  before(:each) do
+    FileUtils.rm_rf(root)
+  end
+
+  after(:each) do
+    FileUtils.rm_rf(root)
+  end
+
+  describe "attr_reader" do
+    it "are set on initialize and readable" do
+      expect(dl.root).to eq root
+      expect(dl.organization).to eq org
+      expect { dl.root = "foo" }.to raise_error NoMethodError
+      expect { dl.organization = "bar" }.to raise_error NoMethodError
+    end
+  end
+
+  describe "the path methods return paths based on root and organization" do
+    it "#base" do
+      expect(dl.base).to eq base_x
+    end
+    it "#holdings" do
+      expect(dl.holdings).to eq holdings_x
+    end
+    it "#holdings_current" do
+      expect(dl.holdings_current).to eq File.join(holdings_x, year)
+    end
+    it "#shared_print" do
+      expect(dl.shared_print).to eq sp_x
+    end
+    it "#analysis" do
+      expect(dl.analysis).to eq analysis_x
+    end
+  end
+
+  describe "#ensure!" do
+    it "ensures that the directories exist" do
+      # The directories don't actually exist ...
+      expect(Dir.exist?(dl.base)).to be false
+      expect(Dir.exist?(dl.holdings)).to be false
+      expect(Dir.exist?(dl.shared_print)).to be false
+      expect(Dir.exist?(dl.analysis)).to be false
+      # ... until we make them.
+      expect { dl.ensure! }.to_not raise_error
+      expect(Dir.exist?(dl.base)).to be true
+      expect(Dir.exist?(dl.holdings)).to be true
+      expect(Dir.exist?(dl.shared_print)).to be true
+      expect(Dir.exist?(dl.analysis)).to be true
+    end
+  end
+end


### PR DESCRIPTION
`DataSources::DirectoryLocator` knows about the directories (local or remote, it don't care) where a member's holdings, shared print & analysis files reside.