### PR TITLE
DEV-406: Use temporary directories for test

### DIFF
--- a/config/environments/test.yml
+++ b/config/environments/test.yml
@@ -1,27 +1,27 @@
-concordance_path: /tmp/concordance
-cost_report_freq_path: /tmp/cost_report_freq
-cost_report_path: /tmp/cost_reports
-deprecation_report_path: /tmp/deprecation_report
-estimates_path: /tmp/estimates
+concordance_path: <%= ENV["TEST_TMP"] %>/concordance
+cost_report_freq_path: <%= ENV["TEST_TMP"] %>/cost_report_freq
+cost_report_path: <%= ENV["TEST_TMP"] %>/cost_reports
+deprecation_report_path: <%= ENV["TEST_TMP"] %>/deprecation_report
+estimates_path: <%= ENV["TEST_TMP"] %>/estimates
 etas_overlap_batch_size: 50
-etas_overlap_reports_path: /tmp/etas_overlap_reports
-etas_overlap_reports_remote_path: /tmp/etas_overlap_report_remote
-hathifile_path: /tmp/hathifiles
-large_cluster_ocns: /tmp/large_cluster_ocns.txt
-loading_flag_path: /tmp/loading_flag
-local_member_data: /tmp/local_member_data
-local_report_path: /tmp/local_reports
+etas_overlap_reports_path: <%= ENV["TEST_TMP"] %>/etas_overlap_reports
+etas_overlap_reports_remote_path: <%= ENV["TEST_TMP"] %>/etas_overlap_report_remote
+hathifile_path: <%= ENV["TEST_TMP"] %>/hathifiles
+large_cluster_ocns: <%= ENV["TEST_TMP"] %>/large_cluster_ocns.txt
+loading_flag_path: <%= ENV["TEST_TMP"] %>/loading_flag
+local_member_data: <%= ENV["TEST_TMP"] %>/local_member_data
+local_report_path: <%= ENV["TEST_TMP"] %>/local_reports
 oclc_collection_id_map_path: spec/fixtures/oclc_collection_id_map.tsv
-oclc_registration_report_path: /tmp
-rclone_config_path: /tmp/rclone.conf
-remote_member_data: /tmp/remote_member_data
-replace_commitment_report_path: /tmp/replace_commitment_report
-scrub_base_path: /tmp/scrub_data
+oclc_registration_report_path: <%= ENV["TEST_TMP"] %>
+rclone_config_path: <%= ENV["TEST_TMP"] %>/rclone.conf
+remote_member_data: <%= ENV["TEST_TMP"] %>/remote_member_data
+replace_commitment_report_path: <%= ENV["TEST_TMP"] %>/replace_commitment_report
+scrub_base_path: <%= ENV["TEST_TMP"] %>/scrub_data
 scrub_chunk_count: 4
-scrub_chunk_work_dir: /tmp
+scrub_chunk_work_dir: <%= ENV["TEST_TMP"] %>
 scrub_line_count_diff_max: 0.05
-shared_print_report_path: /tmp/shared_print_reports
-shared_print_update_report_path: /tmp/shared_print_update_report
+shared_print_report_path: <%= ENV["TEST_TMP"] %>/shared_print_reports
+shared_print_update_report_path: <%= ENV["TEST_TMP"] %>/shared_print_update_report
 slack_endpoint: http://slack.test/endpoint
 target_cost: 9999
 

--- a/spec/concordance_validation/delta_spec.rb
+++ b/spec/concordance_validation/delta_spec.rb
@@ -7,15 +7,18 @@ require "concordance_validation/delta"
 require "fileutils"
 
 # make test files
-FileUtils.mkdir_p Settings.concordance_path + "/validated/"
-FileUtils.mkdir_p Settings.concordance_path + "/diffs/"
-File.write(Settings.concordance_path + "/validated/old_concordance.txt",
-  ["dupe\tdupe", "delete\tdelete"].join("\n"))
-File.write(Settings.concordance_path + "/validated/new_concordance.txt",
-  ["dupe\tdupe", "add\tadd"].join("\n"))
 
 RSpec.describe ConcordanceValidation::Delta do
   let(:delta) { described_class.new("old_concordance.txt", "new_concordance.txt") }
+
+  before(:each) do
+    FileUtils.mkdir_p Settings.concordance_path + "/validated/"
+    FileUtils.mkdir_p Settings.concordance_path + "/diffs/"
+    File.write(Settings.concordance_path + "/validated/old_concordance.txt",
+      ["dupe\tdupe", "delete\tdelete"].join("\n"))
+    File.write(Settings.concordance_path + "/validated/new_concordance.txt",
+      ["dupe\tdupe", "add\tadd"].join("\n"))
+  end
 
   describe "#initialize" do
     it "opens the old and new concordances for reading" do

