### PR TITLE
estimate script crashes if missing crucial setting 

### DIFF
--- a/lib/reports/estimate.rb
+++ b/lib/reports/estimate.rb
@@ -19,6 +19,9 @@ module Reports
       @num_items_ic = 0
       @clusters_seen = Set.new
       @marker = Services.progress_tracker.new(batch_size)
+      if Settings.estimates_path.nil?
+        raise ArgumentError, "Settings.estimates_path must be set."
+      end
     end
 
     def cost_report


### PR DESCRIPTION
I prefer having classes bail from initialize or validate if crucial settings are missing. 
Makes the error much clearer and imho encourages defensive coding.