### PR TITLE
fix push metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         run: docker-compose run --rm dev bundle exec standardrb
 
       - name: Run tests
-        run: docker-compose run --rm -e MONGOID_ENV=test dev bin/setup/wait-for mariadb:3306 -- bundle exec rspec
+        run: docker-compose run --rm -e MONGOID_ENV=test dev bin/setup/wait-for mariadb:3306 pushgateway:9091 -- bundle exec rspec
 
       - name: Report to Coveralls
         uses: coverallsapp/github-action@1.1.3

--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,6 @@
 # Intellij/Rubymine
 /.idea/
 
-# rspec config
-/.rspec
-
 # test coverage
 /coverage
 

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/bin/setup/setup_test.sh
+++ b/bin/setup/setup_test.sh
@@ -2,7 +2,7 @@
 
 docker-compose build
 docker-compose run --rm dev bundle install
-docker-compose up -d mongo_test mariadb
+docker-compose up -d mongo_test mariadb pushgateway
 docker-compose run --rm -e MONGOID_ENV=test dev bin/setup/wait-for mongo_test:27017 -- echo "mongo is ready"
 docker-compose exec -T mongo_test bash /tmp/bin/setup/rs_initiate.sh mongo_test
 docker-compose run --rm -e MONGOID_ENV=test dev bundle exec ruby lib/tasks/build_database.rb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,10 @@ services:
 
   pushgateway:
     image: prom/pushgateway
+    command:
+      - --web.enable-admin-api
+    ports:
+      - 9091:9091
 
   sidekiq_web:
     build: .

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -36,22 +36,7 @@ Services.register(:scrub_stats) { {} }
 Services.register(:large_clusters) { DataSources::LargeClusters.new }
 Services.register(:loading_flag) { FileMutex.new(Settings.loading_flag_path) }
 
-Services.register(:pushgateway) { Prometheus::Client::Push.new(job: File.basename($PROGRAM_NAME), gateway: Settings.pushgateway) }
 Services.register(:prometheus_registry) { Prometheus::Client.registry }
-Services.register(:prometheus_metrics) do
-  {
-    duration: Prometheus::Client::Gauge.new(:job_duration_seconds,
-      docstring: "Time spend running job in seconds"),
-
-    last_success: Prometheus::Client::Gauge.new(:job_last_success,
-      docstring: "Last Unix time when job successfully completed"),
-
-    records_processed: Prometheus::Client::Gauge.new(:job_records_processed,
-      docstring: "Records processed by job"),
-    success_interval: Prometheus::Client::Gauge.new(:job_expected_success_interval,
-      docstring: "Maximum expected time in seconds between job completions")
-  }.tap { |m| m.each_value { |metric| Services.prometheus_registry.register(metric) } }
-end
-
+Services.register(:pushgateway) { Prometheus::Client::Push.new(job: File.basename($PROGRAM_NAME), gateway: Settings.pushgateway) }
 Services.register(:progress_tracker) { Utils::PushMetricsMarker }
 Services.register(:redis_config) { raise "Redis not configured" }

--- a/lib/sidekiq_jobs.rb
+++ b/lib/sidekiq_jobs.rb
@@ -19,7 +19,6 @@ require "scrub/scrub_runner"
 require "shared_print/updater"
 require "shared_print/replacer"
 require "shared_print/deprecator"
-require "utils/null_progress_tracker"
 
 require_relative "../config/initializers/sidekiq"
 

--- a/lib/sidekiq_jobs.rb
+++ b/lib/sidekiq_jobs.rb
@@ -22,7 +22,7 @@ require "shared_print/deprecator"
 
 require_relative "../config/initializers/sidekiq"
 
-if $0 == 'sidekiq'
+if $0 == "sidekiq"
   Services.register(:logger) { Sidekiq.logger }
 end
 

--- a/lib/sidekiq_jobs.rb
+++ b/lib/sidekiq_jobs.rb
@@ -19,11 +19,13 @@ require "scrub/scrub_runner"
 require "shared_print/updater"
 require "shared_print/replacer"
 require "shared_print/deprecator"
+require "utils/null_progress_tracker"
 
 require_relative "../config/initializers/sidekiq"
 
-# Don't want to do this by default when we aren't running under sidekiq
-Services.register(:logger) { Sidekiq.logger }
+if $0 == 'sidekiq'
+  Services.register(:logger) { Sidekiq.logger }
+end
 
 module Jobs
   class Common

--- a/lib/utils/push_metrics_marker.rb
+++ b/lib/utils/push_metrics_marker.rb
@@ -70,7 +70,7 @@ module Utils
 
     def register_metric(name, **kwargs)
       registry.get(name) ||