--- a/spec/data_sources/directory_locator_spec.rb
+++ b/spec/data_sources/directory_locator_spec.rb
@@ -2,27 +2,22 @@
 
 require "spec_helper"
 require "data_sources/directory_locator"
+require "fileutils"
 
 # Conf file must exist, or Utils::FileTransfer raises an error.
 FileUtils.touch(Settings.rclone_config_path)
 
 RSpec.describe DataSources::DirectoryLocator do
   let(:org) { "test" }
-  let(:root) { "/tmp/directory_locator_test" }
+  let(:root) { ENV["TEST_TMP"] }
   let(:dl) { described_class.new(root, org) }
   let(:year) { Time.new.year.to_s }
-  let(:base_x) { "/tmp/directory_locator_test/test-hathitrust-member-data" }
-  let(:holdings_x) { "/tmp/directory_locator_test/test-hathitrust-member-data/print holdings" }
-  let(:sp_x) { "/tmp/directory_locator_test/test-hathitrust-member-data/shared print" }
-  let(:analysis_x) { "/tmp/directory_locator_test/test-hathitrust-member-data/analysis" }
+  let(:base_x) { "#{root}/test-hathitrust-member-data" }
+  let(:holdings_x) { "#{root}/test-hathitrust-member-data/print holdings" }
+  let(:sp_x) { "#{root}/test-hathitrust-member-data/shared print" }
+  let(:analysis_x) { "#{root}/test-hathitrust-member-data/analysis" }
 
-  before(:each) do
-    FileUtils.rm_rf(root)
-  end
-
-  after(:each) do
-    FileUtils.rm_rf(root)
-  end
+  before(:each) { FileUtils.touch(Settings.rclone_config_path) }
 
   describe "attr_reader" do
     it "are set on initialize and readable" do

--- a/spec/data_sources/holdings_db_spec.rb
+++ b/spec/data_sources/holdings_db_spec.rb
@@ -35,40 +35,27 @@ RSpec.describe DataSources::HoldingsDB do
       expect(c.tables).to include(:ht_billing_members)
     end
 
-    context "with clean settings" do
-      around :each do |example|
-        old_db_setting = Settings.database
-        Settings.database = nil
+    it "connects with url" do
+      Settings.database = {url: connection_string}
+      c = described_class.connection
+      expect(c.tables).to include(:ht_billing_members)
+    end
 
-        begin
-          example.run
-        ensure
-          Settings.database = old_db_setting
-        end
-      end
+    it "connects with keyword options" do
+      Settings.database = {opts: opts}
+      c = described_class.connection
+      expect(c.tables).to include(:ht_billing_members)
+    end
 
-      it "connects with url" do
-        Settings.database = {url: connection_string}
-        c = described_class.connection
-        expect(c.tables).to include(:ht_billing_members)
-      end
+    it "fails as expected with bad user" do
+      Settings.database = {opts: opts.merge(user: "NO_SUCH_USER")}
+      expect { described_class.connection }.to raise_error(Sequel::DatabaseConnectionError)
+    end
 
-      it "connects with keyword options" do
-        Settings.database = {opts: opts}
-        c = described_class.connection
-        expect(c.tables).to include(:ht_billing_members)
-      end
-
-      it "fails as expected with bad user" do
-        Settings.database = {opts: opts.merge(user: "NO_SUCH_USER")}
-        expect { described_class.connection }.to raise_error(Sequel::DatabaseConnectionError)
-      end
-
-      it "provided opts override settings" do
-        Settings.database = {opts: opts.merge(user: "NO_SUCH_USER")}
-        c = described_class.connection(opts: opts)
-        expect(c.tables).to include(:ht_billing_members)
-      end
+    it "provided opts override settings" do
+      Settings.database = {opts: opts.merge(user: "NO_SUCH_USER")}
+      c = described_class.connection(opts: opts)
+      expect(c.tables).to include(:ht_billing_members)
     end
   end
 

--- a/spec/file_mutex_spec.rb
+++ b/spec/file_mutex_spec.rb
@@ -5,10 +5,8 @@ require "file_mutex"
 require "fileutils"
 
 RSpec.describe FileMutex do
-  let(:path) { "/tmp/file_mutex" }
+  let(:path) { "#{ENV["TEST_TMP"]}/file_mutex" }
   let(:mutex) { described_class.new(path) }
