### PR TITLE
DEV-659: Convert input files to utf8 and log changes, when scrubbing

### DIFF
--- a/generate_documentation.sh
+++ b/generate_documentation.sh
@@ -1,7 +1,0 @@
-gen_doc(){
-    pandoc \
-	--pdf-engine pdfroff \
-	$*
-}
-
-gen_doc documentation/holdings-spec.md -o documentation/holdings-spec.pdf

--- a/lib/scrub/autoscrub.rb
+++ b/lib/scrub/autoscrub.rb
@@ -24,32 +24,58 @@ module Scrub
 
       # @member_id and @item_type are used in the path to scrub_logger, but we
       # also need somewhere to log to before we know @member_id and @item_type
+      # hence @early_scrub_logger_path.
       scrub_dir = File.dirname(@path)
-      early_scrub_logger_path = File.join(scrub_dir, "scrub.log")
+      @early_scrub_logger_path = File.join(scrub_dir, "scrub.log")
       Services.register(:scrub_logger) do
-        Logger.new(early_scrub_logger_path)
+        Logger.new(@early_scrub_logger_path)
       end
       Services.scrub_logger.info("Getting basic info from #{@path}")
 
       @member_holding_file = Scrub::MemberHoldingFile.new(@path)
       @member_id = @member_holding_file.member_id
+      # @output_struct may create some directories as a side effect
       @output_struct = Scrub::ScrubOutputStructure.new(@member_id)
       @item_type = @member_holding_file.item_type_from_filename
-      @encoding = Utils::Encoding.new(@path)
       @output_dir = @output_struct.date_subdir!("output")
       @log_dir = @output_struct.date_subdir!("log")
       @out_files = []
-      Services.register(:scrub_stats) { {} }
 
+      register_logger
+    end
+
+    def run
+      @encoding = Utils::Encoding.new(@path)
+      convert_to_utf8 unless @encoding.ascii_or_utf8?
+
+      Services.scrub_logger.info("Started scrubbing #{@path}")
+      write_to do |out_file|
+        @member_holding_file.parse do |holding|
+          out_file.puts(holding.to_json)
+          marker.incr
+          marker.on_batch do |m|
+            Services.scrub_logger.info(m.batch_line)
+          end
+        rescue => e
+          Services.scrub_logger.error(e)
+          Services.scrub_logger.error(e.backtrace.join("\n"))
+        end
+      end
+      Services.scrub_logger.info("Finished scrubbing #{@path}")
+    end
+
+    private
+
+    def register_logger
+      Services.register(:scrub_stats) { {} }
       # Once we have @member_id and @item_type,
       # build a new log path and re-register the service logger to that path
       ymd = Time.new.strftime("%Y%m%d")
       @logger_path = File.join(@log_dir, "#{@member_id}_#{@item_type}_#{ymd}.log")
       Services.logger.info "autoscrub logging to #{@logger_path}"
-
       Services.register(:scrub_logger) do
         # Get the early log in there.
-        FileUtils.mv(early_scrub_logger_path, @logger_path)
+        FileUtils.mv(@early_scrub_logger_path, @logger_path)
         lgr = Logger.new(@logger_path)
         # Show time, file:lineno, level for each log message
         lgr.formatter = proc do |severity, datetime, _progname, msg|
@@ -58,63 +84,73 @@ module Scrub
         end
         lgr
       end
-
       Services.scrub_logger.info("INIT")
       Services.logger.info("Logging to #{@logger_path}")
     end
 
-    def run
-      Services.scrub_logger.info("Started scrubbing #{@path}")
+    # Deal with non-utf8 encodings.
+    def convert_to_utf8
+      Services.scrub_logger.warn("Unsupported encoding (#{@encoding.encoding}) in #{@path}")
+      Services.scrub_logger.info("Converting #{@path} to UTF-8")
+      raise "Could not fix the encoding in #{@path}" unless @encoding.force_utf8
 
