### PR TITLE
DEV-632: changed scrub logging to prevent seepage, changed timestamp format on scrub log filename

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe "phctl integration" do
       # Needs a bit of setup.
       local_d = "/tmp/local_member_data/umich-hathitrust-member-data/print\ holdings/#{Time.new.year}/"
       remote_d = "/tmp/remote_member_data/umich-hathitrust-member-data/print\ holdings/#{Time.new.year}/"
-      logfile = File.join(remote_d, "umich_mon_#{Date.today}.log")
+      logfile = File.join(remote_d, "umich_mon_#{Time.new.strftime("%Y%m%d")}.log")
       FileUtils.rm_rf(local_d)
       FileUtils.mkdir_p(remote_d)
       FileUtils.touch("/tmp/rclone.conf")

--- a/spec/scrub/scrub_runner_spec.rb
+++ b/spec/scrub/scrub_runner_spec.rb
@@ -100,7 +100,8 @@ RSpec.describe Scrub::ScrubRunner do
       remote_file = sr.check_new_files.first
       expect { sr.run_file(remote_file) }.to change { cluster_count(:holdings) }.by(6)
       # Expect log file to end up in the remote dir
-      expect(File.exist?(File.join(remote_d.holdings_current, "umich_mon_#{Date.today}.log"))).to be true
+      log = "umich_mon_#{Time.new.strftime("%Y%m%d")}.log"
+      expect(File.exist?(File.join(remote_d.holdings_current, log))).to be true
     end
     it "will refuse a file if it breaks Settings.scrub_line_count_diff_max" do
       remote_d = DataSources::DirectoryLocator.new(Settings.remote_member_data, org1)
@@ -117,8 +118,8 @@ RSpec.describe Scrub::ScrubRunner do
       end
       expect { sr.run_file(remote_file) }.to change { cluster_count(:holdings) }.by(0)
       # Log should have been uploaded.
-      log = File.join(remote_d.holdings_current, "umich_mon_#{Date.today}.log")
-      expect(File.exist?(log)).to be true
+      log = "umich_mon_#{Time.new.strftime("%Y%m%d")}.log"
+      expect(File.exist?(File.join(remote_d.holdings_current, log))).to be true
 
       # We can still force the file through.
       sr_force = described_class.new(


### PR DESCRIPTION
Scrub logs were seeping into each other. 

Uploaded log files had a different timestamp format than we require from the input files, so I harmonized that to all be YYYYMMDD (no dashes) so as to be pleasurable to the eye while I was at it.