### PR TITLE
fix for DEV-454

### DIFF
--- a/lib/shared_print/update_record.rb
+++ b/lib/shared_print/update_record.rb
@@ -85,7 +85,9 @@ module SharedPrint
         local_item_location: :string,
         local_shelving_type: :string,
         oclc_sym: :string, # might be called oclc_symbol in places, TODO: check that.
-        retention_date: :date_time
+        retention_date: :date_time,
+        new_local_id: :string,
+        new_ocn: :integer
       }
     end
 

--- a/lib/shared_print/updater.rb
+++ b/lib/shared_print/updater.rb
@@ -53,10 +53,25 @@ module SharedPrint
       commitment = @commitments.first
       @update_record.updater_fields.each do |k, v|
         report "updating #{k}=#{v}"
-        commitment.send("#{k}=", v)
+        commitment.send("#{strip_new_from_symbol(k)}=", v)
       end
       report "OK."
       commitment.save
+    end
+
+    # Remove /^new_/ from :new_local_id and :new_ocn.
+    def strip_new_from_symbol(key)
+      # :new_ocn  -> :ocn
+      # :local_id -> :local_id
+      # :anything_else -> :anything_else (output=input)
+      case key
+      when :new_ocn
+        :ocn
+      when :new_local_id
+        :local_id
+      else
+        key
+      end
     end
 
     # Removes local_id from search and tries finding commitments again.


### PR DESCRIPTION
Problem: You cannot update `local_id` or `ocn` with the existing shared print update-script.
Solution: Now, in order to update `local_id` and/or `ocn`, add the columns `new_local_id` and/or `new_ocn` to the update file, like:

```
organization  |ocn       |local_id           |new_ocn
bu            |8061382   |99193019080001161  |898915865
bu            |6785135   |99191292180001161  |263616332
bu            |4738078   |99177938200001161  |76925351
```
The "new_" prefix helps us distinguish the update field (`new_local_id`, `new_ocn`) from the lookup field (`local_id`, `ocn`).
Pass to `phctl sp update <file>` as before.