### PR TITLE
handle lines with only \r for line breaks

### DIFF
--- a/lib/scrub/autoscrub.rb
+++ b/lib/scrub/autoscrub.rb
@@ -3,6 +3,7 @@
 require "services"
 require "scrub/member_holding_file"
 require "scrub/scrub_output_structure"
+require "securerandom"
 require "utils/line_counter"
 require "utils/encoding"
 
@@ -74,9 +75,32 @@ module Scrub
       end
 
       # Figure out batch size for 100 batches.
-      tot_lines = Utils::LineCounter.count_file_lines(@path)
+      line_counter = Utils::LineCounter.new(@path)
+      tot_lines = line_counter.count_lines
       if tot_lines <= 1
-        raise "File #{@path} has no data? Total lines #{tot_lines}."
+        Services.scrub_logger.warn("#{tot_lines} lines in #{@path}")
+        Services.scrub_logger.info("Checking line count with '\\r' newlines...")
+        # Did we get zero lines because the file uses \r newlines?
+        rand_str = SecureRandom.hex(8)
+        tmp_file = File.open("/tmp/autoscrub_#{rand_str}.tmp", "w")
+        line_counter.io.open(@path) do |f|
+          # Read lines as delimited by \r,
+          # write lines to tmp_file as delimited by \n
+          while (line = f.gets("\r"))
+            tmp_file.puts(line)
+          end
+        end
+        tmp_file.close
+        # If so, use the temporary file as the real one.
+        tmp_lines = Utils::LineCounter.new(tmp_file.path).count_lines
+        Services.scrub_logger.info("Got #{tmp_lines} lines using '\\r' newlines")
+        if tmp_lines > tot_lines
+          FileUtils.mv(tmp_file.path, @path)
+          tot_lines = tmp_lines
+        else
+          # Nope, file is actually empty.
+          raise "File #{@path} has no data? Total lines #{tot_lines}."
+        end
       end
 
       batch_size = tot_lines < 100 ? 100 : tot_lines / 100

--- a/lib/scrub/record_counter.rb
+++ b/lib/scrub/record_counter.rb
@@ -56,7 +56,7 @@ module Scrub
       if path.nil?
         0
       else
-        Utils::LineCounter.count_file_lines(path)
+        Utils::LineCounter.new(path).count_lines
       end
     end
 

--- a/lib/utils/line_counter.rb
+++ b/lib/utils/line_counter.rb
@@ -1,17 +1,29 @@
 require "zlib"
 # Instead of system calls to wc -l everywhere.
 # Usage:
-# Utils::LineCounter.count_file_lines(some_file) # -> number of lines (as an int)
+# Utils::LineCounter.new(some_file).count_lines # -> number of lines (as an int)
 module Utils
   class LineCounter
-    def self.count_file_lines(path)
-      raise IOError, "path #{path} does not point to existing file" unless File.exist?(path)
+    def initialize(path)
+      @path = path
+      unless File.exist?(@path)
+        raise IOError, "path #{@path} does not point to existing file"
+      end
+    end
 
-      if path.end_with?(".gz")
+    # Determine which class to open with
+    def io
+      if @path.end_with?(".gz")
         Zlib::GzipReader
       else
         File
-      end.open(path).count
+      end
+    end
+
+    def count_lines
+      io.open(@path) do |file|
+        file.count
+      end
     end
   end
 end

--- a/spec/fixtures/umich_mon_full_20220101_macstyle_newline.tsv
+++ b/spec/fixtures/umich_mon_full_20220101_macstyle_newline.tsv
@@ -1,0 +1,1 @@
+oclc	local_id	status	condition3	i3	WD	1	i1	CH	4	i4	CH	BRT5	i5	LM	BRT2	i2	LM	6	i6	WD	BRT

--- a/spec/scrub/auto_scrub_spec.rb
+++ b/spec/scrub/auto_scrub_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Scrub::AutoScrub do
     mpm_scrubber = described_class.new(fixture("umich_mpm_full_20221118.tsv"))
     expect { mpm_scrubber.run }.not_to raise_error
     expect(mpm_scrubber.out_files.size).to eq 1
-    expect(Utils::LineCounter.count_file_lines(mpm_scrubber.out_files.first)).to eq 3
+    expect(Utils::LineCounter.new(mpm_scrubber.out_files.first).count_lines).to eq 3
   end
 
   it "raises if given a file with illegal utf sequence" do
@@ -68,5 +68,16 @@ RSpec.describe Scrub::AutoScrub do
     FileUtils.cp(fixture("non_valid_utf8.txt"), path)
     scrubber = described_class.new(path)
     expect { scrubber.run }.to raise_error EncodingError
+  end
+
+  it "can deal with a file using mac style newlines" do
+    # This test might overwrite input file, so run on a copy in /tmp/
+    fn = "umich_mon_full_20220101_macstyle_newline.tsv"
+    fixture_tmp = "/tmp/#{fn}"
+    FileUtils.cp(fixture(fn), fixture_tmp)
+    scrubber = described_class.new(fixture_tmp)
+    expect { scrubber.run }.not_to raise_error
+    expect(scrubber.out_files.size).to eq 1
+    FileUtils.rm(fixture_tmp)
   end
 end

--- a/spec/utils/line_counter_spec.rb
+++ b/spec/utils/line_counter_spec.rb
@@ -10,30 +10,43 @@ RSpec.describe Utils::LineCounter do
     FileUtils.rm_rf(test_dir)
     FileUtils.mkdir_p(test_dir)
   end
+
   after(:all) do
     FileUtils.rm_rf(test_dir)
   end
+
   let(:null_path) { "/tmp/i/do/not/exist" }
   let(:empty_file) { File.join(test_dir, "empty_file") }
   let(:ten_line_file) { File.join(test_dir, "ten_line_file") }
   let(:gzip_file) { File.join(test_dir, "gzip_file.gz") }
+
   it "raises if path does not point to a file" do
-    expect { described_class.count_file_lines(null_path) }.to raise_error IOError
+    expect { described_class.new(null_path) }.to raise_error IOError
   end
+
   it "counts zero lines in an empty file" do
     FileUtils.touch(empty_file)
-    expect(described_class.count_file_lines(empty_file)).to eq 0
+    expect(described_class.new(empty_file).count_lines).to eq 0
   end
+
+  it "gets the proper IO class for a given file" do
+    FileUtils.touch ten_line_file
+    FileUtils.touch gzip_file
+    expect(described_class.new(ten_line_file).io).to eq File
+    expect(described_class.new(gzip_file).io).to eq Zlib::GzipReader
+  end
+
   it "counts as many lines as there are in a file" do
     File.open(ten_line_file, "w") do |file|
       1.upto(10).each do |i|
         file.puts i
       end
     end
-    expect(described_class.count_file_lines(ten_line_file)).to eq 10
+    expect(described_class.new(ten_line_file).count_lines).to eq 10
   end
+
   it "counts lines in gzipped lines too" do
     system(%(echo -e "1\n2\n3" | gzip > #{gzip_file}))
-    expect(described_class.count_file_lines(gzip_file)).to eq 3
+    expect(described_class.new(gzip_file).count_lines).to eq 3
   end
 end


### PR DESCRIPTION
Some holdings files we see only have `\r` for a line break (old mac style), which needs to be read differently or the whole file looks like a one liner. 

This workaround consists of reading the file with `file.gets("\r")` and writing those lines to a temporary file with proper line breaks, and then overwriting the old file with the new file.