### PR TITLE
Dev 324

### DIFF
--- a/config/environments/test.yml
+++ b/config/environments/test.yml
@@ -17,7 +17,9 @@ rclone_config_path: /tmp/rclone.conf
 remote_member_data: /tmp/remote_member_data
 replace_commitment_report_path: /tmp/replace_commitment_report
 scrub_base_path: /tmp/scrub_data
+scrub_chunk_count: 4
 scrub_chunk_work_dir: /tmp
+scrub_line_count_diff_max: 0.05
 shared_print_report_path: /tmp/shared_print_reports
 shared_print_update_report_path: /tmp/shared_print_update_report
 slack_endpoint: http://slack.test/endpoint

--- a/lib/loader/holding_loader.rb
+++ b/lib/loader/holding_loader.rb
@@ -62,6 +62,8 @@ module Loader
           options["scrub_log"],
           options["remote_dir"]
         )
+        Services.logger.info "moving loaded file to scrubber.member_loaded"
+        FileUtils.mv(options["loaded_file"], options["loaded_dir"])
         Services.logger.info "cleanup done"
       else
         raise "well that was not the status i was hoping for (#{status})"

--- a/lib/phctl.rb
+++ b/lib/phctl.rb
@@ -169,8 +169,9 @@ module PHCTL
     # standard:enable Lint/Debugger
 
     desc "scrub ORG", "Download ORG's new files from DropBox and load them"
-    option :force_holding_loader_cleanup_test, type: :boolean, default: false
     # Only set force_holding_loader_cleanup_test to true in testing.
+    option :force_holding_loader_cleanup_test, type: :boolean, default: false
+    option :force, type: :boolean, default: false
     def scrub(org)
       Scrub::ScrubRunner.new(org, options).run
     end

--- a/lib/scrub/autoscrub.rb
+++ b/lib/scrub/autoscrub.rb
@@ -101,10 +101,3 @@ module Scrub
     end
   end
 end
-
-if $PROGRAM_NAME == __FILE__
-  ARGV.each do |path|
-    autoscrub = Scrub::AutoScrub.new(path)
-    autoscrub.run
-  end
-end

--- a/lib/scrub/autoscrub.rb
+++ b/lib/scrub/autoscrub.rb
@@ -16,7 +16,7 @@ module Scrub
   class AutoScrub
     # Won't put in accessors unless we find a solid case for running this
     # by another ruby class.
-    attr_reader :output_struct, :out_files, :logger_path
+    attr_reader :output_struct, :out_files, :logger_path, :item_type
 
     def initialize(path)
       @path = path

--- a/lib/scrub/record_counter.rb
+++ b/lib/scrub/record_counter.rb
@@ -1,0 +1,72 @@
+require "scrub/scrub_output_structure"
+require "settings"
+require "utils/line_counter"
+
+module Scrub
+  class RecordCounter
+    attr_reader :organization, :item_type, :struct
+    def initialize(organization, item_type)
+      @organization = organization
+      @item_type = item_type
+      @struct = Scrub::ScrubOutputStructure.new(organization)
+      @rx = /^#{@organization}_#{@item_type}_.+\.ndj$/
+      if Settings.scrub_line_count_diff_max.nil?
+        raise ArgumentError, "Missing Settings.scrub_line_count_diff_max"
+      end
+    end
+
+    # Compare loaded and ready and see if the size diff is acceptable,
+    # or if we need to tell the humans about this.
+    def acceptable_diff?
+      if count_ready.zero?
+        # "There is nothing new to load."
+        false
+      elsif count_loaded.zero?
+        # "No previous records loaded for #{@organization}. Any diff is OK."
+        true
+      else
+        # Check if the percent diff is less than the diff_max
+        diff < Settings.scrub_line_count_diff_max
+      end
+    end
+
+    def last_loaded
+      @last_loaded ||= last_file(@struct.member_loaded)
+    end
+
+    def last_ready
+      @last_ready ||= last_file(@struct.member_ready_to_load)
+    end
+
+    def count_loaded
+      @count_loaded ||= count(last_loaded)
+    end
+
+    def count_ready
+      @count_ready ||= count(last_ready)
+    end
+
+    def diff
+      @diff ||= ((count_ready - count_loaded) / count_loaded.to_f).abs
+    end
+
+    private
+
+    def count(path)
+      if path.nil?
+        0
+      else
+        Utils::LineCounter.count_file_lines(path)
+      end
+    end
+
+    def last_file(path)
+      matching_entries = path.entries.select { |f| f.match?(@rx) }
+      if matching_entries.empty?
+        nil
+      else
+        File.join(path, matching_entries.max)
+      end
+    end
+  end
+end

