### PR TITLE
DEV-405, DEV-424: sidekiq/redis configuration

### DIFF
--- a/bin/sidekiq_web.ru
+++ b/bin/sidekiq_web.ru
@@ -11,9 +11,7 @@ if !File.exist?(SESSION_KEY)
   end
 end
 
-Sidekiq.configure_client do |config|
-  config.redis = {size: 1}
-end
+Services.redis_config[:size] = 1
 
 use Rack::Session::Cookie, secret: File.read(SESSION_KEY), same_site: true, max_age: 86400
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,10 +1,24 @@
 require "sidekiq"
+require "services"
 
 # Add anything here you need for sidekiq initialization
 
-redis_config = {
-  url: "redis://redis"
-}
+if ENV["REDIS_MASTER_SET_NAME"] && ENV["REDIS_HEADLESS_SERVICE"]
+  require "resolv"
+
+  # https://github.com/mperham/sidekiq/issues/5194
+  redis_config = {
+    host: ENV["REDIS_MASTER_SET_NAME"],
+    password: ENV["REDIS_PASSWORD"],
+    sentinels: Resolv.getaddresses(ENV["REDIS_HEADLESS_SERVICE"]).map do |address|
+      {host: address, port: 26379, password: ENV["REDIS_PASSWORD"]}
+    end
+  }
+else
+  redis_config = {
+    url: Settings.redis_url || "redis://redis"
+  }
+end
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,24 +6,28 @@ require "services"
 if ENV["REDIS_MASTER_SET_NAME"] && ENV["REDIS_HEADLESS_SERVICE"]
   require "resolv"
 
-  # https://github.com/mperham/sidekiq/issues/5194
-  redis_config = {
-    host: ENV["REDIS_MASTER_SET_NAME"],
-    password: ENV["REDIS_PASSWORD"],
-    sentinels: Resolv.getaddresses(ENV["REDIS_HEADLESS_SERVICE"]).map do |address|
-      {host: address, port: 26379, password: ENV["REDIS_PASSWORD"]}
-    end
-  }
+  Services.register(:redis_config) do
+    # https://github.com/mperham/sidekiq/issues/5194
+    {
+      host: ENV["REDIS_MASTER_SET_NAME"],
+      password: ENV["REDIS_PASSWORD"],
+      sentinels: Resolv.getaddresses(ENV["REDIS_HEADLESS_SERVICE"]).map do |address|
+        {host: address, port: 26379, password: ENV["REDIS_PASSWORD"]}
+      end
+    }
+  end
 else
-  redis_config = {
-    url: Settings.redis_url || "redis://redis"
-  }
+  Services.register(:redis_config) do
+    {
+      url: Settings.redis_url || "redis://redis"
+    }
+  end
 end
 
 Sidekiq.configure_server do |config|
-  config.redis = redis_config
+  config.redis = Services.redis_config
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = redis_config
+  config.redis = Services.redis_config
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -54,3 +54,4 @@ Services.register(:prometheus_metrics) do
 end
 
 Services.register(:progress_tracker) { Utils::PushMetricsMarker }
+Services.register(:redis_config) { raise "Redis not configured" }


### PR DESCRIPTION
- inline configuration when using redis sentinel (rather than putting in ht_tanka)
- ensure sidekiq web doesn't clobber existing redis configuration

Basically, we put the configuration we want in `Services.redis_config` and can get at it / modify it there as needed; the default if we try to use it without configuring it is to raise an exception. The `Sidekiq.configure_server` / `Sidekiq.configure_client` blocks are basically setting up callbacks to tell Sidekiq where to get the configuration from when it needs it rather than providing it directly.. this is just the style of configuration that Sidekiq (and many other Ruby gems like rspec) use, but it does make things a bit more confusing