### PR TITLE
SPO-41: make SharedPrint::Phase3Validator support other_commitments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG UID=1000
 ARG GID=1000
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
-  nodejs netcat rclone less entr uchardet
+  nodejs netcat-openbsd rclone less entr uchardet
 
 WORKDIR /usr/src/app
 ENV BUNDLE_PATH /gems

--- a/lib/clusterable/commitment.rb
+++ b/lib/clusterable/commitment.rb
@@ -36,6 +36,7 @@ module Clusterable
 
     validates_inclusion_of :retention_condition, in: ["EXCELLENT", "ACCEPTABLE"], allow_nil: true
     validate :deprecation_validation
+    validate :other_commitment_validation
 
     def initialize(_params = nil)
       super
@@ -83,6 +84,15 @@ module Clusterable
         errors.add(:deprecation_status, "can't be set without a deprecation date.")
       elsif deprecation_status.nil? && deprecation_date
         errors.add(:deprecation_date, "can't be set without a deprecation status.")
+      end
+    end
+
+    # If one of other_program/other_retention_date is set they must both be set
+    def other_commitment_validation
+      if other_program && other_retention_date.nil?
+        errors.add(:other_program, "cannot be set if other_retention_date is nil")
+      elsif other_program.nil? && other_retention_date
+        errors.add(:other_retention_date, "cannot be set if other_program is nil")
       end
     end
   end

--- a/lib/loader/shared_print_loader.rb
+++ b/lib/loader/shared_print_loader.rb
@@ -38,11 +38,36 @@ module Loader
   #
   ## Subclass that only overrides item_from_line
   class SharedPrintLoaderTSV < SharedPrintLoader
+    @@colon_sep_vals = /.+:.+/
     def item_from_line(line)
       # Utils::TSVReader takes care of parsing into fields, but we still need
       # to clean them up
       fields = line.compact.reject { |k, v| v.empty? }
-      fields[:policies] = fields.fetch(:policies, "").downcase.split(",")
+      # Some fields need specific case. Todo: harmonize this.
+      downcase_fields = [:local_shelving_type, :policies]
+      downcase_fields.each do |sym|
+        fields[sym] = fields[sym]&.downcase
+      end
+      upcase_fields = [:retention_condition]
+      upcase_fields.each do |sym|
+        fields[sym] = fields[sym]&.upcase
+      end
+
+      # policies is an array and comes in as a comma-sep string
+      unless fields[:policies].nil?
+        fields[:policies] = fields[:policies].split(",")
+      end
+
+      # other_commitments is an input that is stored as
+      # other_program and other_retention_date
+      if fields.key?(:other_commitments)
+        if @@colon_sep_vals.match?(fields[:other_commitments])
+          prog, date = fields[:other_commitments].split(":")
+          fields[:other_program] = prog
+          fields[:other_retention_date] = DateTime.parse(date)
+        end
+        fields.delete(:other_commitments)
+      end
 
       Clusterable::Commitment.new(fields)
     end

--- a/lib/shared_print/phase_3_validator.rb
+++ b/lib/shared_print/phase_3_validator.rb
@@ -135,7 +135,7 @@ module SharedPrint
       pols = commitment.policies
       # pols must match ONE AND ONLY ONE of the required policies.
       unless (pols & @phase_3_required_policies).count == 1
-        msg = "Required policies mismatch. Commitment has #{pols.join(",")}. " \
+        msg = "Required policies mismatch. Commitment policies is #{pols.inspect}. " \
               "Exactly one of #{@phase_3_required_policies.join(",")} is required"
         raise SharedPrint::Phase3Error, msg
       end


### PR DESCRIPTION
The (user facing) specs say you can submit commitments with the field `other_commitments`, and that field did exist, but the commitments loader had no code that knew how parse that field.

This PR adds capability to deal with `other_commitments`.