### PR TITLE
Before scrubbing file, make sure it has no illegal utf8 stuff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG UID=1000
 ARG GID=1000
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
-  nodejs netcat rclone less entr
+  nodejs netcat rclone less entr uchardet
 
 WORKDIR /usr/src/app
 ENV BUNDLE_PATH /gems

--- a/lib/utils/encoding.rb
+++ b/lib/utils/encoding.rb
@@ -1,0 +1,55 @@
+require "open3"
+require "securerandom"
+
+# A class for knowing (uchardet) and changing (iconv) the encoding
+# of a file
+
+module Utils
+  class Encoding
+    def initialize(path)
+      @path = path
+      if @path.nil?
+        raise IOError, "Nil file given"
+      end
+      unless File.exist?(@path)
+        raise IOError, "No valid file given (#{@path.inspect})"
+      end
+      @encoding = uchardet
+    end
+
+    # If a file is utf8 or ascii, then we can load it w/o conversion.
+    def ascii_or_utf8?
+      ["ASCII", "UTF-8"].include? @encoding
+    end
+
+    # Takes an input path to a file and forces it into utf8, discarding
+    # any "illegal input sequence" from the output.
+    # Writes output to a file in /tmp/.
+    def force_utf8
+      out = "/tmp/#{SecureRandom.uuid}"
+      cmd = "zcat -f '#{@path}' | iconv -f #{uchardet} - -t utf8 -c > #{out}"
+      res = capture_outs(cmd)[:stderr]
+      unless res.empty?
+        raise EncodingError, res
+      end
+      out
+    end
+
+    # Execute command and return its stat, stderr and stdout in a hash.
+    # iconv will complain in stderr which backticks would miss.
+    def capture_outs(cmd)
+      stdout, stderr, stat = Open3.capture3(cmd)
+
+      {
+        stat: stat.to_i,
+        stderr: stderr.strip,
+        stdout: stdout.strip
+      }
+    end
+
+    # Get the name of the encoding of the file.
+    def uchardet
+      `zcat -f '#{@path}' | uchardet`.strip
+    end
+  end
+end

--- a/spec/fixtures/non_valid_utf8.txt
+++ b/spec/fixtures/non_valid_utf8.txt
@@ -1,0 +1,4 @@
+oclc	local_id	enum_chron
+15778322	318602424	Ann. stat.ptie 1
+15778322	318602424	Résuméptie 1
+15778322	318602424	v.2

--- a/spec/fixtures/valid_utf8.txt
+++ b/spec/fixtures/valid_utf8.txt
@@ -1,0 +1,1 @@
+This file is nothing but valid utf8!

--- a/spec/scrub/auto_scrub_spec.rb
+++ b/spec/scrub/auto_scrub_spec.rb
@@ -62,4 +62,11 @@ RSpec.describe Scrub::AutoScrub do
     expect(mpm_scrubber.out_files.size).to eq 1
     expect(Utils::LineCounter.count_file_lines(mpm_scrubber.out_files.first)).to eq 3
   end
+
+  it "raises if given a file with illegal utf sequence" do
+    path = "/tmp/umich_mpm_full_20200101_badutf.tsv"
+    FileUtils.cp(fixture("non_valid_utf8.txt"), path)
+    scrubber = described_class.new(path)
+    expect { scrubber.run }.to raise_error EncodingError
+  end
 end

--- a/spec/utils/encoding_spec.rb
+++ b/spec/utils/encoding_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "utils/encoding"
+require "spec_helper"
+
+RSpec.describe Utils::Encoding do
+  let(:valid_fixt) { fixture "valid_utf8.txt" }
+  let(:non_valid_fixt) { fixture "non_valid_utf8.txt" }
+
+  describe "#initialize" do
+    it "requires a path to something existing" do
+      expect { described_class.new(valid_fixt) }.to_not raise_error
+      expect { described_class.new(nil) }.to raise_error IOError
+      FileUtils.rm_f("/tmp/no_file")
+      expect { described_class.new("/tmp/no_file") }.to raise_error IOError
+    end
+  end
+
+  describe "#ascii_or_utf8?" do
+    it "recognizes an all-utf8 file as such" do
+      expect(described_class.new(valid_fixt).ascii_or_utf8?).to be true
+    end
+    it "can tell when a file contains illegal utf8 sequences" do
+      expect(described_class.new(non_valid_fixt).ascii_or_utf8?).to be false
+    end
+  end
+  describe "#force_utf8" do
+    it "takes a non-valid utf8 file and creates a copy without illegal input sequences" do
+      fixed = described_class.new(non_valid_fixt).force_utf8
+      expect(described_class.new(fixed).ascii_or_utf8?).to be true
+      # There's only one line with illegal sequences, a diff should confirm.
+      # But we have to count the diffs, because doing anything with the diff
+      # would mean doing something with the illegal sequence, and we cannot
+      # have that now can we.
+      diffs = `diff -y --suppress-common-lines #{non_valid_fixt} #{fixed} | egrep -c .`
+      expect(diffs.strip).to eq "1"
+    end
+  end
+  describe "#capture_outs" do
+    it "captures the different outputs separately" do
+      outs = described_class.new("/dev/null").capture_outs("echo 'foo'")
+      expect(outs[:stat]).to eq 0
+      expect(outs[:stderr]).to eq ""
+      expect(outs[:stdout]).to eq "foo"
+    end
+    it "captures stderr if there is any" do
+      outs = described_class.new("/dev/null").capture_outs("echo 'foo' 1>&2")
+      expect(outs[:stat]).to eq 0
+      expect(outs[:stderr]).to eq "foo"
+      expect(outs[:stdout]).to eq ""
+    end
+    it "captures exit status" do
+      # But it multiplies exit status by 256?
+      outs = described_class.new("/dev/null").capture_outs("exit 1")
+      expect(outs[:stat]).to eq 256
+      expect(outs[:stderr]).to eq ""
+      expect(outs[:stdout]).to eq ""
+    end
+  end
+end


### PR DESCRIPTION
New class `Utils::Encoding` for checking if a file contains illegal utf8 sequences.
`Scrub::AutoScrub` uses it to check incoming files before subjecting them to further analysis.
`Utils::Encoding` has the ability to force_utf8 and remove illegal sequences (but that's not in use yet, if ever).