### PR TITLE
Added uchardet to Dockerfile.prod

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -6,7 +6,7 @@ ARG UID=1000
 ARG GID=1000
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
-  nodejs rclone
+  nodejs rclone uchardet
 
 RUN gem install bundler
 RUN groupadd -g $GID -o $UNAME


### PR DESCRIPTION
It was there in `Dockerfile` but when trying to use `uchardet` in production I realized I hadn't added it to `Dockerfile.prod`.