-
-  before(:each) { FileUtils.rm_f(path) }
 
   describe "#with_lock" do
     context "when the file exists" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -43,14 +43,9 @@ RSpec.describe "phctl integration" do
     end
 
     it "Concordance loads concordance diffs" do
-      old_path = Settings.concordance_path
-      begin
-        Settings.concordance_path = fixture("concordance")
-        expect { phctl(*%w[load concordance 2022-08-01]) }
-          .to change { cluster_count(:ocn_resolutions) }.by(5)
-      ensure
-        Settings.concordance_path = old_path
-      end
+      Settings.concordance_path = fixture("concordance")
+      expect { phctl(*%w[load concordance 2022-08-01]) }
+        .to change { cluster_count(:ocn_resolutions) }.by(5)
     end
 
     it "Holdings loads holdings" do
@@ -80,7 +75,7 @@ RSpec.describe "phctl integration" do
       end
 
       input = fixture("concordance_sample.txt")
-      output = "/tmp/concordance_output"
+      output = "#{ENV["TEST_TMP"]}/concordance_output"
       cleanup(output)
 
       begin
@@ -93,8 +88,8 @@ RSpec.describe "phctl integration" do
     end
 
     it "Delta produces adds and deletes" do
-      validated_path = "/tmp/concordance/validated"
-      diffs_path = "/tmp/concordance/diffs"
+      validated_path = "#{ENV["TEST_TMP"]}/concordance/validated"
+      diffs_path = "#{ENV["TEST_TMP"]}/concordance/diffs"
 
       FileUtils.mkdir_p(validated_path)
       FileUtils.mkdir_p(diffs_path)
@@ -103,8 +98,6 @@ RSpec.describe "phctl integration" do
       Jobs::Concordance::Delta.new.perform("concordance_sample.txt", "concordance_sample_2.txt")
       expect(File.size("#{diffs_path}/comm_diff_#{Date.today}.txt.adds")).to be > 0
       expect(File.size("#{diffs_path}/comm_diff_#{Date.today}.txt.deletes")).to be > 0
-    ensure
-      FileUtils.rm_rf("/tmp/concordance")
     end
   end
 
@@ -118,59 +111,54 @@ RSpec.describe "phctl integration" do
     it "CostReport produces output" do
       phctl(*%w[report costreport])
       year = Time.new.year.to_s
-      expect(File.read(Dir.glob("/tmp/cost_reports/#{year}/*").first))
+      expect(File.read(Dir.glob("#{ENV["TEST_TMP"]}/cost_reports/#{year}/*").first))
         .to match(/Target cost: 9999/)
     end
 
     it "Estimate produces output" do
       phctl("report", "estimate", fixture("ocn_list.txt"))
 
-      expect(File.read(Dir.glob("/tmp/estimates/ocn_list-estimate-*.txt").first))
+      expect(File.read(Dir.glob("#{ENV["TEST_TMP"]}/estimates/ocn_list-estimate-*.txt").first))
         .to match(/Total Estimated IC Cost/)
     end
 
     it "MemberCount produces output" do
-      output_path = "/tmp/member_count_output"
-      FileUtils.rm_rf(output_path) if File.exist?(output_path)
+      output_path = "#{ENV["TEST_TMP"]}/member_count_output"
 
-      begin
-        phctl("report", "member-counts", fixture("freq.txt"), output_path)
-        expect(File.size("#{output_path}/member_counts_#{Date.today}.tsv")).to be > 0
-      ensure
-        FileUtils.rm_rf(output_path)
-      end
+      phctl("report", "member-counts", fixture("freq.txt"), output_path)
+      expect(File.size("#{output_path}/member_counts_#{Date.today}.tsv")).to be > 0
     end
 
     it "EtasOverlap produces output" do
       phctl(*%w[report etas-overlap umich])
 
-      expect(File.size("/tmp/etas_overlap_report_remote/umich-hathitrust-member-data/analysis/etas_overlap_umich_#{Date.today}.tsv.gz")).to be > 0
+      expect(File.size("#{ENV["TEST_TMP"]}/etas_overlap_report_remote/umich-hathitrust-member-data/analysis/etas_overlap_umich_#{Date.today}.tsv.gz")).to be > 0
     end
 
     it "EligibleCommitments produces output" do
       phctl(*%w[report eligible-commitments 1])
 
