### PR TITLE
DEV-523, `NON-REPRO` policy for commitments

### DIFF
--- a/lib/clusterable/commitment.rb
+++ b/lib/clusterable/commitment.rb
@@ -31,7 +31,7 @@ module Clusterable
       :facsimile
     validates_inclusion_of :local_shelving_type, in: ["cloa", "clca", "sfca", "sfcahm", "sfcaasrs"],
       allow_nil: true
-    validates_inclusion_of :policies, in: ["blo", "digitizeondemand", "non-circ"], allow_nil: true
+    validates_inclusion_of :policies, in: ["blo", "digitizeondemand", "non-circ", "non-repro"], allow_nil: true
     validate :deprecation_validation
 
     def initialize(_params = nil)

--- a/lib/loader/shared_print_loader.rb
+++ b/lib/loader/shared_print_loader.rb
@@ -2,6 +2,7 @@
 
 require "clusterable/commitment"
 require "clustering/cluster_commitment"
+require "utils/tsv_reader"
 
 module Loader
   # Constructs batches of Commitments from incoming file data

--- a/lib/utils/tsv_reader.rb
+++ b/lib/utils/tsv_reader.rb
@@ -1,3 +1,5 @@
+require "English"
+
 module Utils
   class TSVReader
     # Takes a .tsv file with a header and turns it into hashes,
@@ -49,7 +51,7 @@ module Utils
     def line_to_hash(line)
       cols = line.split(@delim, -1)
       if cols.size != @header_hash.keys.size
-        raise IndexError, "Line cols: #{cols.size}, header cols: (#{@header_hash.keys.size})."
+        raise IndexError, "Line #{$INPUT_LINE_NUMBER} has #{cols.size} cols, header has #{@header_hash.keys.size} cols."
       end
       col_hash = @header_hash.clone
       cols.each_with_index do |col_val, i|

--- a/spec/clusterable/commitment_spec.rb
+++ b/spec/clusterable/commitment_spec.rb
@@ -122,7 +122,11 @@ RSpec.describe Clusterable::Commitment do
   end
 
   describe "policies" do
-    ["blo", "digitizeondemand", "non-circ"].each do |policy|
+    it "accepts empty policy" do
+      expect(build(:commitment, policies: [])).to be_valid
+    end
+
+    ["blo", "digitizeondemand", "non-circ", "non-repro"].each do |policy|
       it "accepts #{policy}" do
         expect(build(:commitment, policies: [policy])).to be_valid
       end

--- a/spec/fixtures/sp_commitment_policies.tsv
+++ b/spec/fixtures/sp_commitment_policies.tsv
@@ -1,2 +1,4 @@
 uuid	organization	ocn	local_id	oclc_sym	committed_date	retention_date	local_bib_id	local_item_id	local_item_location	local_shelving_type	policies	facsimile	other_program	other_retention_date	deprecation_status	deprecation_date
 e78047da-1193-43c7-aab0-492067d13f9c	ucsd	2	i6536255x	CUS	2019-02-28						BLO,DIGITIZEONDEMAND	0				
+e78047da-1193-43c7-aab0-492067d13f9d	ucsd	3	i6536255y	CUS	2019-02-28						NON-REPRO,BLO	0				
+e78047da-1193-43c7-aab0-492067d13f9e	ucsd	4	i6536255z	CUS	2019-02-28							0				

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "phctl integration" do
 
       it "loads tsv file with policies" do
         expect { phctl("load", "commitments", fixture("sp_commitment_policies.tsv")) }
-          .to change { cluster_count(:commitments) }.by(1)
+          .to change { cluster_count(:commitments) }.by(3)
       end
     end
 

--- a/spec/utils/tsv_reader_spec.rb
+++ b/spec/utils/tsv_reader_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require "utils/tsv_reader"
 require "spec_helper"
-require "fileutils"
+require "utils/tsv_reader"
 
 RSpec.describe Utils::TSVReader do
   let(:reader) { described_class.new("spec/fixtures/test_sp_update_file.tsv") }
@@ -24,9 +23,11 @@ RSpec.describe Utils::TSVReader do
       # Set up a header with 3 cols and try to parse lines of different length.
       reader.process_header("a\tb\tc")
       # Too short
-      expect { reader.line_to_hash("x\ty") }.to raise_error IndexError
+      rx1 = /Line \d+ has 2 cols, header has 3 cols/
+      rx2 = /Line \d+ has 4 cols, header has 3 cols/
+      expect { reader.line_to_hash("x\ty") }.to raise_error(IndexError, rx1)
       # Too long
-      expect { reader.line_to_hash("x\ty\tz\tfoo") }.to raise_error IndexError
+      expect { reader.line_to_hash("x\ty\tz\tfoo") }.to raise_error(IndexError, rx2)
       # Just right!
       expect { reader.line_to_hash("x\ty\tz") }.not_to raise_error
     end


### PR DESCRIPTION
Adding new shared print policy `NON-REPRO` (formerly hypothesized as `do not reproduce`) and some associated tests.
For context: `policies` is an array field on `Clusterable::Commitments` that may take a number of different values.
We expect to get it from members in the form of a comma-separated text field in a `.tsv` file.