--- a/lib/scrub/scrub_runner.rb
+++ b/lib/scrub/scrub_runner.rb
@@ -155,6 +155,8 @@ module Scrub
       File.join(local_dir, File.split(remote_file).last)
     end
 
+    private
+
     def remote_dir
       DataSources::DirectoryLocator.for(:remote, @organization).holdings_current
     end

--- a/lib/scrub/scrub_runner.rb
+++ b/lib/scrub/scrub_runner.rb
@@ -15,9 +15,12 @@ require "loader/file_loader"
 require "loader/holding_loader"
 require "scrub/autoscrub"
 require "scrub/chunker"
+require "scrub/malformed_file_error"
+require "scrub/record_counter"
 require "sidekiq_jobs"
 require "sidekiq/batch"
 require "utils/file_transfer"
+require "utils/line_counter"
 
 # Example:
 # runner = Scrub::ScrubRunner.new(ORG)
@@ -28,9 +31,11 @@ module Scrub
   class ScrubRunner
     def initialize(organization, options = {})
       @organization = organization
+      # @force: force loading a file even if it exceeds diff limit
+      @force = options["force"] || false
+      # @force_holding_loader_cleanup_test: only set to true in testing.
+      @force_holding_loader_cleanup_test = options["force_holding_loader_cleanup_test"] || false
       @ft = Utils::FileTransfer.new
-      # Only set force_holding_loader_cleanup_test to true in testing.
-      @force_holding_loader_cleanup_test = options["force_holding_loader_cleanup_test"]
       validate
     end
 
@@ -41,8 +46,20 @@ module Scrub
       if Settings.remote_member_data.nil?
         raise "Need Settings.remote_member_data to be set"
       end
+      if Settings.scrub_chunk_count.nil?
+        raise "Need Settings.scrub_chunk_count to be set"
+      end
+      if Settings.scrub_line_count_diff_max.nil?
+        raise "Need Settings.scrub_line_count_diff_max to be set"
+      end
       if @organization.nil?
         raise "Need @organization to be set"
+      end
+      unless [true, false].include?(@force)
+        raise "Need @force to be true/false"
+      end
+      unless [true, false].include?(@force_holding_loader_cleanup_test)
+        raise "Need @force_holding_loader_cleanup_test to be true/false"
       end
     end
 
@@ -60,9 +77,26 @@ module Scrub
       downloaded_file = download_to_work_dir(file)
       scrubber = Scrub::AutoScrub.new(downloaded_file)
       scrubber.run
+
+      rc = Scrub::RecordCounter.new(@organization, scrubber.item_type)
+      unless rc.acceptable_diff? || @force
+        raise MalformedFileError, [
+          "Unacceptable diff for #{@organization} when scrubbing #{file["Name"]}.",
+          "Last loaded file (#{rc.last_loaded}) had #{rc.count_loaded} records",
+          "The scrubbed file (#{rc.last_ready}) has #{rc.count_ready} records.",
+          "Diff is #{rc.diff}, which is greater than Settings.scrub_line_count_diff_max",
+          "... which is #{Settings.scrub_line_count_diff_max}.",
+          "Run again with --force to load anyways."
+        ].join("\n")
+      end
+
       scrubber.out_files.each do |scrubber_out_file|
         Services.logger.info "Ready to split #{scrubber_out_file} into chunks"
-        chunker = Scrub::Chunker.new(scrubber_out_file, chunk_count: 4, out_ext: "ndj")
+        chunker = Scrub::Chunker.new(
+          scrubber_out_file,
+          chunk_count: Settings.scrub_chunk_count,
+          out_ext: "ndj"
+        )
         chunker.run
         batch = Sidekiq::Batch.new
         batch.description = "Holdings load for #{scrubber_out_file}"