-      expect(File.read(Dir.glob("/tmp/shared_print_reports/eligible_commitments_*").first))
+      expect(File.read(Dir.glob("#{ENV["TEST_TMP"]}/shared_print_reports/eligible_commitments_*").first))
         .to match(/^organization/)
     end
 
     it "UncommittedHoldings produces output" do
       phctl(*%w[report uncommitted-holdings --organization umich])
 
-      expect(File.read(Dir.glob("/tmp/shared_print_reports/uncommitted_holdings_umich_*").first))
+      expect(File.read(Dir.glob("#{ENV["TEST_TMP"]}/shared_print_reports/uncommitted_holdings_umich_*").first))
         .to match(/^organization/)
     end
 
     it "RareUncommittedCounts produces output" do
       phctl(*%w[report rare-uncommitted-counts --max-h 1])
 
-      expect(File.read(Dir.glob("/tmp/shared_print_reports/rare_uncommitted_counts_*").first))
+      expect(File.read(Dir.glob("#{ENV["TEST_TMP"]}/shared_print_reports/rare_uncommitted_counts_*").first))
         .to match(/^number of holding libraries/)
     end
 
     it "OCLCRegistration produces output" do
       phctl(*%w[report oclc-registration umich])
-      expect(File.read(Dir.glob("/tmp/oclc_registration_umich_*").first))
+      expect(File.read(Dir.glob("#{ENV["TEST_TMP"]}/oclc_registration_umich_*").first))
         .to match(/^local_oclc/)
     end
   end
@@ -178,16 +166,14 @@ RSpec.describe "phctl integration" do
   describe "Scrub" do
     it "'scrub x' loads records and produces output for org x" do
       # Needs a bit of setup.
-      local_d = "/tmp/local_member_data/umich-hathitrust-member-data/print\ holdings/#{Time.new.year}/"
-      remote_d = "/tmp/remote_member_data/umich-hathitrust-member-data/print\ holdings/#{Time.new.year}/"
+      local_d = "#{ENV["TEST_TMP"]}/local_member_data/umich-hathitrust-member-data/print\ holdings/#{Time.new.year}/"
+      remote_d = "#{ENV["TEST_TMP"]}/remote_member_data/umich-hathitrust-member-data/print\ holdings/#{Time.new.year}/"
       logfile = File.join(remote_d, "umich_mon_#{Time.new.strftime("%Y%m%d")}.log")
-      FileUtils.rm_rf(local_d)
       FileUtils.mkdir_p(remote_d)
-      FileUtils.touch("/tmp/rclone.conf")
-      FileUtils.rm_rf(logfile)
       FileUtils.cp("spec/fixtures/umich_mon_full_20220101.tsv", remote_d)
       # Verify precondition:
       expect(File.exist?(logfile)).to be false
+      expect(File.exist?(local_d)).to be false
       # Actual tests:
       # Only set force_holding_loader_cleanup_test to true in testing.
       expect { phctl(*%w[scrub umich --force_holding_loader_cleanup_test --force]) }.to change { cluster_count(:holdings) }.by(6)

--- a/spec/loader/hathifile_spec.rb
+++ b/spec/loader/hathifile_spec.rb
@@ -6,7 +6,7 @@ require "loader/hathifile"
 RSpec.describe Loader::Hathifile, type: "loaded_file" do
   let(:logger) { double(:logger, info: true) }
   let(:hathifile) { described_class.new(Date.parse("2021-04-02")) }
-  let(:expected_filename) { Pathname.new("/tmp/hathifiles/hathi_upd_20210401.txt.gz") }
+  let(:expected_filename) { Pathname.new("#{ENV["TEST_TMP"]}/hathifiles/hathi_upd_20210401.txt.gz") }
 
   it "computes the path for an update file" do
     expect(hathifile.filename).to eq(expected_filename)

--- a/spec/ocn_concordance_diffs_spec.rb
+++ b/spec/ocn_concordance_diffs_spec.rb
@@ -6,9 +6,9 @@ require "ocn_concordance_diffs"
 RSpec.describe OCNConcordanceDiffs, type: "loaded_file" do
   let(:logger) { double(:logger, info: true) }
   let(:concordance_diffs) { described_class.new(Date.parse("2021-04-02")) }
