### PR TITLE
fail more gracefully if ocn.nil?, DEV-513

### DIFF
--- a/lib/scrub/autoscrub.rb
+++ b/lib/scrub/autoscrub.rb
@@ -71,23 +71,17 @@ module Scrub
       out_file = File.open(out_file_path, "w")
       Services.scrub_logger.info("Outputting to #{out_file_path}")
 
-      begin
-        @member_holding_file.parse do |holding|
-          out_file.puts(holding.to_json)
-          marker.incr
-          marker.on_batch do |m|
-            Services.scrub_logger.info(m.batch_line)
-          end
+      @member_holding_file.parse do |holding|
+        out_file.puts(holding.to_json)
+        marker.incr
+        marker.on_batch do |m|
+          Services.scrub_logger.info(m.batch_line)
         end
-        out_file.close
       rescue => e
-        # Any uncaught error that isn't a CustomError should be fatal
-        # and is a sign that error handling needs to be improved.
-        Services.scrub_logger.fatal(e)
-        Services.scrub_logger.fatal(e.backtrace.join("\n"))
-        Services.scrub_logger.fatal("Premature exit, exit status 1.")
-        exit 1
+        Services.scrub_logger.error(e)
+        Services.scrub_logger.error(e.backtrace.join("\n"))
       end
+      out_file.close
       Services.scrub_logger.info("Finished scrubbing #{@path}")
       FileUtils.mv(out_file_path, @output_struct.member_ready_to_load)
       Services.scrub_logger.info(

--- a/lib/scrub/ocn_candidate.rb
+++ b/lib/scrub/ocn_candidate.rb
@@ -28,8 +28,8 @@ module Scrub
       return if is_digit_mix?
       return unless is_ok_prefix?
       capture_numeric
-      return if numeric_too_large?
       return if numeric_zero?
+      return if numeric_too_large?
       @valid = true
     end
 
@@ -89,14 +89,18 @@ module Scrub
     end
 
     def numeric_zero?
-      if @numeric_part.zero?
+      if @numeric_part.nil?
+        count_x("ocn rejected: numeric part is nil", @numeric_part)
+      elsif @numeric_part.zero?
         count_x("ocn rejected: numeric part is zero", @numeric_part)
       end
     end
 
     def capture_numeric
       md = @candidate.match(NUMERIC_PART)
-      @numeric_part = md[0].to_i
+      unless md.nil?
+        @numeric_part = md[0].to_i
+      end
     end
   end
 end

--- a/spec/scrub/ocn_candidate_spec.rb
+++ b/spec/scrub/ocn_candidate_spec.rb
@@ -15,4 +15,10 @@ RSpec.describe Scrub::OcnCandidate do
     expect(cand.numeric_part).to eq 0
     expect(cand.valid?).to be false
   end
+
+  it "invalidates nil" do
+    cand = described_class.new("")
+    expect(cand.numeric_part).to eq nil
+    expect(cand.valid?).to be false
+  end
 end


### PR DESCRIPTION
Autoscrub would previously crash if given an OCN without a numeric part.