### PR TITLE
DEV-464, a validator for phase 3 sp commitments

### DIFF
--- a/lib/phctl.rb
+++ b/lib/phctl.rb
@@ -87,6 +87,11 @@ module PHCTL
     def deprecate(*infile)
       run_job(Jobs::SharedPrintOps::Deprecate, options[:verbose], [*infile])
     end
+
+    desc "phase3load INFILE", "Load Phase 3 commitments, if valid, from file"
+    def phase3load(infile)
+      run_common_job(SharedPrint::Phase3Validator, options, infile)
+    end
   end
 
   class Report < JobCommand

--- a/lib/shared_print/phase_3_validator.rb
+++ b/lib/shared_print/phase_3_validator.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "cluster"
+require "loader/shared_print_loader"
+require "services"
+Services.mongo!
+
+module SharedPrint
+  class Phase3Error < StandardError
+    # Any error occurring during pass_validation?(commitment) should be of this class.
+  end
+
+  class Phase3Validator
+    attr_reader :path, :last_error, :log
+
+    def initialize(path)
+      @path = path
+      @last_error = nil
+      @log = nil
+
+      # Any commitment in Phase 3 should have 1+ of these policies:
+      @phase_3_required_policies = ["blo", "non-circ"]
+
+      # Setup dirs
+      if Settings.local_report_path.nil?
+        raise "Missing Settings.local_report_path"
+      end
+      FileUtils.mkdir_p(Settings.local_report_path)
+    end
+
+    # Check all commitments in file and load the valid ones,
+    # log both loaded and non-valid commitments to file.
+    def run
+      # Setup log files
+      base = File.basename(@path)
+      @log = File.open(File.join(Settings.local_report_path, base) + ".log", "w")
+      @log.puts "Checking if commitments in #{@path} are valid..."
+      # Go through input and process
+      loader = Loader::SharedPrintLoader.for(@path)
+      handle = Loader::SharedPrintLoader.filehandle_for(@path)
+      handle.each do |line|
+        # commitment is an unsaved commitment until it has passed
+        # validation and is then saved by load()
+        commitment = loader.item_from_line(line)
+        if pass_validation? commitment
+          loader.load commitment
+          @log.puts "Loaded #{commitment.inspect}"
+        else
+          @log.puts "Failed to load #{commitment.inspect}"
+        end
+      end
+    ensure
+      # Close log files
+      @log.puts "Done."
+      @log.close
+    end
+
+    # Check if a given commitment is valid (for the phase 3 definition of valid).
+    # Log errors.
+    def pass_validation?(commitment)
+      @last_error = nil
+      require_valid_commitment(commitment)
+
+      # Check that a valid cluster with matching OCN exists
+      ocn = commitment.ocn
+      cluster = Cluster.find_by(ocns: ocn)
+      require_matching_cluster(cluster)
+      require_valid_cluster(cluster)
+      require_cluster_ht_items(cluster)
+
+      # Check that org has a matching holdings record in the cluster
+      require_matching_org_holding(cluster, commitment.organization)
+      # Check that commitment satisfies phase 3 policy rules
+      require_phase_3_policies(commitment)
+      # We made it. The commitment should be safe to load.
+      true
+    rescue SharedPrint::Phase3Error => err
+      # Any Phase3Error raised in pass_validation?() should get processed here
+      report_error(commitment, err)
+      false
+    end
+
+    def require_valid_commitment(commitment)
+      unless commitment.valid?
+        raise SharedPrint::Phase3Error, "Commitment not valid: #{commitment.errors.inspect}"
+      end
+    end
+
+    def require_matching_cluster(cluster)
+      if cluster.nil?
+        raise SharedPrint::Phase3Error, "Commitment has no matching cluster"
+      end
+    end
+
+    def require_valid_cluster(cluster)
+      unless cluster.valid?
+        raise SharedPrint::Phase3Error, "Commitment has an invalid matching cluster"
+      end
+    end
+
+    def require_cluster_ht_items(cluster)
+      if cluster.ht_items.empty?
+        raise SharedPrint::Phase3Error, "Cluster has no ht_items"
+      end
+    end
+
+    def require_matching_org_holding(cluster, org)
+      if cluster.holdings.count { |h| h.organization == org }.zero?
+        raise SharedPrint::Phase3Error, "Commitment has no matching holdings"
+      end
+    end
+
+    def require_phase_3_policies(commitment)
+      pols = commitment.policies
+      # pols must match ONE AND ONLY ONE of the required policies.
+      unless (pols & @phase_3_required_policies).count == 1
+        msg = "Required policies mismatch. Commitment has #{pols.join(",")}. " \
+              "Exactly one of #{@phase_3_required_policies.join(",")} is required"
+        raise SharedPrint::Phase3Error, msg
+      end
+    end
+
+    # Log errors to file and save the last one in @last_err
+    def report_error(commitment, err)
+      @last_error = err
+      @log&.puts "Commitment not valid:"
+      @log&.puts "* Inspect: #{commitment.inspect}"
+      @log&.puts "* Message: #{err.message}"
+      @log&.puts "---"
+    end
+  end
+end

