### PR TITLE
Default date for phase 3 commitments

### DIFF
--- a/lib/shared_print/phase_3_validator.rb
+++ b/lib/shared_print/phase_3_validator.rb
@@ -3,6 +3,7 @@
 require "cluster"
 require "loader/shared_print_loader"
 require "services"
+require "date"
 Services.mongo!
 
 module SharedPrint
@@ -20,7 +21,7 @@ module SharedPrint
 
       # Any commitment in Phase 3 should have 1+ of these policies:
       @phase_3_required_policies = ["blo", "non-circ"]
-
+      @phase_3_date = DateTime.parse("2023-01-31")
       # Setup dirs
       if Settings.local_report_path.nil?
         raise "Missing Settings.local_report_path"
@@ -42,6 +43,7 @@ module SharedPrint
         # commitment is an unsaved commitment until it has passed
         # validation and is then saved by load()
         commitment = loader.item_from_line(line)
+        commitment.committed_date = @phase_3_date
         if pass_validation? commitment
           loader.load commitment
           @log.puts "Loaded #{commitment.inspect}"

--- a/spec/shared_print/phase_3_validator_spec.rb
+++ b/spec/shared_print/phase_3_validator_spec.rb
@@ -210,4 +210,20 @@ RSpec.describe SharedPrint::Phase3Validator do
       expect(p3v.last_error).to be nil
     end
   end
+  describe "committed_date" do
+    it "should default to 2023-01-31 for phase 3 commitments" do
+      # Set up clusters
+      [2, 3].each do |ocn|
+        cluster_tap_save [
+          build(:ht_item, ocns: [ocn]),
+          build(:holding, ocn: ocn, organization: "umich")
+        ]
+      end
+      p3v.run
+      p3_date = DateTime.parse("2023-01-31")
+      # All p3 commitments should have the p3 date
+      expect(Cluster.first.commitments.first.committed_date).to eq p3_date
+      expect(Cluster.last.commitments.first.committed_date).to eq p3_date
+    end
+  end
 end


### PR DESCRIPTION
Phase 3 commitments should all have the same `committed_date`. Set as they are being parsed by `phase_3_validator.rb`.