-  let(:expected_filename) { Pathname.new("/tmp/concordance/diffs/comm_diff_2021-04-02.txt") }
-  let(:expected_adds) { Pathname.new("/tmp/concordance/diffs/comm_diff_2021-04-02.txt.adds") }
-  let(:expected_deletes) { Pathname.new("/tmp/concordance/diffs/comm_diff_2021-04-02.txt.deletes") }
+  let(:expected_filename) { Pathname.new("#{ENV["TEST_TMP"]}/concordance/diffs/comm_diff_2021-04-02.txt") }
+  let(:expected_adds) { Pathname.new("#{ENV["TEST_TMP"]}/concordance/diffs/comm_diff_2021-04-02.txt.adds") }
+  let(:expected_deletes) { Pathname.new("#{ENV["TEST_TMP"]}/concordance/diffs/comm_diff_2021-04-02.txt.deletes") }
 
   it "computes the path to concordance diffs" do
     expect(concordance_diffs.filename).to eq(expected_filename)

--- a/spec/phctl_spec.rb
+++ b/spec/phctl_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "PHCTL::PHCTL", type: :sidekiq_fake do
       it "does the thing" do
         PHCTL::PHCTL.start(["report", "costreport", "--inline"])
         year = Time.new.year.to_s
-        expect(File.read(Dir.glob("/tmp/cost_reports/#{year}/*").first))
+        expect(File.read(Dir.glob("#{ENV["TEST_TMP"]}/cost_reports/#{year}/*").first))
           .to match(/Target cost: 9999/)
       end
     end

--- a/spec/reports/cost_report_spec.rb
+++ b/spec/reports/cost_report_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Reports::CostReport do
   let(:holding2) { build(:holding, ocn: c.ocns.first, organization: "smu") }
 
   before(:each) do
-    @old_cost = Settings.target_cost
     Cluster.each(&:delete)
     c.save
     c2.save
@@ -25,10 +24,6 @@ RSpec.describe Reports::CostReport do
     Clustering::ClusterHtItem.new(mpm).cluster.tap(&:save)
     Clustering::ClusterHolding.new(holding).cluster.tap(&:save)
     Clustering::ClusterHolding.new(holding2).cluster.tap(&:save)
-  end
-
-  after(:each) do
-    Settings.target_cost = @old_cost
   end
 
   describe "#num_volumes" do

--- a/spec/reports/estimate_spec.rb
+++ b/spec/reports/estimate_spec.rb
@@ -11,15 +11,10 @@ RSpec.describe Reports::Estimate do
   let(:rpt) { described_class.new }
 
   before(:each) do
-    @old_cost = Settings.target_cost
     Settings.target_cost = 20
     Cluster.each(&:delete)
     Clustering::ClusterHtItem.new(ht_allow).cluster.tap(&:save)
     Clustering::ClusterHtItem.new(ht_deny).cluster.tap(&:save)
-  end
-
-  after(:each) do
-    Settings.target_cost = @old_cost
   end
 
   describe "#cost_report" do

--- a/spec/reports/etas_organization_overlap_report_spec.rb
+++ b/spec/reports/etas_organization_overlap_report_spec.rb
@@ -9,17 +9,6 @@ RSpec.describe Reports::EtasOrganizationOverlapReport do
   let(:tmp_pers) { Settings.etas_overlap_reports_path }
   let(:tmp_rmt) { Settings.etas_overlap_reports_remote_path }
 
-  before(:each) do
-    FileUtils.rm_rf(tmp_pers)
-    FileUtils.rm_rf(tmp_rmt)
-  end
-
-  after(:each) do
-    FileUtils.rm_rf(tmp_local)
-    FileUtils.rm_rf(tmp_pers)
-    FileUtils.rm_rf(tmp_rmt)
-  end
-
   describe "#initialize" do
     it "makes the directory if it doesn't exist" do
       rpt = described_class.new

--- a/spec/reports/member_counts_spec.rb
+++ b/spec/reports/member_counts_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "MemberCounts" do
   let(:mokk_members) { ["umich", "utexas", "smu"] }
 
   let(:mcr) do
-    Reports::MemberCounts.new("/dev/null", "/tmp/member_counts_reports", mokk_members)
+    Reports::MemberCounts.new("/dev/null", "#{ENV["TEST_TMP"]}/member_counts_reports", mokk_members)
   end
 
   let(:rows) { mcr.rows }
@@ -62,7 +62,7 @@ RSpec.describe "MemberCounts" do
   describe "matching_volumes" do
     it "reads a freq file and populates report accordingly" do
       freq_file = "spec/fixtures/freq.txt"
-      rows2 = Reports::MemberCounts.new(freq_file, "/tmp/member_counts", mokk_members).rows
+      rows2 = Reports::MemberCounts.new(freq_file, "#{ENV["TEST_TMP"]}/member_counts", mokk_members).rows
       expect(rows2["umich"].matching_volumes["spm"]).to eq(1)
       expect(rows2["umich"].matching_volumes["mpm"]).to eq(2)
       expect(rows2["umich"].matching_volumes["ser"]).to eq(1)