-      Prometheus::Client::Gauge.new(name, **kwargs).tap { |m| registry.register(m) }
+        Prometheus::Client::Gauge.new(name, **kwargs).tap { |m| registry.register(m) }
     end
   end
 end

--- a/lib/utils/push_metrics_marker.rb
+++ b/lib/utils/push_metrics_marker.rb
@@ -13,7 +13,6 @@ module Utils
     def initialize(batch_size,
       marker: Milemarker.new(batch_size: batch_size),
       registry: Services.prometheus_registry,
-      metrics: Services.prometheus_metrics,
       pushgateway: Services.pushgateway,
       success_interval: ENV["JOB_SUCCESS_INTERVAL"])
       @marker = marker
@@ -24,14 +23,14 @@ module Utils
       super(@marker)
 
       if success_interval
-        metrics[:success_interval].set(success_interval.to_i)
+        success_interval_metric.set(success_interval.to_i)
       end
 
       update_metrics
     end
 
     def final_line
-      metrics[:last_success].set(Time.now.to_i)
+      last_success_metric.set(Time.now.to_i)
       update_metrics
       marker.final_line
     end
@@ -48,9 +47,30 @@ module Utils
     attr_reader :marker, :pushgateway, :registry, :metrics
 
     def update_metrics
-      metrics[:duration].set(@marker.total_seconds_so_far)
-      metrics[:records_processed].set(@marker.count)
+      duration_metric.set(@marker.total_seconds_so_far)
+      records_processed_metric.set(@marker.count)
       pushgateway.add(registry)
+    end
+
+    def duration_metric
+      @duration_metric ||= register_metric(:job_duration_seconds, docstring: "Time spend running job in seconds")
+    end
+
+    def last_success_metric
+      @last_success_metric ||= register_metric(:job_last_success, docstring: "Last Unix time when job successfully completed")
+    end
+
+    def records_processed_metric
+      @records_processed ||= register_metric(:job_records_processed, docstring: "Records processed by job")
+    end
+
+    def success_interval_metric
+      @success_interval ||= register_metric(:job_expected_success_interval, docstring: "Maximum expected time in seconds between job completions")
+    end
+
+    def register_metric(name, **kwargs)
+      registry.get(name) ||
+      Prometheus::Client::Gauge.new(name, **kwargs).tap { |m| registry.register(m) }
     end
   end
 end

--- a/spec/utils/push_metrics_marker_spec.rb
+++ b/spec/utils/push_metrics_marker_spec.rb
@@ -21,21 +21,10 @@ RSpec.describe Utils::PushMetricsMarker do
   end
 
   let(:pushgateway) { instance_double(Prometheus::Client::Push, add: true) }
-  let(:registry) { instance_double(Prometheus::Client::Registry) }
-  let(:metrics) do
-    {
-      duration: instance_double(Prometheus::Client::Gauge, set: true),
-      last_success: instance_double(Prometheus::Client::Gauge, set: true),
-      records_processed: instance_double(Prometheus::Client::Gauge, set: true),
-      success_interval: instance_double(Prometheus::Client::Gauge, set: true)
-    }
-  end
 
   let(:params) do
     {
       marker: marker,
-      registry: registry,
-      metrics: metrics,
       pushgateway: pushgateway
     }
   end
@@ -44,38 +33,45 @@ RSpec.describe Utils::PushMetricsMarker do
     described_class.new(batch_size, **params)
   end
 
+  let(:metrics) { Services.prometheus_registry }
+
+  before(:each) do
+    # Start each test with a clean slate
+    Services.register(:prometheus_registry) { Prometheus::Client::Registry.new }
+  end
+
   describe "#initialize" do
     it "can be constructed" do
       expect(pm_marker).not_to be(nil)
     end
 
     it "sets initial values for duration and records processed" do
-      expect(metrics[:duration]).to receive(:set).with(seconds_so_far)
-      expect(metrics[:records_processed]).to receive(:set).with(records_so_far)
-
       pm_marker
+
+      expect(metrics.get(:job_duration_seconds).get).to eq(seconds_so_far)
+      expect(metrics.get(:job_records_processed).get).to eq(records_so_far)
     end
 
     it "doesn't set last success" do
-      expect(metrics[:last_success]).not_to receive(:set)
-
       pm_marker
+
+      expect(metrics.get(:job_last_success)).to be(nil)
     end
 
     it "by default doesn't set success interval" do
-      expect(metrics[:success_interval]).not_to receive(:set)
-
       pm_marker