@@ -86,10 +120,27 @@ module Scrub
           Loader::HoldingLoader::Cleanup.new.on_success(:success, cleanup_data)
         end
       end
-    rescue
+    rescue => err
       # If the scrub failed, remove the file from local storage, that we may try again.
+      Services.logger.error err
       FileUtils.rm(downloaded_file)
       raise "Scrub failed, removing downloaded file #{downloaded_file}"
+    end
+
+    # If we just scrubbed a umich mono we want to know what the line count was
+    # in the most recent umich mono so we can warn if that number is way +/-.
+    def count_lines_last_loaded(scrubber)
+      # Look for files by the same org and item_type
+      rx = /^#{scrubber.output_struct.member_id}_#{scrubber.item_type}.+\.ndj$/
+      loaded = scrubber.output_struct.member_loaded.entries.select { |f| f.match?(rx) }
+      # If we find any, count lines of the most recent one.
+      if loaded.empty?
+        0
+      else
+        Utils::LineCounter.count_file_lines(
+          File.join(scrubber.output_struct.member_loaded, loaded.max)
+        )
+      end
     end
 
     # Check org-uploaded files for any not previously seen files

--- a/lib/scrub/scrub_runner.rb
+++ b/lib/scrub/scrub_runner.rb
@@ -105,22 +105,6 @@ module Scrub
       raise "Scrub failed, removing downloaded file #{downloaded_file}"
     end
 
-    # If we just scrubbed a umich mono we want to know what the line count was
-    # in the most recent umich mono so we can warn if that number is way +/-.
-    def count_lines_last_loaded(scrubber)
-      # Look for files by the same org and item_type
-      rx = /^#{scrubber.output_struct.member_id}_#{scrubber.item_type}.+\.ndj$/
-      loaded = scrubber.output_struct.member_loaded.entries.select { |f| f.match?(rx) }
-      # If we find any, count lines of the most recent one.
-      if loaded.empty?
-        0
-      else
-        Utils::LineCounter.count_file_lines(
-          File.join(scrubber.output_struct.member_loaded, loaded.max)
-        )
-      end
-    end
-
     # Check org-uploaded files for any not previously seen files
     def check_new_files
       # Return new (as in not in old) files

--- a/lib/scrub/scrub_runner.rb
+++ b/lib/scrub/scrub_runner.rb
@@ -39,30 +39,6 @@ module Scrub
       validate
     end
 
-    def validate
-      if Settings.local_member_data.nil?
-        raise "Need Settings.local_member_data to be set"
-      end
-      if Settings.remote_member_data.nil?
-        raise "Need Settings.remote_member_data to be set"
-      end
-      if Settings.scrub_chunk_count.nil?
-        raise "Need Settings.scrub_chunk_count to be set"
-      end
-      if Settings.scrub_line_count_diff_max.nil?
-        raise "Need Settings.scrub_line_count_diff_max to be set"
-      end
-      if @organization.nil?
-        raise "Need @organization to be set"
-      end
-      unless [true, false].include?(@force)
-        raise "Need @force to be true/false"
-      end
-      unless [true, false].include?(@force_holding_loader_cleanup_test)
-        raise "Need @force_holding_loader_cleanup_test to be true/false"
-      end
-    end
-
     def run
       Services.logger.info "Running org #{@organization}."
       new_files = check_new_files
@@ -104,7 +80,9 @@ module Scrub
           "tmp_chunk_dir" => chunker.tmp_chunk_dir,
           "organization" => @organization,
           "scrub_log" => scrubber.logger_path,
-          "remote_dir" => remote_dir
+          "remote_dir" => remote_dir,
+          "loaded_file" => scrubber_out_file,
+          "loaded_dir" => scrubber.output_struct.member_loaded
         }
         batch.on(:success, Loader::HoldingLoader::Cleanup, cleanup_data)
         batch.jobs do
@@ -183,6 +161,30 @@ module Scrub
 
     def local_dir
       DataSources::DirectoryLocator.for(:local, @organization).holdings_current