--- a/spec/scrub/auto_scrub_spec.rb
+++ b/spec/scrub/auto_scrub_spec.rb
@@ -4,43 +4,57 @@ require "scrub/autoscrub"
 require "utils/line_counter"
 
 RSpec.describe Scrub::AutoScrub do
-  # Set up a minimal OK input file, which should result in success.
-  test_file_path = "/tmp/testmember_mon_full_20201230_rspec.tsv"
-  test_file = File.open(test_file_path, "w")
-  test_file.puts("oclc\tlocal_id")
-  test_file.puts("555\ti12345678")
-  test_file.close
+  def test_file
+    # Set up a minimal OK input file, which should result in success.
+    test_file_path = "#{ENV["TEST_TMP"]}/testmember_mon_full_20201230_rspec.tsv"
+    File.open(test_file_path, "w") do |f|
+      f.puts("oclc\tlocal_id")
+      f.puts("555\ti12345678")
+    end
+
+    test_file_path
+  end
 
   let(:today_ymd) { Time.new.strftime("%F") }
-  let(:scrubber) { described_class.new(test_file_path) }
+  let(:scrubber) { described_class.new(test_file) }
   let(:out_struct) { scrubber.output_struct }
 
   it "does a scrub without raising anything" do
     expect { scrubber.run }.not_to raise_error
   end
 
-  it "created a set of directories handled by ScrubOutputStructure" do
+  it "creates a set of directories handled by ScrubOutputStructure" do
+    scrubber.run
+
     expect(Dir.exist?(out_struct.member_dir)).to be(true)
     expect(Dir.exist?(out_struct.member_log)).to be(true)
     expect(Dir.exist?(out_struct.member_output)).to be(true)
   end
 
-  it "datestamped dirs with current date" do
+  it "datestamps dirs with current date" do
+    scrubber.run
+
     expect(out_struct.latest("output").to_path).to end_with today_ymd
   end
 
-  it "put files in the ready_to_load and log dirs" do
+  it "puts files in the ready_to_load and log dirs" do
+    scrubber.run
+
     expect(Dir.empty?(out_struct.member_ready_to_load)).to be(false)
     expect(Dir.empty?(out_struct.latest("log"))).to be(false)
   end
 
-  it "didn't put anything in the loaded dir" do
+  it "doesn't put anything in the loaded dir" do
+    scrubber.run
+
     expect(Dir.empty?(out_struct.member_loaded)).to be(true)
   end
 
-  xit "produced valid JSON" do
+  it "produces valid JSON" do
+    scrubber.run
+
     latest_rtl = out_struct.member_ready_to_load.children.select do |file|
-      file.match?(/testmember_mono_[0-9-]+.ndj/)
+      file.match?(/testmember_mon_[0-9-]+.ndj/)
     end.max
 
     first_line = File.open(
@@ -51,11 +65,6 @@ RSpec.describe Scrub::AutoScrub do
     expect(JSON.parse(first_line)).to be_a(Hash)
   end
 
-  it "cleans up after the last test" do
-    FileUtils.remove_dir(out_struct.member_dir)
-    expect(Dir.exist?(out_struct.member_dir)).to be(false)
-  end
-
   it "ok with enum_chron in the header line" do
     mpm_scrubber = described_class.new(fixture("umich_mpm_full_20221118.tsv"))
     expect { mpm_scrubber.run }.not_to raise_error
@@ -64,7 +73,7 @@ RSpec.describe Scrub::AutoScrub do
   end
 
   it "raises if given a file with illegal utf sequence" do
-    path = "/tmp/umich_mpm_full_20200101_badutf.tsv"
+    path = "#{ENV["TEST_TMP"]}/umich_mpm_full_20200101_badutf.tsv"
     FileUtils.cp(fixture("non_valid_utf8.txt"), path)
     scrubber = described_class.new(path)
     expect { scrubber.run }.to raise_error EncodingError

--- a/spec/scrub/chunker_spec.rb
+++ b/spec/scrub/chunker_spec.rb
@@ -3,7 +3,6 @@
 require "spec_helper"
 require "scrub/chunker"
 
-Settings.scrub_chunk_work_dir = "/tmp/scrub_chunks"
 RSpec.describe Scrub::Chunker do
   let(:pre_chunked_file) { "spec/fixtures/pre_chunk.tsv" }
   let(:input_line_count) { 16 }

--- a/spec/scrub/member_holding_spec.rb
+++ b/spec/scrub/member_holding_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Scrub::MemberHolding do
   end
 
   context "with known scrub logger" do
-    let(:tmp_log) { "/tmp/member_holding_spec.log" }
+    let(:tmp_log) { "#{ENV["TEST_TMP"]}/member_holding_spec.log" }
 
     around(:each) do |example|
       # FIXME should log to string in RAM; duplicative of the around(:each, type: "loaded_file")

--- a/spec/scrub/record_counter_spec.rb
+++ b/spec/scrub/record_counter_spec.rb
@@ -15,9 +15,6 @@ RSpec.describe Scrub::RecordCounter do
   }
   let(:hundo) { 100 }
   let(:small_diff) { (Settings.scrub_line_count_diff_max * 100) - 1 }
