### PR TITLE
changed back costreport output path

### DIFF
--- a/lib/reports/cost_report.rb
+++ b/lib/reports/cost_report.rb
@@ -190,9 +190,15 @@ module Reports
     private
 
     def report_file
-      FileUtils.mkdir_p(Settings.cost_report_path)
-      iso_stamp = Time.now.strftime("%Y%m%d-%H%M%S")
-      File.join(Settings.cost_report_path, "cost_report_#{iso_stamp}.txt")
+      year = Time.now.year.to_s
+      FileUtils.mkdir_p(File.join(Settings.cost_report_path, year))
+      iso_stamp = Time.now.strftime("%Y%m%d")
+
+      File.join(
+        Settings.cost_report_path,
+        year,
+        "cost_report_#{iso_stamp}.tsv"
+      )
     end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe "phctl integration" do
 
     it "CostReport produces output" do
       phctl(*%w[report costreport])
-
-      expect(File.read(Dir.glob("/tmp/cost_reports/*").first))
+      year = Time.new.year.to_s
+      expect(File.read(Dir.glob("/tmp/cost_reports/#{year}/*").first))
         .to match(/Target cost: 9999/)
     end
 


### PR DESCRIPTION
Making sure cost reports are named the way they used to be and placed in the right subdirectory.