### PR TITLE
fail gracefully when scrubbing an empty line

### DIFF
--- a/lib/scrub/member_holding_file.rb
+++ b/lib/scrub/member_holding_file.rb
@@ -193,7 +193,7 @@ module Scrub
 
     def item_from_line(line, col_map)
       if line.nil? || line.empty?
-        raise "bad line (nil/empty)"
+        raise Scrub::MalformedRecordError, "bad line (nil/empty)"
       end
 
       holding = MemberHolding.new(col_map)

--- a/spec/scrub/member_holding_file_spec.rb
+++ b/spec/scrub/member_holding_file_spec.rb
@@ -85,6 +85,10 @@ RSpec.describe Scrub::MemberHoldingFile do
     expect(value.size).to be(3)
   end
 
+  it "rejects empty lines" do
+    expect { ok_header_mhf.item_from_line("", ok_col_map) }.to raise_error Scrub::MalformedRecordError
+  end
+
   it "can read a file and yield MemberHolding records" do
     expect { ok_header_mhf.parse { |record| } }.not_to raise_error
 


### PR DESCRIPTION
autoscrub would previously crash out when encountering an empty file