### PR TITLE
DEV-505: Only use resolutions & htitems when updating OCNs

### DIFF
--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -178,7 +178,7 @@ class Cluster
   end
 
   def update_ocns
-    self.ocns = [clusterable_ocn_tuples].flatten.uniq
+    self.ocns = [ocn_resolutions.pluck(:ocns) + ht_items.pluck(:ocns)].flatten.uniq
     save
   end
 


### PR DESCRIPTION
This change ensures that when OCNs in a cluster change, we only use the OCNs for the resolutions and the htitems. In normal usage, holdings should never end up in the "wrong" cluster. However, a small number of shared print commitments had their OCNs changed without moving clusters, leading to inconsistent clusters. This update mitigates the effect of that. DEV-504 will address the underlying issue.