-      unless @encoding.ascii_or_utf8?
-        Services.scrub_logger.error(
-          "Encoding error in #{@path} (unsupported #{@encoding.uchardet})"
+      # If we didn't raise, means we could convert, so swap files.
+      FileUtils.mv(@encoding.utf8_output, @path)
+      # Put encoding diff in scrub log
+      unless @encoding.diff.nil?
+        Services.scrub_logger.info(
+          "These lines in #{@path} contained characters that " \
+          "had to be converted from #{@encoding.encoding} to UTF-8:"
         )
-        raise EncodingError
+        File.open(@encoding.diff) do |enc_diff_file|
+          enc_diff_file.each_line do |enc_diff_line|
+            Services.scrub_logger.info enc_diff_line.strip
+          end
+        end
+        FileUtils.rm(@encoding.diff)
+      end
+    end
+
+    # Manage marker & batch size
+    def marker
+      if @marker.nil?
+        # Figure out batch size for 100 batches.
+        line_counter = Utils::LineCounter.new(@path)
+        tot_lines = line_counter.count_lines
+        if tot_lines <= 1
+          raise "File #{@path} has no data? Total lines #{tot_lines}."
+        end
+        batch_size = tot_lines < 100 ? 100 : tot_lines / 100
+        Services.scrub_logger.info("File is #{tot_lines} lines long, batch size #{batch_size}")
+        @marker = Services.progress_tracker.call(batch_size: batch_size)
       end
 
-      # Figure out batch size for 100 batches.
-      line_counter = Utils::LineCounter.new(@path)
-      tot_lines = line_counter.count_lines
-      if tot_lines <= 1
-        raise "File #{@path} has no data? Total lines #{tot_lines}."
-      end
+      # Return the marker
+      @marker
+    end
 
-      batch_size = tot_lines < 100 ? 100 : tot_lines / 100
-      Services.scrub_logger.info("File is #{tot_lines} lines long, batch size #{batch_size}")
-      marker = Services.progress_tracker.call(batch_size: batch_size)
-
-      # Set up output file
+    # Manage output
+    def write_to
+      # set up output file path
       datetime = Time.new.strftime("%F-%T").delete(":")
       out_file_path = File.join(
         @output_dir,
         "#{@member_id}_#{@item_type}_#{datetime}.ndj"
       )
-      out_file = File.open(out_file_path, "w")
       Services.scrub_logger.info("Outputting to #{out_file_path}")
 
-      @member_holding_file.parse do |holding|
-        out_file.puts(holding.to_json)
-        marker.incr
-        marker.on_batch do |m|
-          Services.scrub_logger.info(m.batch_line)
-        end
-      rescue => e
-        Services.scrub_logger.error(e)
-        Services.scrub_logger.error(e.backtrace.join("\n"))
-      end
-
+      # yield opened out file
+      out_file = File.open(out_file_path, "w")
+      yield out_file # scrubbing happens during this yield
       out_file.close
-      Services.scrub_logger.info("Finished scrubbing #{@path}")
+
+      # clean up
       FileUtils.mv(out_file_path, @output_struct.member_ready_to_load)
       Services.scrub_logger.info(
         "Output file moved to #{@output_struct.member_ready_to_load.to_path}"
       )
       # Move file and store new location in array.
-      @out_files << File.join(
-        @output_struct.member_ready_to_load,
-        File.split(out_file_path).last
-      )
+      @out_files << File.join(@output_struct.member_ready_to_load, File.split(out_file_path).last)
     end
   end
 end

--- a/lib/scrub/member_holding_file.rb
+++ b/lib/scrub/member_holding_file.rb
@@ -52,11 +52,6 @@ module Scrub
       @error_count = 0
       @item_type = item_type_from_filename
       @member_id = member_id_from_filename
-
-      # get a file
-      # check filename for member_id, item_type etc.
-      # parse header & set up the column map
-      # check individual lines
     end
 
     def log(msg)

--- a/spec/utils/encoding_spec.rb
+++ b/spec/utils/encoding_spec.rb
@@ -6,6 +6,14 @@ require "spec_helper"
 RSpec.describe Utils::Encoding do
   let(:valid_fixt) { fixture "valid_utf8.txt" }
   let(:non_valid_fixt) { fixture "non_valid_utf8.txt" }
+  let(:valid_enc) { described_class.new(valid_fixt) }
+
+  # Clean up
+  after(:all) do
+    Dir.glob("/tmp/Utils_Encoding_*").each do |f|
+      FileUtils.rm(f)
+    end
+  end
 
   describe "#initialize" do
     it "requires a path to something existing" do
@@ -14,11 +22,18 @@ RSpec.describe Utils::Encoding do
       FileUtils.rm_f("#{ENV["TEST_TMP"]}/no_file")
       expect { described_class.new("#{ENV["TEST_TMP"]}/no_file") }.to raise_error IOError
     end
+    it "sets @encoding on initialize" do
+      expect(valid_enc.encoding).to eq "ASCII"
+    end
+    it "leaves @utf8_output and @diff unset until used" do
+      expect(valid_enc.utf8_output).to eq nil
+      expect(valid_enc.diff).to eq nil
+    end
   end
 
   describe "#ascii_or_utf8?" do
     it "recognizes an all-utf8 file as such" do
-      expect(described_class.new(valid_fixt).ascii_or_utf8?).to be true
+      expect(valid_enc.ascii_or_utf8?).to be true
     end
     it "can tell when a file contains illegal utf8 sequences" do
       expect(described_class.new(non_valid_fixt).ascii_or_utf8?).to be false
@@ -26,14 +41,23 @@ RSpec.describe Utils::Encoding do
   end
   describe "#force_utf8" do
     it "takes a non-valid utf8 file and creates a copy without illegal input sequences" do
-      fixed = described_class.new(non_valid_fixt).force_utf8
-      expect(described_class.new(fixed).ascii_or_utf8?).to be true
-      # There's only one line with illegal sequences, a diff should confirm.
-      # But we have to count the diffs, because doing anything with the diff
-      # would mean doing something with the illegal sequence, and we cannot
-      # have that now can we.
-      diffs = `diff -y --suppress-common-lines #{non_valid_fixt} #{fixed} | egrep -c .`
-      expect(diffs.strip).to eq "1"
+      enc = described_class.new(non_valid_fixt)
+      # Make sure that we think it is non-valid
+      expect(enc.ascii_or_utf8?).to be false
+      # See if we can force it to be valid
+      expect(enc.force_utf8).to be true
+      # Let's double check...
+      # Pass the converted output file as input to a new encoder,
+      # and ask the new encoder if that input is valid
+      expect(described_class.new(enc.utf8_output).ascii_or_utf8?).to be true
+    end
+    it "creates a diff file with only the post-encoding version" do
+      enc = described_class.new(non_valid_fixt)
+      expect(enc.diff.nil?).to be true
+      enc.force_utf8
+      expect(enc.diff.nil?).to be false
+      # In this case there should only be one line that differs
+      expect(File.new(enc.diff).count).to be 1
     end
   end
   describe "#capture_outs" do


### PR DESCRIPTION
Changes mostly involve `Util::Encoding.force_utf8` which already existed but wasn't really plugged in.

It used to be that when `Scrub::AutoScrub` encountered a file with non-utf8 strings it would report what the encoding was and give up. This led to way too much back and forth between members. 

`Util::Encoding` now `iconv`s to a new file and does a `diff` between the old (non-valid) and the new (valid) files, so that the changes can be reported to the scrub log in `Scrub::AutoScrub.run`, and proceeds with the new (valid) file.