### PR TITLE
Added policy validation rule from DEV-465

### DIFF
--- a/lib/clusterable/commitment.rb
+++ b/lib/clusterable/commitment.rb
@@ -67,6 +67,11 @@ module Clusterable
       self.deprecation_replaced_by = replacement._id unless replacement.nil?
     end
 
+    # Extra policy validation on top of validates_inclusion_of :policies, in: [...]
+    def self.incompatible_policies?(policies)
+      policies.include?("digitizeondemand") && policies.include?("non-repro")
+    end
+
     private
 
     # If one of the deprecation fields is set they both must be set

--- a/lib/shared_print/phase_3_validator.rb
+++ b/lib/shared_print/phase_3_validator.rb
@@ -67,7 +67,7 @@ module SharedPrint
       require_matching_cluster(cluster)
       require_valid_cluster(cluster)
       require_cluster_ht_items(cluster)
-
+      require_compatible_policies(commitment)
       # Check that org has a matching holdings record in the cluster
       require_matching_org_holding(cluster, commitment.organization)
       # Check that commitment satisfies phase 3 policy rules
@@ -101,6 +101,13 @@ module SharedPrint
     def require_cluster_ht_items(cluster)
       if cluster.ht_items.empty?
         raise SharedPrint::Phase3Error, "Cluster has no ht_items"
+      end
+    end
+
+    def require_compatible_policies(commitment)
+      if Clusterable::Commitment.incompatible_policies?(commitment.policies)
+        msg = "Commitment contains mutually exclusive policies."
+        raise SharedPrint::Phase3Error, msg
       end
     end
 

--- a/lib/shared_print/update_record.rb
+++ b/lib/shared_print/update_record.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "clusterable/commitment"
+
 module SharedPrint
   # An individual update record. Consists of find-fields and update-fields
   class UpdateRecord
@@ -54,7 +56,13 @@ module SharedPrint
       when :bool
         {"true" => true, "false" => false}[val]
       when :array
-        val.split(",").map(&:strip)
+        split_vals = val.split(",").map(&:strip)
+        if key == :policies
+          if Clusterable::Commitment.incompatible_policies?(split_vals)
+            raise ArgumentError, "Policies contain mutually exclusive commitments."
+          end
+        end
+        split_vals
       else
         raise ArgumentError, "Did not know how to cast #{key} (= #{val})"
       end
@@ -79,15 +87,15 @@ module SharedPrint
       {
         committed_date: :date_time,
         facsimile: :bool,
-        policies: :array, # spec probably calls these lending_policy/scanning_repro_policy
         local_bib_id: :string,
         local_item_id: :string,
         local_item_location: :string,
         local_shelving_type: :string,
-        oclc_sym: :string, # might be called oclc_symbol in places, TODO: check that.
-        retention_date: :date_time,
         new_local_id: :string,
-        new_ocn: :integer
+        new_ocn: :integer,
+        oclc_sym: :string, # might be called oclc_symbol in places, TODO: check that.
+        policies: :array,
+        retention_date: :date_time
       }
     end
 


### PR DESCRIPTION
Per https://hathitrust.atlassian.net/browse/DEV-465 we should reject a commitment if it has both `NON-REPRO` & `DIGITIZEONDEMAND`, as these are mutually exclusive.

This goes both for adding new commitments as for updating existing ones.