+    end
+
+    def validate
+      if Settings.local_member_data.nil?
+        raise "Need Settings.local_member_data to be set"
+      end
+      if Settings.remote_member_data.nil?
+        raise "Need Settings.remote_member_data to be set"
+      end
+      if Settings.scrub_chunk_count.nil?
+        raise "Need Settings.scrub_chunk_count to be set"
+      end
+      if Settings.scrub_line_count_diff_max.nil?
+        raise "Need Settings.scrub_line_count_diff_max to be set"
+      end
+      if @organization.nil?
+        raise "Need @organization to be set"
+      end
+      unless [true, false].include?(@force)
+        raise "Need @force to be true/false"
+      end
+      unless [true, false].include?(@force_holding_loader_cleanup_test)
+        raise "Need @force_holding_loader_cleanup_test to be true/false"
+      end
     end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe "phctl integration" do
       expect(File.exist?(logfile)).to be false
       # Actual tests:
       # Only set force_holding_loader_cleanup_test to true in testing.
-      expect { phctl(*%w[scrub umich --force_holding_loader_cleanup_test]) }.to change { cluster_count(:holdings) }.by(6)
+      expect { phctl(*%w[scrub umich --force_holding_loader_cleanup_test --force]) }.to change { cluster_count(:holdings) }.by(6)
       expect(File.exist?(logfile)).to be true
       expect(File.exist?(local_d)).to be true
     end

--- a/spec/scrub/record_counter_spec.rb
+++ b/spec/scrub/record_counter_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "scrub/record_counter"
+
+RSpec.describe Scrub::RecordCounter do
+  let(:org) { "umich" }
+  let(:item_type) { "mono" }
+  let(:rc) { described_class.new(org, item_type) }
+  let(:loaded_file) {
+    File.join(rc.struct.member_loaded, "#{org}_#{item_type}_2020-01-01.ndj")
+  }
+  let(:ready_file) {
+    File.join(rc.struct.member_ready_to_load, "#{org}_#{item_type}_2021-01-01.ndj")
+  }
+  let(:hundo) { 100 }
+  let(:small_diff) { (Settings.scrub_line_count_diff_max * 100) - 1 }
+  before(:each) do
+    FileUtils.rm_rf("/tmp/scrub_data/#{org}/")
+  end
+  def put_x_lines_in_file(x, file)
+    File.open(file, "w") do |f|
+      1.upto(x) do |i|
+        f.puts(i)
+      end
+    end
+  end
+  context "#initialize" do
+    it "requires required args" do
+      expect { described_class.new }.to raise_error ArgumentError
+    end
+    it "raises ArgumentError if missing any important settings" do
+      org_setting = Settings.scrub_line_count_diff_max
+      Settings.scrub_line_count_diff_max = nil
+      expect { described_class.new(org, item_type) }.to raise_error ArgumentError
+      Settings.scrub_line_count_diff_max = org_setting
+    end
+  end
+  context "#count_loaded & #count_ready" do
+    it "count_loaded empty == 0" do
+      expect(rc.count_loaded).to eq 0
+    end
+    it "count_loaded 1 == 1" do
+      put_x_lines_in_file(1, loaded_file)
+      expect(rc.count_loaded).to eq 1
+    end
+    it "count_ready empty == 0" do
+      expect(rc.count_ready).to eq 0
+    end
+    it "count_ready 1 == 1" do
+      put_x_lines_in_file(1, ready_file)
+      expect(rc.count_ready).to eq 1
+    end
+  end
+  context "#acceptable_diff?" do
+    it "is not acceptable if there are no files to load" do
+      expect(rc.acceptable_diff?).to be false
+    end
+    it "is acceptable if there are files to load and nothing was loaded before" do
+      put_x_lines_in_file(hundo, ready_file)
+      expect(rc.acceptable_diff?).to be true
+    end
+    it "is acceptable if the line counts are the same" do
+      put_x_lines_in_file(hundo, ready_file)
+      put_x_lines_in_file(hundo, loaded_file)
+      expect(rc.acceptable_diff?).to be true
+    end
+    it "is acceptable if the line counts are same-ish" do
+      put_x_lines_in_file(hundo, ready_file)
+      put_x_lines_in_file(hundo - small_diff, loaded_file)
+      expect(rc.acceptable_diff?).to be true
+    end
+    it "is not acceptable if the diff is greater than Settings.scrub_line_count_diff_max" do
+      put_x_lines_in_file(hundo, ready_file)
+      put_x_lines_in_file(hundo / small_diff, loaded_file)
+      expect(rc.acceptable_diff?).to be false
+    end
+    it "is not acceptable if the diff is greater than scrub_line_count_diff_max, reversed" do
+      put_x_lines_in_file(hundo / small_diff, ready_file)
+      put_x_lines_in_file(hundo, loaded_file)
+      expect(rc.acceptable_diff?).to be false
+    end
+  end
+end