--- a/lib/sidekiq_jobs.rb
+++ b/lib/sidekiq_jobs.rb
@@ -19,6 +19,7 @@ require "scrub/scrub_runner"
 require "shared_print/updater"
 require "shared_print/replacer"
 require "shared_print/deprecator"
+require "shared_print/phase_3_validator"
 
 require_relative "../config/initializers/sidekiq"
 

--- a/phctl.sh
+++ b/phctl.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Slight shortcut to starting phctl
+bundle exec ruby bin/phctl.rb $*

--- a/spec/fixtures/phase_3_commitments.tsv
+++ b/spec/fixtures/phase_3_commitments.tsv
@@ -1,0 +1,4 @@
+uuid	organization	ocn	local_id	oclc_sym	committed_date	retention_date	local_bib_id	local_item_id	local_item_location	local_shelving_type	policies
+e78047da-1193-43c7-aab0-492067d13f9c	umich	2	i6536255x	CUS	2019-02-28						BLO,DIGITIZEONDEMAND
+e78047da-1193-43c7-aab0-492067d13f9d	umich	3	i6536255y	CUS	2019-02-28						NON-REPRO,BLO
+e78047da-1193-43c7-aab0-492067d13f9e	umich	4	i6536255z	CUS	2019-02-28						

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe "phctl integration" do
         expect { phctl("load", "commitments", fixture("sp_commitment_policies.tsv")) }
           .to change { cluster_count(:commitments) }.by(3)
       end
+
+      it "loads tsv file with phase 3 commitments" do
+        # Setup, need populated clusters to load commitments
+        [2, 3].each do |ocn|
+          cluster_tap_save [
+            build(:ht_item, ocns: [ocn]),
+            build(:holding, ocn: ocn, organization: "umich")
+          ]
+        end
+        expect { phctl("sp", "phase3load", fixture("phase_3_commitments.tsv")) }
+          .to change { cluster_count(:commitments) }.by(2)
+      end
     end
 
     it "HtItems loads hathifiles" do

--- a/spec/phctl_spec.rb
+++ b/spec/phctl_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "PHCTL::PHCTL", type: :sidekiq_fake do
     %w[sp replace infile] => Jobs::Common,
     %w[sp deprecate infile] => Jobs::SharedPrintOps::Deprecate,
     %w[sp deprecate infile --verbose] => Jobs::SharedPrintOps::Deprecate,
+    %w[sp phase3load somefile] => Jobs::Common,
     %w[report estimate ocnfile] => Jobs::Common,
     %w[report eligible-commitments ocnfile] => Jobs::Common,
     %w[report uncommitted-holdings] => Jobs::Common,

