### PR TITLE
Don't pass --inline option through to common job

### DIFF
--- a/lib/phctl.rb
+++ b/lib/phctl.rb
@@ -18,8 +18,9 @@ module PHCTL
         end
       end
 
-      def run_common_job(klass, *args, **kwargs)
-        run_job(Jobs::Common, klass.to_s, *args, **kwargs)
+      def run_common_job(klass, options, *args, **kwargs)
+        options.delete(:inline)
+        run_job(Jobs::Common, klass.to_s, options, *args, **kwargs)
       end
     end
   end


### PR DESCRIPTION
Most don't know how to handle it