--- a/spec/scrub/scrub_runner_spec.rb
+++ b/spec/scrub/scrub_runner_spec.rb
@@ -124,17 +124,4 @@ RSpec.describe Scrub::ScrubRunner do
       expect { sr_force.run_file(remote_file) }.not_to raise_error
     end
   end
-  describe "#count_lines_last_loaded" do
-    it "counts the number of records in the last scrubbed file that matches org & item_type" do
-      scrubber = Scrub::AutoScrub.new(fixture_file)
-      expect(sr.count_lines_last_loaded(scrubber)).to eq 0
-      remote_d = DataSources::DirectoryLocator.new(Settings.remote_member_data, org1)
-      remote_d.ensure!
-      # Copy fixture to "dropbox" so there is a "new file" to "download",
-      FileUtils.cp(fixture_file, remote_d.holdings_current)
-      sr.run
-      linecount_sans_header = (File.new(fixture_file).count - 1)
-      expect(sr.count_lines_last_loaded(scrubber)).to eq linecount_sans_header
-    end
-  end
 end

--- a/spec/scrub/scrub_runner_spec.rb
+++ b/spec/scrub/scrub_runner_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "scrub/record_counter"
 require "scrub/scrub_runner"
 require "data_sources/directory_locator"
 require "data_sources/ht_organizations"
@@ -17,6 +18,7 @@ RSpec.describe Scrub::ScrubRunner do
     FileUtils.touch(Settings.rclone_config_path)
     FileUtils.mkdir_p(Settings.local_member_data)
     FileUtils.mkdir_p(Settings.remote_member_data)
+    FileUtils.rm_rf("/tmp/scrub_data/#{org1}/")
   end
 
   after(:each) do
@@ -98,6 +100,27 @@ RSpec.describe Scrub::ScrubRunner do
       expect { sr.run_file(remote_file) }.to change { cluster_count(:holdings) }.by(6)
       # Expect log file to end up in the remote dir
       expect(File.exist?(File.join(remote_d.holdings_current, "umich_mono_#{Date.today}.log"))).to be true
+    end
+    it "will refuse a file if it breaks Settings.scrub_line_count_diff_max" do
+      remote_d = DataSources::DirectoryLocator.new(Settings.remote_member_data, org1)
+      remote_d.ensure!
+      # Copy fixture to "dropbox" so there is a "new file" to "download",
+      FileUtils.cp(fixture_file, remote_d.holdings_current)
+      remote_file = sr.check_new_files.first
+
+      FileUtils.mkdir_p("/tmp/scrub_data/#{org1}/loaded/")
+      File.open("/tmp/scrub_data/#{org1}/loaded/umich_mono_1.ndj", "w") do |file|
+        1.upto(20) do |i|
+          file.puts i
+        end
+      end
+      expect { sr.run_file(remote_file) }.to raise_error RuntimeError
+      # BUT will do it if we force it
+      sr_force = described_class.new(
+        org1,
+        {"force" => true, "force_holding_loader_cleanup_test" => true}
+      )
+      expect { sr_force.run_file(remote_file) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
Adds a check of the record count of the most recent comparable loadfile, and warns (so far only in the logs) if the abs diff% against the current scrub is greater than some value. That value is `Settings.scrub_line_count_diff_max` and is a percentage expressed as a  float (where 0.0 is 0% and 1.0 is 100%). 

`scrub_line_count_diff_max: 0.05` means a submitted file with a scubbed record diff (compared to the last loaded file with the same org & item_type) greater than +5% or smaller than -5% will be rejected with a warning.

This check is done after scrubbing but before chunking and loading, so we can bail out early. It also follows the old style approach of counting scrubbed records rather than submitted records.

If you want to force through an update anyways, set `@force=true` either by
`Scrub::ScrubRunner.new(org, {"force" => true})`
or via phctl
`$ bundle exec ruby bin/phctl.rb scrub <org> --force`