### PR TITLE
fix for bug DEV-423, add `.inspect` to a `SharedPrint::DeprecationError` message

### DIFF
--- a/lib/shared_print/deprecation_record.rb
+++ b/lib/shared_print/deprecation_record.rb
@@ -81,7 +81,10 @@ module SharedPrint
       raise SharedPrint::DeprecationError, "No commitments by organization:#{organization} in cluster." if org_commitments.empty?
       raise SharedPrint::DeprecationError, "Only deprecated commitments found." if undeprecated_commitments.empty?
       raise SharedPrint::DeprecationError, "No commitment with local_id:#{@local_id} found" if local_id_matches.empty?
-      raise SharedPrint::DeprecationError, "Multiple local_ids found: #{local_id_matches.join(", ")}" unless validate_single_match
+      unless validate_single_match
+        raise SharedPrint::DeprecationError,
+          "Multiple local_ids found:\n#{local_id_matches.map(&:inspect).join("\n")}"
+      end
       local_id_matches.first
     end
 

--- a/spec/shared_print/deprecation_record_spec.rb
+++ b/spec/shared_print/deprecation_record_spec.rb
@@ -161,12 +161,20 @@ RSpec.describe SharedPrint::DeprecationRecord do
       expect(dep.validate_single_match).to be true
     end
   end
-
-  it "be OK when asked to find commitments when there is no cluster" do
-    expect {
-      described_class.parse_line(
-        "ou\t780750\t99334010002042\tL"
-      ).find_commitment
-    }.to raise_error SharedPrint::DeprecationError
+  describe "#find_commitment" do
+    it "be OK when asked to find commitments when there is no cluster" do
+      expect {
+        described_class.parse_line(
+          "ou\t780750\t99334010002042\tL"
+        ).find_commitment
+      }.to raise_error SharedPrint::DeprecationError
+    end
+    it "shows full commitment data for duplicates, including uuid" do
+      make_commitment(ocn, org, loc)
+      make_commitment(ocn, org, loc)
+      dep = described_class.new(organization: org, ocn: ocn, local_id: loc, status: sta)
+      expect { dep.find_commitment }.to raise_error SharedPrint::DeprecationError
+      expect { dep.find_commitment }.to raise_error(/uuid/)
+    end
   end
 end


### PR DESCRIPTION
All it does inspect a variable that was previously not inspected, when raising a particular error.