-  before(:each) do
-    FileUtils.rm_rf("/tmp/scrub_data/#{org}/")
-  end
   def put_x_lines_in_file(x, file)
     File.open(file, "w") do |f|
       1.upto(x) do |i|

--- a/spec/scrub/scrub_runner_spec.rb
+++ b/spec/scrub/scrub_runner_spec.rb
@@ -19,13 +19,6 @@ RSpec.describe Scrub::ScrubRunner do
     FileUtils.touch(Settings.rclone_config_path)
     FileUtils.mkdir_p(Settings.local_member_data)
     FileUtils.mkdir_p(Settings.remote_member_data)
-    FileUtils.rm_rf("/tmp/scrub_data/#{org1}/")
-  end
-
-  after(:each) do
-    FileUtils.rm_f(Settings.rclone_config_path)
-    FileUtils.rm_rf(Settings.local_member_data)
-    FileUtils.rm_rf(Settings.remote_member_data)
   end
 
   describe "#check_old_files" do
@@ -110,8 +103,8 @@ RSpec.describe Scrub::ScrubRunner do
       FileUtils.cp(fixture_file, remote_d.holdings_current)
       remote_file = sr.check_new_files.first
 
-      FileUtils.mkdir_p("/tmp/scrub_data/#{org1}/loaded/")
-      File.open("/tmp/scrub_data/#{org1}/loaded/umich_mon_1.ndj", "w") do |file|
+      FileUtils.mkdir_p("#{ENV["TEST_TMP"]}/scrub_data/#{org1}/loaded/")
+      File.open("#{ENV["TEST_TMP"]}/scrub_data/#{org1}/loaded/umich_mon_1.ndj", "w") do |file|
         1.upto(20) do |i|
           file.puts i
         end

--- a/spec/shared_print/deprecator_spec.rb
+++ b/spec/shared_print/deprecator_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe SharedPrint::Deprecator do
 
   before(:each) do
     Cluster.collection.find.delete_many
-    FileUtils.rm(Dir.glob("/tmp/deprecation_report/*"))
     dep.clear_err
   end
 
@@ -77,7 +76,7 @@ RSpec.describe SharedPrint::Deprecator do
     make_commitment(5, org_2, "E")
     make_commitment(6, org_2, "F")
     # Make a deprecation file (#7)
-    deprecation_file_path = "/tmp/acceptance_criteria_file.tsv"
+    deprecation_file_path = "#{ENV["TEST_TMP"]}/acceptance_criteria_file.tsv"
     File.open(deprecation_file_path, "w") do |f|
       f.puts "organization\tocn\tlocal_id\tdeprecation_status"
       f.puts "umich\t3\tC\tM"
@@ -98,7 +97,7 @@ RSpec.describe SharedPrint::Deprecator do
     expect(lookup_commitment(1).deprecated?).to be false
     expect(lookup_commitment(2).deprecated?).to be false
 