+
+      expect(metrics.get(:job_expected_success_interval)).to be(nil)
     end
 
     it "sets success interval metric with constructor param" do
-      expect(metrics[:success_interval]).to receive(:set).with(success_interval)
-
       described_class.new(batch_size, **params.merge({success_interval: success_interval}))
+
+      expect(metrics.get(:job_expected_success_interval).get).to eq(success_interval)
     end
 
     it "pushes initial metrics to pushgateway" do
-      expect(pushgateway).to receive(:add).with(registry)
+      expect(pushgateway).to receive(:add).with(Services.prometheus_registry)
 
       pm_marker
     end
@@ -102,15 +98,15 @@ RSpec.describe Utils::PushMetricsMarker do
     end
 
     it "updates the metrics" do
-      expect(metrics[:duration]).to receive(:set).with(seconds_so_far)
-      expect(metrics[:records_processed]).to receive(:set).with(records_so_far)
-      expect(metrics[:last_success]).to receive(:set).with(Time.now.to_i)
-
       pm_marker.final_line
+
+      expect(metrics.get(:job_duration_seconds).get).to eq(seconds_so_far)
+      expect(metrics.get(:job_records_processed).get).to eq(records_so_far)
+      expect(metrics.get(:job_last_success).get).to eq(Time.now.to_i)
     end
 
     it "pushes metrics to pushgateway" do
-      expect(pushgateway).to receive(:add).with(registry)
+      expect(pushgateway).to receive(:add).with(Services.prometheus_registry)
 
       pm_marker.final_line
     end
@@ -124,22 +120,22 @@ RSpec.describe Utils::PushMetricsMarker do
     end
 
     it "updates the metrics" do
-      expect(metrics[:duration]).to receive(:set).with(seconds_so_far)
-      expect(metrics[:records_processed]).to receive(:set).with(records_so_far)
-
       pm_marker.on_batch {}
+
+      expect(metrics.get(:job_duration_seconds).get).to eq(seconds_so_far)
+      expect(metrics.get(:job_records_processed).get).to eq(records_so_far)
     end
 
     it "pushes metrics to pushgateway" do
-      expect(pushgateway).to receive(:add).with(registry)
+      expect(pushgateway).to receive(:add).with(Services.prometheus_registry)
 
       pm_marker.on_batch {}
     end
 
     it "doesn't overwrite last success metric" do
-      expect(metrics[:last_success]).not_to receive(:set)
-
       pm_marker.on_batch {}
+
+      expect(metrics.get(:job_last_success)).to be(nil)
     end
   end
 
@@ -158,23 +154,20 @@ RSpec.describe Utils::PushMetricsMarker do
 
   describe "integration test" do
     before(:each) do
+      WebMock.disable!
       Faraday.put("#{ENV["PUSHGATEWAY"]}/api/v1/admin/wipe")
     end
 
     let(:batch_size) { 5 }
-    let(:tracker) { Utils::PushMetricsMarker.new(batch_size) }
     let(:metrics) { Faraday.get("#{ENV["PUSHGATEWAY"]}/metrics").body }
 
     describe "#on_batch" do
 
       before(:each) do
-        tracker.incr(batch_size)
-        tracker.on_batch { }
+        pm_marker.on_batch { }
       end
 
       it "updates job_duration_seconds" do
-        require 'pry'
-        binding.pry
         expect(metrics).to match(/^job_duration_seconds\S* [\d.]+$/m)
       end
 
@@ -192,6 +185,7 @@ RSpec.describe Utils::PushMetricsMarker do
     end
 
     it "can record success" do
+      require 'pry'
       tracker.final_line
       # job_last_success is nonzero
       expect(metrics).to match(/^job_last_success\S* \S+/m)


### PR DESCRIPTION
With the old version of prometheus client, metrics that we had registered but not actually set a value for did not get sent to the push gateway. With the newer version, they do, which reset last success time & expected success interval to '0' at every job start, which caused spurious alerts.

This version substantially changes how metrics & the specs work. Now, metrics are lazily registered by the push metrics marker when they are actually needed. This also removes some of the stubbing in the specs for prometheus stuff while adding integration tests to ensure that pushing to the push gateway does actually work.

In doing this I found that the behavior in rspec with various hooks running at spread-out times got pretty confusing esp. regarding stubbing the push gateway and at what time that happened. I'm not sure what to do about that, but I still think that stubbing the pushgateway in tests in general makes sense.

Any way, let me know what you think. I also think this code is ripe for merging with https://github.com/billdueber/milemarker (and moving to hathitrust/mlibrary) but I'm not quite ready to do that yet.