### PR TITLE
Small fixes for Shared Print reports (DEV-250, DEV-361)

### DIFF
--- a/lib/reports/oclc_registration.rb
+++ b/lib/reports/oclc_registration.rb
@@ -55,7 +55,7 @@ module Reports
         com.oclc_sym,
         collection_id(com.oclc_sym),
         "committed to retain",
-        com.committed_date,
+        com.committed_date.strftime("%Y%m%d"),
         "20421231"
       ].join("\t")
     end
@@ -65,15 +65,15 @@ module Reports
     def collection_id(oclc_sym)
       if @collection_memo.empty?
         Utils::TSVReader.new(@collection_id_map_path).run do |rec|
-          @collection_memo[rec[:oclc_sym]] = rec[:collection_id]
+          @collection_memo[rec[:oclc_sym].upcase] = rec[:collection_id]
         end
       end
-      if @collection_memo[oclc_sym].nil?
+      if @collection_memo[oclc_sym.upcase].nil?
         raise KeyError,
           "No collection_id for oclc_sym \"#{oclc_sym}\"" \
           "in #{@collection_id_map_path}"
       end
-      @collection_memo[oclc_sym]
+      @collection_memo[oclc_sym.upcase]
     end
 
     private
@@ -83,7 +83,7 @@ module Reports
       # Require that a path for a dir for output files be set.
       raise "Settings.oclc_registration_report_path not set" if @outd.nil?
       # Require that a path to a file with oclc_collection mapping be set.
-      raise "Settings.oclc_collection_id_map not set" if @collection_id_map_path.nil?
+      raise "Settings.oclc_collection_id_map_path not set" if @collection_id_map_path.nil?
     end
   end
 end

--- a/lib/reports/rare_uncommitted.rb
+++ b/lib/reports/rare_uncommitted.rb
@@ -107,11 +107,13 @@ module Reports
       return enum_for(:output_organization) unless block_given?
 
       header = [
-        "organization",
+        "member_id",
         "local_id",
         "gov_doc",
         "condition",
-        "OCN"
+        "OCN",
+        "overlap_ht",
+        "overlap_sp"
       ].join("\t")
       yield header
 
@@ -129,7 +131,9 @@ module Reports
             holding.local_id,
             govdoc_bool_2_int,
             holding.condition,
-            holding.ocn
+            holding.ocn,
+            cluster_h(cluster),
+            cluster_sp_h(cluster)
           ].join("\t")
           yield record
         end

--- a/spec/reports/oclc_registration_spec.rb
+++ b/spec/reports/oclc_registration_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe Reports::OCLCRegistration do
     expect(rep.collection_id("BAR")).to eq "456"
   end
 
+  it "looks up collection_id case-insensitively" do
+    expect(rep.collection_id("FOO")).to eq "123"
+    expect(rep.collection_id("foo")).to eq "123"
+  end
+
   it "throws a key error if there is no mapping for an oclc_sym" do
     expect { rep.collection_id("QUX") }.to raise_error KeyError
   end
@@ -28,7 +33,7 @@ RSpec.describe Reports::OCLCRegistration do
       "FOO",
       "123",
       "committed to retain",
-      com.committed_date,
+      com.committed_date.strftime("%Y%m%d"),
       "20421231"
     ].join("\t")
   end

--- a/spec/reports/rare_uncommitted_spec.rb
+++ b/spec/reports/rare_uncommitted_spec.rb
@@ -277,4 +277,32 @@ RSpec.describe Reports::RareUncommitted do
       expect(counts).to eq expected
     end
   end
+
+  describe "#output_organization" do
+    it "returns an array of report rows, incl header" do
+      cluster_tap_save [hti1, hol1_org1, hti2, hol2_org1, spc2_org1]
+      out_arr = report(organization: org1, max_h: 5).output_organization.to_a
+      expect(out_arr).to be_a Array
+      expect(out_arr.size).to eq 2
+      compare_header = [
+        "member_id",
+        "local_id",
+        "gov_doc",
+        "condition",
+        "OCN",
+        "overlap_ht",
+        "overlap_sp"
+      ].join("\t")
+      header = out_arr.shift
+      expect(header).to eq compare_header
+
+      row_data = out_arr.shift.split("\t")
+      expect(row_data[0]).to eq "umich"
+      expect(row_data[1]).to eq hol1_org1.local_id
+      expect(row_data[2]).to eq hol1_org1.gov_doc_flag ? "1" : "0"
+      expect(row_data[3]).to eq hol1_org1.condition
+      expect(row_data[4]).to eq hol1_org1.ocn.to_s
+      puts out_arr
+    end
+  end
 end


### PR DESCRIPTION
DEV-250:
* change a column header
* add 2 overlap-count columns (Weltin wanted 3 but the 3rd one is a whole nother thing that we spun off into a separate ticket https://hathitrust.atlassian.net/browse/DEV-412 for later)

DEV-361: 
* change oclc_sym lookup to be case-insensitive
* format dates into %Ymd format, no delimiters
* change raise-message for when the path to the oclc_sym_collection_map is missing