### PR TITLE
Configuration for sidekiq

### DIFF
--- a/bin/load_test_data.sh
+++ b/bin/load_test_data.sh
@@ -7,7 +7,7 @@
 # Run this outside docker; it will start all required services.
 # Running this script assumes you have already run --rm bin/setup_dev.sh
 
-docker-compose up -d sidekiq_web processor redis
+docker-compose up --scale processor=3 -d sidekiq_web processor redis 
 docker-compose run --rm dev bin/setup/wait-for redis:6379 -- echo "redis is ready"
 
 echo "generating fake data"

--- a/bin/setup/setup_dev.sh
+++ b/bin/setup/setup_dev.sh
@@ -2,7 +2,7 @@
 
 $(dirname ${BASH_SOURCE[0]})/setup_test.sh
 
-docker-compose up -d mongo_dev pushgateway
+docker-compose up -d mongo_dev pushgateway redis
 docker-compose run --rm dev bin/setup/wait-for mongo_dev:27017 -- echo "mongo is ready"
 docker-compose exec -T mongo_dev bash /tmp/bin/setup/rs_initiate.sh mongo_dev
 docker-compose run --rm -e MONGOID_ENV=development dev bundle exec ruby lib/tasks/build_database.rb

--- a/bin/sidekiq_web.ru
+++ b/bin/sidekiq_web.ru
@@ -1,5 +1,6 @@
 require "sidekiq"
 require "sidekiq/web"
+require_relative "../config/initializers/sidekiq"
 
 SESSION_KEY = ".session.key"
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,15 @@
+require "sidekiq"
+
+# Add anything here you need for sidekiq initialization
+
+redis_config = {
+  url: "redis://redis"
+}
+
+Sidekiq.configure_server do |config|
+  config.redis = redis_config
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = redis_config
+end

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,13 +1,13 @@
 production:
   clients:
     default:
-      database: holdings
+      database: "<%= Settings.mongodb.database %>"
       hosts:
         - "<%= Settings.mongodb.host %>"
       options:
-        user: holdings
+        user: "<%= Settings.mongodb.username %>"
         password: "<%= Settings.mongodb.password %>"
-        auth_source: admin
+        auth_source: "<%= Settings.mongodb.auth_source %>"
   options:
     raise_not_found_error: false
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,8 +13,11 @@ large_cluster_ocns: /usr/src/app/config/large_cluster_ocns.txt
 loading_flag_path: <%= ENV["LOADING_FLAG_PATH"] %>
 local_report_path: <%= ENV["LOCAL_REPORT_PATH"] %>
 mongodb:
+  database: holdings
+  username: holdings
   host: <%= ENV["MONGODB_HOST"] %>
   password: <%= ENV["MONGODB_PASSWORD"] %>
+  auth_source: admin
 pushgateway: <%= ENV["PUSHGATEWAY"] %>
 rclone_config_path: <%= ENV["RCLONE_CONFIG_PATH"] %>
 replace_commitment_report_path: <%= ENV["REPLACE_COMMITMENT_REPORT_PATH"] %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       - .:/usr/src/app
       - gem_cache:/gems
     environment:
-      REDIS_URL: redis://redis/
       MYSQL_CONNECTION_STRING: "mysql2://ht_repository:ht_repository@mariadb/ht_repository"
       PUSHGATEWAY: http://pushgateway:9091
     entrypoint: bundle exec ruby bin/phctl.rb
@@ -29,11 +28,10 @@ services:
       - .:/usr/src/app
       - gem_cache:/gems
       - ./example/datasets:/tmp/datasets
-    command: bundle exec sidekiq -r ./lib/sidekiq_jobs.rb
+    command: bundle exec sidekiq -c 1 -r ./lib/sidekiq_jobs.rb
     environment:
       MYSQL_CONNECTION_STRING: "mysql2://ht_repository:ht_repository@mariadb/ht_repository"
       PUSHGATEWAY: http://pushgateway:9091
-      REDIS_URL: redis://redis/
 
   mongo_dev:
     image: mongo:5.0.9

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -15,7 +15,7 @@ require "prometheus/client/push"
 
 Services = Canister.new
 Services.register(:mongo!) do
-  Mongoid.load!("mongoid.yml", Settings.environment)
+  Mongoid.load!(File.join(__dir__, "..", "config", "mongoid.yml"), Settings.environment)
 end
 
 Services.register(:holdings_db) { DataSources::HoldingsDB.new }

--- a/lib/sidekiq_jobs.rb
+++ b/lib/sidekiq_jobs.rb
@@ -19,6 +19,8 @@ require "shared_print/updater"
 require "shared_print/replacer"
 require "shared_print/deprecator"
 
+require_relative "../config/initializers/sidekiq"
+
 # Don't want to do this by default when we aren't running under sidekiq
 Services.register(:logger) { Sidekiq.logger }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ SimpleCov.start
 Sidekiq.strict_args!
 Sidekiq::Testing.inline!
 
-Mongoid.load!("mongoid.yml", Settings.environment)
+Services.mongo!
 
 RSpec.configure do |config|
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
* Add location for sidekiq/redis configuration
* Expose more configuration for mongodb -- holdings-testing / mongo 5 needed some different options here

sidekiq-web still isn't working, I suspect because the inline config overrides the provided config in the sidekiq initializer.