### PR TITLE
DEV-569: Adding `Thread.pass` to get rid of Sidekiq warnings when loading holdings

### DIFF
--- a/lib/clustering/cluster_holding.rb
+++ b/lib/clustering/cluster_holding.rb
@@ -64,6 +64,7 @@ module Clustering
         c.holdings
           .select { |h| h.organization == org && h.date_received < date }
           .map { |h| ClusterHolding.new(h).delete }
+        Thread.pass
       end
     end
 

--- a/lib/loader/holding_loader.rb
+++ b/lib/loader/holding_loader.rb
@@ -43,6 +43,7 @@ module Loader
   ## Subclass that only overrides item_from_line
   class HoldingLoaderNDJ < HoldingLoader
     def item_from_line(line)
+      Thread.pass # for sidekiq
       Clusterable::Holding.new_from_scrubbed_file_line(line).tap do |h|
         @organization ||= h.organization
         @current_date ||= h.date_received

--- a/lib/reports/commitment_replacements.rb
+++ b/lib/reports/commitment_replacements.rb
@@ -48,6 +48,7 @@ module Reports
         fh.puts header.join("\t")
         replacements.each do |row|
           fh.puts row.join("\t")
+          Thread.pass
         end
       end
     end

--- a/lib/reports/cost_report.rb
+++ b/lib/reports/cost_report.rb
@@ -132,6 +132,7 @@ module Reports
           add_ht_item_to_freq_table(ht_item)
           marker.on_batch { |m| logger.info m.batch_line }
         end
+        Thread.pass
       end
     end
 

--- a/lib/reports/estimate.rb
+++ b/lib/reports/estimate.rb
@@ -42,6 +42,7 @@ module Reports
         count_matching_items(cluster)
 
         marker.on_batch { |m| Services.logger.info m.batch_line }
+        Thread.pass
       end
       Services.logger.info marker.final_line
     end

--- a/lib/reports/etas_organization_overlap_report.rb
+++ b/lib/reports/etas_organization_overlap_report.rb
@@ -100,6 +100,7 @@ module Reports
         next if cluster.nil?
         holdings_matched = write_overlaps(cluster, organization)
         write_records_for_unmatched_holdings(cluster, holdings_matched)
+        Thread.pass
       end
       move_reports
     end

--- a/lib/reports/rare_uncommitted.rb
+++ b/lib/reports/rare_uncommitted.rb
@@ -176,6 +176,7 @@ module Reports
         # If we didn't find reason to reject cluster, then the cluster goes in the report.
         log "yield cluster #{cluster.ocns}"
         yield cluster
+        Thread.pass
       end
       Services.logger.info marker.final_line
     end

--- a/lib/reports/uncommitted_holdings.rb
+++ b/lib/reports/uncommitted_holdings.rb
@@ -51,6 +51,7 @@ module Reports
         cluster.holdings.each do |holding|
           yield Reports::UncommittedHoldingsRecord.new(holding)
         end
+        Thread.pass
       end
     end
 

--- a/lib/shared_print/deprecator.rb
+++ b/lib/shared_print/deprecator.rb
@@ -40,6 +40,7 @@ module SharedPrint
       end
       inf.each_line do |line|
         try_deprecate(line.strip)
+        Thread.pass
       rescue SharedPrint::DeprecationError => e
         append_report "Could not deprecate record. #{e}"
       end

--- a/lib/shared_print/phase_3_validator.rb
+++ b/lib/shared_print/phase_3_validator.rb
@@ -48,6 +48,7 @@ module SharedPrint
         else
           @log.puts "Failed to load #{commitment.inspect}"
         end
+        Thread.pass
       end
     ensure
       # Close log files

--- a/lib/shared_print/replacer.rb
+++ b/lib/shared_print/replacer.rb
@@ -36,6 +36,7 @@ module SharedPrint
         rep_rec.apply
         report "Success: #{rep_rec.verify}"
         report rep_rec.replaced.inspect
+        Thread.pass
       rescue ArgumentError => err
         report "Could not replace. #{err.message}"
       rescue IndexError => err

--- a/lib/shared_print/updater.rb
+++ b/lib/shared_print/updater.rb
@@ -21,6 +21,7 @@ module SharedPrint
         report "{"
         process_record(rec)
         report "}"
+        Thread.pass
       end
       report "Done with #{file}."
       @report&.close


### PR DESCRIPTION
As far as I can tell, `Loader::HoldingLoader.item_from_line` is _the_ thing being called once for each line in the input file being loaded. If `Thread.pass` needs to be sprinkled in more places, I'm not seeing it.