--- a/spec/shared_print/phase_3_validator_spec.rb
+++ b/spec/shared_print/phase_3_validator_spec.rb
@@ -1,0 +1,115 @@
+require "shared_print/phase_3_validator"
+require "cluster"
+
+RSpec.describe SharedPrint::Phase3Validator do
+  let(:fixt) { fixture("phase_3_commitments.tsv") }
+  let(:p3v) { described_class.new(fixt) }
+  let(:spc) { build(:commitment) }
+
+  before(:each) do
+    Cluster.collection.find.delete_many
+  end
+
+  describe "initialize" do
+    it "no last_error when freshly inited" do
+      expect(p3v.last_error).to be nil
+    end
+    it "raises if missing settings" do
+      original_setting = Settings.local_report_path
+      Settings.local_report_path = nil
+      expect { described_class.new(fixt) }.to raise_error(/Missing Settings/)
+      Settings.local_report_path = original_setting
+    end
+  end
+
+  describe "low-level individual checks called by pass_validation?" do
+    it "rejects a commitment if non-valid" do
+      expect { p3v.require_valid_commitment(spc) }.to_not raise_error
+      spc.committed_date = nil # This makes the commitment non-valid
+      expect { p3v.require_valid_commitment(spc) }.to raise_error SharedPrint::Phase3Error
+    end
+    it "rejects a commitment if no matching cluster" do
+      cluster = build(:cluster)
+      expect { p3v.require_matching_cluster(cluster) }.to_not raise_error
+      expect { p3v.require_matching_cluster(nil) }.to raise_error SharedPrint::Phase3Error
+    end
+    it "rejects a commitment if no valid cluster" do
+      cluster = build(:cluster)
+      expect { p3v.require_valid_cluster(cluster) }.to_not raise_error
+      cluster.ocns = ["x"] # this makes the cluster non-valid
+      expect { p3v.require_valid_cluster(cluster) }.to raise_error SharedPrint::Phase3Error
+    end
+    it "rejects a commitment if no ht_items in cluster" do
+      ht = build(:ht_item, ocns: [spc.ocn])
+      cluster_tap_save [spc]
+      cluster = Cluster.find_by(ocns: [spc.ocn])
+      expect { p3v.require_cluster_ht_items(cluster) }.to raise_error SharedPrint::Phase3Error
+      # Add an ht_item to make it work
+      cluster_tap_save [ht]
+      cluster = Cluster.find_by(ocns: [spc.ocn])
+      expect { p3v.require_cluster_ht_items(cluster) }.to_not raise_error
+    end
+    it "rejects a commitment if no matching holding in cluster" do
+      cluster_tap_save [spc]
+      cluster = Cluster.find_by(ocns: [spc.ocn])
+      expect { p3v.require_matching_org_holding(cluster, spc.organization) }.to raise_error SharedPrint::Phase3Error
+      # Add a holding to make it work
+      hol = build(:holding, ocn: spc.ocn, organization: spc.organization)
+      cluster_tap_save [hol]
+      cluster = Cluster.find_by(ocns: [spc.ocn])
+      expect { p3v.require_matching_org_holding(cluster, spc.organization) }.to_not raise_error
+    end
+    it "rejects a commitment if no phase 3 policies" do
+      spc.policies = []
+      expect { p3v.require_phase_3_policies(spc) }.to raise_error SharedPrint::Phase3Error
+      spc.policies = ["non-repro"]
+      expect { p3v.require_phase_3_policies(spc) }.to raise_error SharedPrint::Phase3Error
+      spc.policies = ["non-circ", "blo"] # one or the other is ok, both is not ok
+      expect { p3v.require_phase_3_policies(spc) }.to raise_error SharedPrint::Phase3Error
+    end
+    it "allows a commitment with the proper policies" do
+      spc.policies = ["non-circ"]
+      expect { p3v.require_phase_3_policies(spc) }.to_not raise_error
+      spc.policies = ["blo"]
+      expect { p3v.require_phase_3_policies(spc) }.to_not raise_error
+    end
+  end
+  describe "pass_validation? itself" do
+    it "validates a commitment that satisfies all the checks" do
+      ht = build(:ht_item, ocns: [spc.ocn])
+      hol = build(:holding, ocn: spc.ocn, organization: spc.organization)
+      cluster_tap_save [ht, hol]
+      spc.policies = ["blo"]
+      expect(p3v.pass_validation?(spc)).to be true
+      expect(p3v.last_error).to be nil
+    end
+    it "reports any raised errors" do
+      ht = build(:ht_item, ocns: [spc.ocn])
+      hol = build(:holding, ocn: spc.ocn, organization: spc.organization)
+      cluster_tap_save [ht, hol]
+      spc.policies = [] # this should raise something
+      expect(p3v.pass_validation?(spc)).to be false
+      expect(p3v.last_error.message).to match(/Required policies mismatch/)
+    end
+  end
+
+  describe "run" do
+    it "validates and loads records from a file" do
+      # Setup, need there to be items and holdings for 2 of the commitments
+      # (so that we get a warning from validator about the third)
+      [2, 3].each do |ocn|
+        cluster_tap_save [
+          build(:ht_item, ocns: [ocn]),
+          build(:holding, ocn: ocn, organization: "umich")
+        ]
+      end
+      # Check that 2 commitments were loaded
+      expect { p3v.run }.to change { cluster_count(:commitments) }.by(2)
+      # And that we got an error from the third
+      expect(p3v.last_error).to be_a SharedPrint::Phase3Error
+      expect(p3v.last_error.message).to match(/Commitment has no matching cluster/)
+      # And that we got a log file out of it
+      expect(File.exist?(p3v.log.path)).to be true
+    end
+  end
+end


### PR DESCRIPTION
Implementing the phase 3 commitments validator that DEV-464 implies.
`SharedPrint::Phase3Validator` can take a file of commitments and load the ones that meet the criteria set forth in `pass_validation?`.