### PR TITLE
PHO-20: Bug fix for overlap report, now counting uniq orgs for hols & coms

### DIFF
--- a/lib/reports/overlap_report.rb
+++ b/lib/reports/overlap_report.rb
@@ -106,7 +106,7 @@ module Reports
       if @ph
         cluster
           .holdings
-          .select(&:organization)
+          .map(&:organization)
           .uniq
           .count
       end
@@ -127,7 +127,7 @@ module Reports
         cluster
           .commitments
           .select { |spc| !spc.deprecated? }
-          .select(&:organization)
+          .map(&:organization)
           .uniq
           .count
       end

--- a/spec/reports/overlap_report_spec.rb
+++ b/spec/reports/overlap_report_spec.rb
@@ -77,6 +77,18 @@ RSpec.describe Reports::OverlapReport do
       cluster_tap_save([hol2])
       expect(rep_short.count_cluster_ph(Cluster.where(ocns: [ocn1]).first)).to eq 2
     end
+    it "counts multiple holdings on the same cluster by the same org as 1" do
+      cluster_tap_save([hol1])
+      expect(Cluster.where(ocns: [ocn1]).first.holdings.count).to eq 1
+      expect(rep_short.count_cluster_ph(Cluster.where(ocns: [ocn1]).first)).to eq 1
+
+      # Add another holding with the same org & ocn, then holdings should go to 2
+      # but count_cluster_ph should stay 1
+      hol2.organization = org1
+      cluster_tap_save([hol2])
+      expect(Cluster.where(ocns: [ocn1]).first.holdings.count).to eq 2
+      expect(rep_short.count_cluster_ph(Cluster.where(ocns: [ocn1]).first)).to eq 1
+    end
   end
   describe "#count_cluster_htdl" do
     it "counts the number of ht_items in a cluster" do
@@ -104,6 +116,19 @@ RSpec.describe Reports::OverlapReport do
       # 2 if there are 2 orgs w commitment in cluster, ... n
       cluster_tap_save([spc2])
       expect(rep.count_cluster_sp(Cluster.where(ocns: [ocn1]).first)).to eq 2
+    end
+    it "counts multiple commitments on the same cluster by the same org as 1" do
+      rep = described_class.new(organization: org1, sp: true)
+      cluster_tap_save([spc1])
+      expect(Cluster.where(ocns: [ocn1]).first.commitments.count).to eq 1
+      expect(rep.count_cluster_sp(Cluster.where(ocns: [ocn1]).first)).to eq 1
+
+      # Add another holding with the same org & ocn, then holdings should go to 2
+      # but count_cluster_ph should stay 1
+      spc2.organization = org1
+      cluster_tap_save([spc2])
+      expect(Cluster.where(ocns: [ocn1]).first.commitments.count).to eq 2
+      expect(rep.count_cluster_sp(Cluster.where(ocns: [ocn1]).first)).to eq 1
     end
   end
   describe "#run" do


### PR DESCRIPTION
For `#count_cluster_sp` and `#count_cluster_ph`, changed `select` to `map` and added tests.