### PR TITLE
DEV-500, enable deprecation and update of commitments based on uuid

### DIFF
--- a/lib/scrub/autoscrub.rb
+++ b/lib/scrub/autoscrub.rb
@@ -71,6 +71,7 @@ module Scrub
       out_file = File.open(out_file_path, "w")
       Services.scrub_logger.info("Outputting to #{out_file_path}")
 
+      holding = "" # so it can be debugged in rescue
       begin
         @member_holding_file.parse do |holding|
           out_file.puts(holding.to_json)
@@ -81,12 +82,8 @@ module Scrub
         end
         out_file.close
       rescue => e
-        # Any uncaught error that isn't a CustomError should be fatal
-        # and is a sign that error handling needs to be improved.
-        Services.scrub_logger.fatal(e)
-        Services.scrub_logger.fatal(e.backtrace.join("\n"))
-        Services.scrub_logger.fatal("Premature exit, exit status 1.")
-        exit 1
+        Services.scrub_logger.error(e)
+        Services.scrub_logger.error(e.backtrace.join("\n"))
       end
       Services.scrub_logger.info("Finished scrubbing #{@path}")
       FileUtils.mv(out_file_path, @output_struct.member_ready_to_load)

--- a/lib/shared_print/finder.rb
+++ b/lib/shared_print/finder.rb
@@ -10,11 +10,12 @@ module SharedPrint
   # * call clusters()    to yield the matching clusters,
   # * call commitments() to yield the matching commitments.
   class Finder
-    attr_reader :organization, :ocn, :local_id, :deprecated, :query
-    def initialize(organization: [], ocn: [], local_id: [], deprecated: false)
+    attr_reader :organization, :ocn, :local_id, :uuid, :deprecated, :query
+    def initialize(organization: [], ocn: [], local_id: [], uuid: [], deprecated: false)
       @organization = organization
       @ocn = ocn
       @local_id = local_id
+      @uuid = uuid
       @deprecated = deprecated # nil = don't care, could be deprecated or not.
 
       # Put together a query based on the criteria gathered.
@@ -56,6 +57,9 @@ module SharedPrint
       if @local_id.any?
         q["commitments.local_id"] = {"$in": @local_id}
       end
+      if @uuid.any?
+        q["commitments.uuid"] = {"$in": @uuid}
+      end
 
       q
     end
@@ -67,7 +71,9 @@ module SharedPrint
       (@deprecated.nil? || @deprecated == commitment.deprecated?) &&
         empty_or_include?(@organization, commitment.organization) &&
         empty_or_include?(@ocn, commitment.ocn) &&
-        empty_or_include?(@local_id, commitment.local_id)
+        empty_or_include?(@local_id, commitment.local_id) &&
+        empty_or_include?(@uuid, commitment.uuid)
+
     end
 
     # A commitment matches e.g. the @ocn acriterion if @ocn == []

--- a/spec/shared_print/finder_spec.rb
+++ b/spec/shared_print/finder_spec.rb
@@ -92,6 +92,19 @@ RSpec.describe SharedPrint::Finder do
       res = described_class.new(local_id: [loc1, loc2]).commitments.to_a
       expect(res.map(&:local_id)).to eq [loc1, loc2]
     end
+    it "can search by single uuid" do
+      cluster_tap_save [spc1, spc2]
+      uuid1 = spc1.uuid
+      res = described_class.new(uuid: [uuid1]).commitments.to_a
+      expect(res.map(&:uuid)).to eq [uuid1]
+    end
+    it "can search by multiple uuids" do
+      cluster_tap_save [spc1, spc2]
+      uuid1 = spc1.uuid
+      uuid2 = spc2.uuid
+      res = described_class.new(uuid: [uuid1, uuid2]).commitments.to_a
+      expect(res.map(&:uuid)).to eq [uuid1, uuid2]
+    end
   end
 
   describe "deprecated records" do


### PR DESCRIPTION
When updating and/or deprecating commitments, we use `organization + ocn + local_id` as the identifying fields.
That's just by convention, though. So it is possible, usually because of legacy data, that 2+ commitments share the same `organization + ocn + local_id`. The updater and deprecator scripts are aware of this issue, and won't let you update/deprecate a commitment if they find more than 1 commitment given a `organization + ocn + local_id`.

Because we still might want to update/deprecate commitments that have "duplicates" we need to expand the search params to include `uuid` which should (all but) guarantee unique commitments.