-    report_slurp = File.read(Dir.glob("/tmp/deprecation_report/commitments_deprecator_*").first).split("\n")
+    report_slurp = File.read(Dir.glob("#{ENV["TEST_TMP"]}/deprecation_report/commitments_deprecator_*").first).split("\n")
     # We logged what we did and what we could not do (#11 & 12).
     today = Date.today.strftime("%Y-%m-%d")
     expect(report_slurp.count { |x| x =~ /Commitment deprecated.+deprecation_date: #{today}/ }).to eq 2

--- a/spec/shared_print/phase_3_validator_spec.rb
+++ b/spec/shared_print/phase_3_validator_spec.rb
@@ -15,10 +15,8 @@ RSpec.describe SharedPrint::Phase3Validator do
       expect(p3v.last_error).to be nil
     end
     it "raises if missing settings" do
-      original_setting = Settings.local_report_path
       Settings.local_report_path = nil
       expect { described_class.new(fixt) }.to raise_error(/Missing Settings/)
-      Settings.local_report_path = original_setting
     end
   end
 

--- a/spec/utils/encoding_spec.rb
+++ b/spec/utils/encoding_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Utils::Encoding do
     it "requires a path to something existing" do
       expect { described_class.new(valid_fixt) }.to_not raise_error
       expect { described_class.new(nil) }.to raise_error IOError
-      FileUtils.rm_f("/tmp/no_file")
-      expect { described_class.new("/tmp/no_file") }.to raise_error IOError
+      FileUtils.rm_f("#{ENV["TEST_TMP"]}/no_file")
+      expect { described_class.new("#{ENV["TEST_TMP"]}/no_file") }.to raise_error IOError
     end
   end
 

--- a/spec/utils/file_transfer_spec.rb
+++ b/spec/utils/file_transfer_spec.rb
@@ -7,7 +7,7 @@ require "services"
 
 # Since rclone does not care what the remote location is,
 # and since we do not have a separate test dropbox,
-# these tests use directories under /tmp/ as a fake remote location.
+# these tests use directories under TEST_TMP as a fake remote location.
 #
 # So, CAVEAT EMPTOR, it does not truly test rclone's ability to
 # transfer files to a remote location, just that the wrapper code
@@ -15,17 +15,15 @@ require "services"
 
 RSpec.describe Utils::FileTransfer do
   let(:ft) { described_class.new }
-  # Do not change local_dir or remote_dir to something important,
-  # as they WILL be deleted during these tests.
-  let(:local_dir) { "/tmp/file_transfer_test/local" }
-  let(:remote_dir) { "/tmp/file_transfer_test/remote" }
+  let(:local_dir) { "#{ENV["TEST_TMP"]}/file_transfer_test/local" }
+  let(:remote_dir) { "#{ENV["TEST_TMP"]}/file_transfer_test/remote" }
   let(:local_file_name) { "test_file_a.txt" }
   let(:remote_file_name) { "test_file_b.txt" }
   let(:local_file_path) { "#{local_dir}/#{local_file_name}" }
   let(:remote_file_path) { "#{remote_dir}/#{remote_file_name}" }
   let(:conf) { Settings.rclone_config_path }
-  let(:missing_dir) { "/dev/null/foo" }
-  let(:missing_file) { "/dev/null/foo.txt" }
+  let(:missing_dir) { "/nonexistent/foo" }
+  let(:missing_file) { "/nonexistent/foo.txt" }
 
   # Clean up temporary files and directories
   before(:each) do
@@ -38,18 +36,11 @@ RSpec.describe Utils::FileTransfer do
     FileUtils.touch remote_file_path
   end
 
-  after(:each) do
-    FileUtils.rm_rf local_dir
-    FileUtils.rm_rf remote_dir
-  end
-
   describe "initialize" do
     it "requires conf file to be set in Settings" do
       expect { described_class.new }.not_to raise_error
-      original_path = Settings.rclone_config_path
       Settings.rclone_config_path = nil
       expect { described_class.new }.to raise_error RuntimeError
-      Settings.rclone_config_path = original_path
     end
     it "requires conf file to exist" do
       expect { described_class.new }.not_to raise_error

--- a/spec/utils/line_counter_spec.rb
+++ b/spec/utils/line_counter_spec.rb
@@ -3,17 +3,14 @@
 require "utils/line_counter"
 require "spec_helper"
 
-# Because when declared as a `let` it does not work in the after(:all) hook.
-test_dir = "/tmp/line_counter_test"
 RSpec.describe Utils::LineCounter do
+  let(:test_dir) { "#{ENV["TEST_TMP"]}/line_counter_test" }
+
   before(:each) do
-    FileUtils.rm_rf(test_dir)
     FileUtils.mkdir_p(test_dir)
   end
-  after(:all) do
-    FileUtils.rm_rf(test_dir)
-  end
-  let(:null_path) { "/tmp/i/do/not/exist" }
+
+  let(:null_path) { "/nonexistent" }
   let(:empty_file) { File.join(test_dir, "empty_file") }
   let(:ten_line_file) { File.join(test_dir, "ten_line_file") }
   let(:gzip_file) { File.join(test_dir, "gzip_file.gz") }


### PR DESCRIPTION
- creates a temporary directory just for that test; puts it in ENV["TEST_TMP"]. This means we can avoid cleanup in each test

- reloads settings to point to that tmpdir; reloading settings before each test also means we don't have to worry about saving/restoring settings in individual specs

- Enable disabled autoscrub JSON spec