### PR TITLE
DEV-518: Chunked files were not sorted numerically by OCN. Fix for that.

### DIFF
--- a/lib/scrub/chunker.rb
+++ b/lib/scrub/chunker.rb
@@ -42,8 +42,15 @@ module Scrub
       # TODO: we might want another dir for sort -T .
       tmp_file = File.join(@tmp_chunk_dir, "tmp_sorted.txt")
       add_uuid_call = @add_uuid ? "| bundle exec ruby bin/add_uuid.rb" : ""
+      # Sort call explained:
+      # input lines look like {"ocn":7804,"local_id":"991000029949706390", ... }
+      # -t:   = split lines into fields on :
+      # -k2,2 = only sort based on the 2nd field (7804,"local_id")
+      # -s    = stable sort, which should make it faster?
+      # -n    = numeric sort so [1, 3, 20] instead of [1, 20, 3]
+      # -T ./ = put temporary files in the current directory
       sort_call = "egrep -vh '^OCN' #{@glob} | " \
-                  "sort -s -n -k1,1 -T ./ " \
+                  "sort -t: -k2,2 -s -n -T ./ " \
                   "#{add_uuid_call} " \
                   "> #{tmp_file}"
       Services.logger.info sort_call

--- a/spec/scrub/chunker_spec.rb
+++ b/spec/scrub/chunker_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Scrub::Chunker do
       expect(chunk_line_count).to be_within(1).of(expected_chunk_line_count)
 
       # is internally sorted:
-      expect(system("sort -c #{chunker.chunks[i]}")).to be true
+      expect(system("sort -t: -k2,2 -s -n -c #{chunker.chunks[i]}")).to be true
     end
 
     # Check that the line count of all the chunks add up to the line count of pre_chunked_file


### PR DESCRIPTION
Updated sort call & associated test.
Changed from `sort -s -n -k1,1` to `sort -t: -k2,2 -s -n`, so that we are actually sorting on the OCN numerically.
