### PR TITLE
getting scrubrunner to batch load with sidekiq

### DIFF
--- a/lib/phctl.rb
+++ b/lib/phctl.rb
@@ -169,9 +169,10 @@ module PHCTL
     # standard:enable Lint/Debugger
 
     desc "scrub ORG", "Download ORG's new files from DropBox and load them"
+    option :force_holding_loader_cleanup_test, type: :boolean, default: false
+    # Only set force_holding_loader_cleanup_test to true in testing.
     def scrub(org)
-      # Jobs::Common.perform_async("Scrub::ScrubRunner", options)
-      Scrub::ScrubRunner.new(org).run
+      Scrub::ScrubRunner.new(org, options).run
     end
 
     # report

--- a/lib/scrub/chunker.rb
+++ b/lib/scrub/chunker.rb
@@ -9,7 +9,7 @@ module Scrub
   # Take a glob of scrubbed files, sort, and then make
   # #{chunk_count} equal-sized (roughly) files from them.
   class Chunker
-    attr_reader :glob, :chunks
+    attr_reader :glob, :chunks, :tmp_chunk_dir
     def initialize(glob, chunk_count: 16, add_uuid: false, out_ext: nil)
       @glob = glob # to one or more files
       @chunks = [] # store paths to output files here

--- a/lib/utils/file_transfer.rb
+++ b/lib/utils/file_transfer.rb
@@ -52,7 +52,8 @@ module Utils
     def make_call(sys_call)
       Services.logger.info sys_call
       # returns true/false based on exit code of the executed system call
-      system sys_call
+      # direct output to devnull so we don't pollute stderr
+      system("#{sys_call} > /dev/null")
     end
 
     # Any call will start with:

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -170,7 +170,8 @@ RSpec.describe "phctl integration" do
       # Verify precondition:
       expect(File.exist?(logfile)).to be false
       # Actual tests:
-      expect { phctl(*%w[scrub umich]) }.to change { cluster_count(:holdings) }.by(6)
+      # Only set force_holding_loader_cleanup_test to true in testing.
+      expect { phctl(*%w[scrub umich --force_holding_loader_cleanup_test]) }.to change { cluster_count(:holdings) }.by(6)
       expect(File.exist?(logfile)).to be true
       expect(File.exist?(local_d)).to be true
     end

--- a/spec/scrub/scrub_runner_spec.rb
+++ b/spec/scrub/scrub_runner_spec.rb
@@ -5,10 +5,12 @@ require "scrub/scrub_runner"
 require "data_sources/directory_locator"
 require "data_sources/ht_organizations"
 require "date"
+require "loader/holding_loader"
 
 RSpec.describe Scrub::ScrubRunner do
   let(:org1) { "umich" }
-  let(:sr) { described_class.new(org1) }
+  # Only set force_holding_loader_cleanup_test to true in testing.
+  let(:sr) { described_class.new(org1, {"force_holding_loader_cleanup_test" => true}) }
   let(:fixture_file) { "spec/fixtures/umich_mono_full_20220101.tsv" }
 
   before(:each) do


### PR DESCRIPTION
This PR adds `Sidekiq::Batch` to `Scrub::ScrubRunner`.
When a batch completes it triggers some cleanup (done by `Loader::HoldingLoader::Cleanup`), and we have to fake this in testing (where sidekiq is not running), hence the `force_holding_loader_cleanup_test` stuff.