### PR TITLE
DEV-412, shared print overlap groups

### DIFF
--- a/lib/shared_print/groups.rb
+++ b/lib/shared_print/groups.rb
@@ -1,0 +1,88 @@
+module SharedPrint
+  # A lookup object for which orgs are members of which shared print program,
+  # and vice versa.
+  class Groups
+    attr_reader :groups
+
+    def initialize
+      @groups = {
+        "coppul" => [
+          "ucalgary",
+          "ualberta"
+        ],
+        "east" => [
+          "brandeis",
+          "brynmawr",
+          "bu",
+          "colby",
+          "lafayette",
+          "nyu",
+          "pitt",
+          "rochester",
+          "swarthmore",
+          "tufts",
+          "umd",
+          "union"
+        ],
+        "flare" => ["flbog"],
+        "mssc" => ["colby"],
+        "recap" => [
+          "columbia",
+          "harvard",
+          "nypl",
+          "princeton"
+        ],
+        "ivyplus" => [
+          "brown",
+          "columbia",
+          "cornell",
+          "dartmouth",
+          "duke",
+          "harvard",
+          "jhu",
+          "mit",
+          "princeton",
+          "psu",
+          "stanford",
+          "uchigaco",
+          "yale"
+        ],
+        "ucsp" => [
+          "nrlf",
+          "srlf",
+          "ucmerced",
+          "ucsc",
+          "ucsd"
+        ],
+        "viva" => ["virgina"],
+        "downsview" => ["utoronto"],
+        "fdlp" => ["umn"]
+      }
+
+      @reverse = reverse_lookup
+    end
+
+    # Which orgs are members in a group?
+    def group_to_orgs(group)
+      groups[group]
+    end
+
+    # Which groups is an org in?
+    def org_to_groups(org)
+      @reverse[org]
+    end
+
+    private
+
+    def reverse_lookup
+      reverse = {}
+      groups.each do |group, org_arr|
+        org_arr.each do |org|
+          reverse[org] ||= []
+          reverse[org] << group
+        end
+      end
+      reverse
+    end
+  end
+end

--- a/spec/reports/rare_uncommitted_spec.rb
+++ b/spec/reports/rare_uncommitted_spec.rb
@@ -343,6 +343,13 @@ RSpec.describe Reports::RareUncommitted do
       # Adding holdings from a member who's not in group with ucalgary also does nothing
       cluster_tap_save [hol1_org1]
       expect(r.group_overlap(Cluster.first)).to eq 1
+
+      # Check that the text output looks as expected.
+      # We expect a 2-line tsv, with overlap_group in the 8th (index 7) column.
+      out_arr = r.output_organization.to_a
+      expect(out_arr.size).to eq 2
+      expect(out_arr.first.split("\t")[7]).to eq "overlap_group"
+      expect(out_arr.last.split("\t")[7]).to eq "1"
     end
   end
 end

--- a/spec/shared_print/groups_spec.rb
+++ b/spec/shared_print/groups_spec.rb
@@ -1,0 +1,21 @@
+require "shared_print/groups"
+
+RSpec.describe SharedPrint::Groups do
+  let(:g) { described_class.new }
+  describe "#group_to_orgs" do
+    it "given a group name it returns the member organizations" do
+      expect(g.group_to_orgs("recap")).to eq ["columbia", "harvard", "nypl", "princeton"]
+    end
+    it "given a group name that does not exist it returns nil" do
+      expect(g.group_to_orgs("foo")).to be_nil
+    end
+  end
+  describe "#org_to_groups" do
+    it "given an organization name it returns the organization(s) it is a member of" do
+      expect(g.org_to_groups("princeton")).to eq ["recap", "ivyplus"]
+    end
+    it "given an organization that does not exist it returns nil" do
+      expect(g.org_to_groups("foo")).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Added shared print groups and related overlap column in the rare_uncommitted report.

Now if you run a rare_uncommitted report for an organization that is one of the `SharedPrint::Groups`, you get the additional column "overlap_group" which counts how many of the other members in your group(s) have holdings on the same cluster.