### PR TITLE
DEV-573: Fix broken phase lookup for Shared Print reporting purposes

### DIFF
--- a/bin/inspect_ocn.rb
+++ b/bin/inspect_ocn.rb
@@ -1,23 +1,33 @@
 # frozen_string_literal: true
 
-# For manual/ocular inspection of a single OCN.
-# Takes an OCN and outputs a pretty-printed matching cluster.
+# For manual/ocular inspection of clusters based on OCN(s).
+# Takes 1+ OCN(s) commandline args and outputs pretty-printed array
+# of matching clusters.
+# Usage:
+# $ bundle exec ruby bin/inspect_ocn.rb req:ocn_1 (... opt:ocn_n)
+
 require "cluster"
 require "services"
 require "json"
 
 def main
   Services.mongo!
-  ocn = ARGV.shift
-  puts look_up(ocn)
+  @buffer = []
+  @warnings = []
+
+  ARGV.each do |ocn|
+    look_up(ocn)
+  end
+  puts JSON.pretty_generate(@buffer)
+  warn @warnings.join("\n")
 end
 
 def look_up(ocn)
   cluster = Cluster.find_by(ocns: ocn.to_i)
   if cluster.nil?
-    "No cluster found for OCN #{ocn}."
+    @warnings << "# Warning: No cluster found for OCN #{ocn}."
   else
-    JSON.pretty_generate(cluster.as_document)
+    @buffer << cluster.as_document
   end
 end
 

--- a/lib/clusterable/commitment.rb
+++ b/lib/clusterable/commitment.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "mongoid"
+require "shared_print/phases"
 
 module Clusterable
   # A shared print commitment
@@ -25,6 +26,7 @@ module Clusterable
     field :deprecation_status, type: String
     field :deprecation_date, type: DateTime
     field :deprecation_replaced_by, type: String
+    field :phase, type: Integer, default: 0
 
     embedded_in :cluster
 
@@ -37,6 +39,7 @@ module Clusterable
     validates_inclusion_of :retention_condition, in: ["EXCELLENT", "ACCEPTABLE"], allow_nil: true
     validate :deprecation_validation
     validate :other_commitment_validation
+    validate :phase_validation
 
     def initialize(_params = nil)
       super
@@ -93,6 +96,12 @@ module Clusterable
         errors.add(:other_program, "cannot be set if other_retention_date is nil")
       elsif other_program.nil? && other_retention_date
         errors.add(:other_retention_date, "cannot be set if other_program is nil")
+      end
+    end
+
+    def phase_validation
+      unless SharedPrint::Phases.list.include?(phase)
+        errors.add(:phase, "Not a recognized phase")
       end
     end
   end

--- a/lib/shared_print/phase_updater.rb
+++ b/lib/shared_print/phase_updater.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "mongo_updater"
+
+# This is an outer wrapper for a MongoUpdater call.
+# Objective: based on commitments.committed_date, set commitments.phase.
+# Usage: bundle exec ruby get_by_date.rb <date_str> <phase>
+# E.g. : bundle exec ruby get_by_date.rb "2023-01-31 00:00:00 UTC" 3
+
+class PhaseUpdater
+  def initialize(date, phase)
+    # Get input
+    @date = date
+    @phase = phase
+
+    validate!
+    puts "Get commitments with committed_date #{@date}."
+    puts "Set phase to #{@phase}."
+  end
+
+  # Make sure date and phase look like they should.
+  def validate!
+    date_rx = /^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\s[A-Z]{3}$/
+    raise ArgumentError, "bad date: #{@date}" unless date_rx.match?(@date)
+
+    @phase = @phase.to_i
+    raise ArgumentError, "bad phase: #{@phase}" unless [0, 1, 2, 3].include?(@phase)
+  rescue ArgumentError => e
+    puts "ERROR: Failed validation: #{e.message}"
+    exit
+  end
+
+  # Pass on call to MongoUpdater which does all the lifting.
+  def run
+    puts "Started: #{Time.now.utc}"
+    res = MongoUpdater.update_embedded(
+      clusterable: "commitments",
+      matcher: {committed_date: @date},
+      updater: {phase: @phase}
+    )
+    puts res.inspect
+    puts "Finished: #{Time.now.utc}"
+  end
+end
+
+if $0 == __FILE__
+  date = ARGV.shift
+  phase = ARGV.shift
+  PhaseUpdater.new(date, phase).run
+end

--- a/lib/shared_print/phases.rb
+++ b/lib/shared_print/phases.rb
@@ -2,17 +2,25 @@
 
 module SharedPrint
   class Phases
-    PHASE_1_DATE = "2017-09-30"
-    PHASE_2_DATE = "2019-02-28"
-    PHASE_3_DATE = "2023-01-31"
+    PHASE_0 = 0 # Default, has not associated date
+    PHASE_1 = 1
+    PHASE_2 = 2
+    PHASE_3 = 3
+    PHASE_1_DATE = "2017-09-30  00:00:00 UTC"
+    PHASE_2_DATE = "2019-02-28  00:00:00 UTC"
+    PHASE_3_DATE = "2023-01-31 00:00:00 UTC"
 
     # Call .invert on this if you ever need reverse map
     def self.phase_to_date
       {
-        1 => PHASE_1_DATE,
-        2 => PHASE_2_DATE,
-        3 => PHASE_3_DATE
+        PHASE_1 => PHASE_1_DATE,
+        PHASE_2 => PHASE_2_DATE,
+        PHASE_3 => PHASE_3_DATE
       }
+    end
+
+    def self.list
+      [PHASE_0, PHASE_1, PHASE_2, PHASE_3]
     end
   end
 end

--- a/lib/shared_print/select_distinct_phases.rb
+++ b/lib/shared_print/select_distinct_phases.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "basic_query_report"
+
+# Aggregate query to get all committed_date from db.
+query = [
+  {"$match": {"commitments.0": {"$exists": 1}}},
+  {"$unwind": "$commitments"},
+  {"$project": {commitments: 1}},
+  {"$group": {_id: {date: "$commitments.committed_date"}}}
+]
+
+BasicQueryReport.new.aggregate(query) do |res|
+  puts res["_id"]["date"]
+end
+
+# 2023-01-31 00:00:00 UTC
+# 2022-01-01 00:00:00 UTC
+# 2021-01-01 05:00:00 UTC
+# 2017-09-30 04:00:00 UTC
+# 2019-02-28 05:00:00 UTC
+# 1970-01-01 00:00:01 UTC

--- a/spec/fixtures/shared_print_umich_phase123.json
+++ b/spec/fixtures/shared_print_umich_phase123.json
@@ -1,0 +1,213 @@
+[
+    {
+	"ocns": [
+	    67402621
+	],
+	"ht_items": [
+	    {
+		"ocns": [
+		    67402621
+		],
+		"item_id": "mdp.39015068568859",
+		"ht_bib_key": 1507264,
+		"rights": "pd",
+		"bib_fmt": "BK",
+		"enum_chron": "",
+		"content_provider_code": "umich",
+		"n_enum": "",
+		"n_chron": "",
+		"access": "allow",
+		"billing_entity": "umich",
+		"collection_code": "MIU",
+		"n_enum_chron": ""
+	    }
+	],
+	"holdings": [
+	    {
+		"enum_chron": "",
+		"n_enum": "",
+		"n_chron": "",
+		"n_enum_chron": "",
+		"ocn": 67402621,
+		"local_id": "990015072640106381",
+		"organization": "umich",
+		"country_code": "us",
+		"weight": 1.33,
+		"status": "CH",
+		"condition": "",
+		"date_received": "2022-02-07 00:00:00 UTC",
+		"mono_multi_serial": "spm",
+		"issn": "",
+		"gov_doc_flag": true,
+		"uuid": "3fea1bf1-91a2-492d-b131-42e056b8306b"
+	    }
+	],
+	"last_modified": "2023-08-14 09:25:13 UTC",
+	"commitments": [
+	    {
+		"policies": [
+		    "blo"
+		],
+		"organization": "umich",
+		"ocn": 67402621,
+		"local_id": "990015072640106381",
+		"local_item_id": "39015068568859",
+		"oclc_sym": "EYM",
+		"local_shelving_type": "clca",
+		"retention_condition": "ACCEPTABLE",
+		"facsimile": false,
+		"uuid": "ccd2fd58-7fe1-4aac-879e-38145cd3054b",
+		"committed_date": "2023-01-31 00:00:00 UTC"
+	    }
+	]
+    },
+    {
+	"ocns": [
+	    1237445392,
+	    13212412
+	],
+	"ht_items": [
+	    {
+		"ocns": [
+		    13212412
+		],
+		"item_id": "mdp.39015016915723",
+		"ht_bib_key": 1752174,
+		"rights": "ic",
+		"bib_fmt": "BK",
+		"enum_chron": "",
+		"content_provider_code": "umich",
+		"n_enum": "",
+		"n_chron": "",
+		"access": "deny",
+		"billing_entity": "umich",
+		"collection_code": "MIU",
+		"n_enum_chron": ""
+	    }
+	],
+	"holdings": [
+	    {
+		"enum_chron": "",
+		"n_enum": "",
+		"n_chron": "",
+		"n_enum_chron": "",
+		"ocn": 13212412,
+		"local_id": "990017521740106381",
+		"organization": "umich",
+		"country_code": "us",
+		"weight": 1.33,
+		"status": "CH",
+		"condition": "",
+		"date_received": "2022-02-07 00:00:00 UTC",
+		"mono_multi_serial": "spm",
+		"issn": "",
+		"gov_doc_flag": false,
+		"uuid": "e30001cd-856e-412d-9cf5-966e96e776f0"
+	    }
+	],
+	"last_modified": "2023-07-28 00:14:28 UTC",
+	"ocn_resolutions": [
+	    {
+		"deprecated": 1237445392,
+		"resolved": 13212412,
+		"ocns": [
+		    1237445392,
+		    13212412
+		]
+	    }
+	],
+	"commitments": [
+	    {
+		"policies": [
+		    
+		],
+		"uuid": "3443251c-c005-4f28-adf8-23b44da54bf1",
+		"organization": "umich",
+		"ocn": 13212412,
+		"local_id": "001752174",
+		"oclc_sym": "eym",
+		"committed_date": "2017-09-30 04:00:00 UTC",
+		"local_bib_id": "001752174",
+		"local_item_id": "39015016915723",
+		"local_item_location": "buhr",
+		"local_shelving_type": "sfca",
+		"facsimile": false
+	    }
+	]
+    },
+    {
+	"ocns": [
+	    978001669,
+	    13212329
+	],
+	"ht_items": [
+	    {
+		"ocns": [
+		    13212329
+		],
+		"item_id": "mdp.39015022720109",
+		"ht_bib_key": 1752192,
+		"rights": "ic",
+		"bib_fmt": "BK",
+		"enum_chron": "",
+		"content_provider_code": "umich",
+		"n_enum": "",
+		"n_chron": "",
+		"access": "deny",
+		"billing_entity": "umich",
+		"collection_code": "MIU",
+		"n_enum_chron": ""
+	    }
+	],
+	"ocn_resolutions": [
+	    {
+		
+		"deprecated": 978001669,
+		"resolved": 13212329,
+		"ocns": [
+		    978001669,
+		    13212329
+		]
+	    }
+	],
+	"holdings": [
+	    {
+		"enum_chron": "",
+		"n_enum": "",
+		"n_chron": "",
+		"n_enum_chron": "",
+		"ocn": 13212329,
+		"local_id": "990017521920106381",
+		"organization": "umich",
+		"country_code": "us",
+		"weight": 1.33,
+		"status": "CH",
+		"condition": "",
+		"date_received": "2022-02-07 00:00:00 UTC",
+		"mono_multi_serial": "spm",
+		"issn": "",
+		"gov_doc_flag": false,
+		"uuid": "dc88bc1b-64ac-451c-a339-f38ec2c78ffd"
+	    }
+	],
+	"last_modified": "2023-07-28 00:14:28 UTC",
+	"commitments": [
+	    {
+		"policies": [
+		    
+		],
+		"uuid": "c3039c4e-af4a-4500-8d13-c1f1d791e2c2",
+		"organization": "umich",
+		"ocn": 13212329,
+		"local_id": "001752192",
+		"oclc_sym": "eym",
+		"committed_date": "2017-09-30 04:00:00 UTC",
+		"local_bib_id": "001752192",
+		"local_item_id": "39015022720109",
+		"local_item_location": "buhr",
+		"local_shelving_type": "sfca",
+		"facsimile": false
+	    }
+	]
+    }
+]

--- a/spec/reports/phase3_oclc_registration_spec.rb
+++ b/spec/reports/phase3_oclc_registration_spec.rb
@@ -66,9 +66,9 @@ RSpec.describe Reports::Phase3OCLCRegistration do
       )
     end
     # Set phase 1 for the first 3, phase 2 for the mid 3, phase 3 for the last 3
-    comms[0..2].each { |c| c.committed_date = SharedPrint::Phases::PHASE_1_DATE }
-    comms[3..5].each { |c| c.committed_date = SharedPrint::Phases::PHASE_2_DATE }
-    comms[6..8].each { |c| c.committed_date = SharedPrint::Phases::PHASE_3_DATE }
+    comms[0..2].each { |c| c.phase = SharedPrint::Phases::PHASE_1 }
+    comms[3..5].each { |c| c.phase = SharedPrint::Phases::PHASE_2 }
+    comms[6..8].each { |c| c.phase = SharedPrint::Phases::PHASE_3 }
     cluster_tap_save(*comms) # ... and save.
 
     # Only expect to see header & the phase 3 commitments in report:

--- a/spec/shared_print/phase_3_validator_spec.rb
+++ b/spec/shared_print/phase_3_validator_spec.rb
@@ -1,26 +1,37 @@
 require "shared_print/phase_3_validator"
 require "shared_print/phases"
+require "shared_print/finder"
 require "cluster"
 
 RSpec.describe SharedPrint::Phase3Validator do
+  let(:excellent_condition) { "EXCELLENT" }
+  let(:acceptable_condition) { "ACCEPTABLE" }
+  let(:blo_pol) { "blo" }
+  let(:dig_pol) { "digitizeondemand" }
+  let(:non_rep_pol) { "non-repro" }
+  let(:umich) { "umich" }
+  let(:east) { "EAST" }
   let(:fixt) { fixture("phase_3_commitments.tsv") }
+  let(:hol) { build(:holding, ocn: spc.ocn, organization: spc.organization) }
+  let(:ht) { build(:ht_item, ocns: [spc.ocn]) }
   let(:p3v) { described_class.new(fixt) }
-  let(:spc) { build(:commitment, retention_condition: "ACCEPTABLE") }
+  let(:spc) { build(:commitment, retention_condition: acceptable_condition) }
+  let(:finder) { SharedPrint::Finder.new(organization: [spc.organization]) }
 
   before(:each) do
     Cluster.collection.find.delete_many
   end
-
   describe "initialize" do
     it "no last_error when freshly inited" do
       expect(p3v.last_error).to be nil
     end
     it "raises if missing settings" do
+      orig = Settings.local_report_path
       Settings.local_report_path = nil
       expect { described_class.new(fixt) }.to raise_error(/Missing Settings/)
+      Settings.local_report_path = orig
     end
   end
-
   describe "low-level individual checks called by pass_validation?" do
     it "rejects a commitment if non-valid" do
       expect { p3v.require_valid_commitment(spc) }.to_not raise_error
@@ -52,13 +63,13 @@ RSpec.describe SharedPrint::Phase3Validator do
       spc.policies = []
       expect { p3v.require_compatible_policies(spc) }.to_not raise_error
       # add non-repro, should still be good
-      spc.policies = ["non-repro"]
+      spc.policies = [non_rep_pol]
       expect { p3v.require_compatible_policies(spc) }.to_not raise_error
       # add blo, should still be good
-      spc.policies = ["non-repro", "blo"]
+      spc.policies = [non_rep_pol, blo_pol]
       expect { p3v.require_compatible_policies(spc) }.to_not raise_error
       # add digitizeondemand should blow it up
-      spc.policies = ["non-repro", "blo", "digitizeondemand"]
+      spc.policies = [non_rep_pol, blo_pol, dig_pol]
       expect { p3v.require_compatible_policies(spc) }.to raise_error SharedPrint::Phase3Error
     end
     it "rejects a commitment if no matching holding in cluster" do
@@ -66,6 +77,7 @@ RSpec.describe SharedPrint::Phase3Validator do
       cluster = Cluster.find_by(ocns: [spc.ocn])
       expect { p3v.require_matching_org_holding(cluster, spc.organization) }.to raise_error SharedPrint::Phase3Error
       # Add a holding to make it work
+
       hol = build(:holding, ocn: spc.ocn, organization: spc.organization)
       cluster_tap_save hol
       cluster = Cluster.find_by(ocns: [spc.ocn])
@@ -74,24 +86,24 @@ RSpec.describe SharedPrint::Phase3Validator do
     it "rejects a commitment if no phase 3 policies" do
       spc.policies = []
       expect { p3v.require_phase_3_policies(spc) }.to raise_error SharedPrint::Phase3Error
-      spc.policies = ["non-repro"]
+      spc.policies = [non_rep_pol]
       expect { p3v.require_phase_3_policies(spc) }.to raise_error SharedPrint::Phase3Error
-      spc.policies = ["non-circ", "blo"] # one or the other is ok, both is not ok
+      spc.policies = ["non-circ", blo_pol] # one or the other is ok, both is not ok
       expect { p3v.require_phase_3_policies(spc) }.to raise_error SharedPrint::Phase3Error
     end
     it "allows a commitment with the proper policies" do
       spc.policies = ["non-circ"]
       expect { p3v.require_phase_3_policies(spc) }.to_not raise_error
-      spc.policies = ["blo"]
+      spc.policies = [blo_pol]
       expect { p3v.require_phase_3_policies(spc) }.to_not raise_error
     end
     it "requires a valid retention_condition" do
-      spc.policies = ["blo"]
+      spc.policies = [blo_pol]
       # should work
-      spc.retention_condition = "ACCEPTABLE"
+      spc.retention_condition = acceptable_condition
       expect { p3v.require_retention_condition(spc) }.to_not raise_error
       # should work
-      spc.retention_condition = "EXCELLENT"
+      spc.retention_condition = excellent_condition
       expect { p3v.require_retention_condition(spc) }.to_not raise_error
       # should not
       spc.retention_condition = ""
@@ -103,7 +115,7 @@ RSpec.describe SharedPrint::Phase3Validator do
       ht = build(:ht_item, ocns: [spc.ocn])
       hol = build(:holding, ocn: spc.ocn, organization: spc.organization)
       cluster_tap_save(ht, hol)
-      spc.policies = ["blo"]
+      spc.policies = [blo_pol]
       expect(p3v.pass_validation?(spc)).to be true
       expect(p3v.last_error).to be nil
     end
@@ -111,14 +123,14 @@ RSpec.describe SharedPrint::Phase3Validator do
       ht = build(:ht_item, ocns: [spc.ocn])
       hol = build(:holding, ocn: spc.ocn, organization: spc.organization)
       cluster_tap_save(ht, hol)
-      spc.policies = ["blo", "digitizeondemand"]
+      spc.policies = [blo_pol, dig_pol]
       expect(p3v.pass_validation?(spc)).to be true
     end
     it "does not allow DIGITIZEONDEMAND mixed with NON-REPRO" do
       ht = build(:ht_item, ocns: [spc.ocn])
       hol = build(:holding, ocn: spc.ocn, organization: spc.organization)
       cluster_tap_save(ht, hol)
-      spc.policies = ["blo", "non-repro", "digitizeondemand"]
+      spc.policies = [blo_pol, non_rep_pol, dig_pol]
       expect(p3v.pass_validation?(spc)).to be false
       expect(p3v.last_error.message).to match(/mutually exclusive policies/)
     end
@@ -131,16 +143,37 @@ RSpec.describe SharedPrint::Phase3Validator do
       expect(p3v.last_error.message).to match(/Required policies mismatch/)
     end
   end
-
+  describe "load_one" do
+    it "loads a commitment with the proper phase and date" do
+      # Add a ht_item, a holding, and a policy or the commitment won't be valid.
+      cluster_tap_save(
+        build(:ht_item, ocns: [spc.ocn]),
+        build(:holding, ocn: spc.ocn, organization: spc.organization)
+      )
+      spc.policies = [blo_pol]
+      # Load it and expect success.
+      p3v.load_one(spc)
+      # Post-check: no errors, 1 commitment with proper phase and date.
+      expect(p3v.last_error).to be_nil
+      expect(finder.commitments.count).to eq 1
+      expect(finder.commitments.first.phase).to eq SharedPrint::Phases::PHASE_3
+      expect(finder.commitments.first.committed_date).to eq SharedPrint::Phases::PHASE_3_DATE
+    end
+  end
   describe "retention_condition" do
     it "works" do
+      # Save a cluster with item + holding ...
       ht = build(:ht_item, ocns: [spc.ocn])
       hol = build(:holding, ocn: spc.ocn, organization: spc.organization)
       cluster_tap_save(ht, hol)
-      spc.policies = ["blo"]
-      spc.retention_condition = "EXCELLENT"
+      # set up a matching valid commitment
+      spc.policies = [blo_pol]
+      spc.retention_condition = excellent_condition
       expect(p3v.pass_validation?(spc)).to be true
       expect(p3v.last_error).to be nil
+      # If we load the commitment, we expect to find it.
+      p3v.load_one(spc)
+      expect(finder.commitments.first.retention_condition).to eq excellent_condition
     end
   end
 
@@ -151,7 +184,7 @@ RSpec.describe SharedPrint::Phase3Validator do
       [2, 3].each do |ocn|
         cluster_tap_save(
           build(:ht_item, ocns: [ocn]),
-          build(:holding, ocn: ocn, organization: "umich")
+          build(:holding, ocn: ocn, organization: umich)
         )
       end
       # Check that 2 commitments were loaded
@@ -174,14 +207,14 @@ RSpec.describe SharedPrint::Phase3Validator do
       # setting up the same htitem and holding for a matching commitment
       ocn = 3
       htitem = build(:ht_item, ocns: [ocn])
-      holding = build(:holding, ocn: ocn, organization: "umich")
+      holding = build(:holding, ocn: ocn, organization: umich)
       cluster_tap_save(htitem, holding)
-      spc.organization = "umich"
+      spc.organization = umich
       spc.ocn = ocn
-      spc.policies = ["blo"]
+      spc.policies = [blo_pol]
     end
     it "accepts a commitment with a proper other_commitments" do
-      spc.other_program = "EAST"
+      spc.other_program = east
       spc.other_retention_date = DateTime.parse("2099-09-09")
       pass = p3v.pass_validation?(spc)
       expect(pass).to be true
@@ -198,7 +231,7 @@ RSpec.describe SharedPrint::Phase3Validator do
     it "error if other_program is set & other_retention_date is nil" do
       # setting other_program but not other_retention_date
       # should result in failed validation
-      spc.other_program = "EAST"
+      spc.other_program = east
       pass = p3v.pass_validation?(spc)
       expect(pass).to be false
       expect(p3v.last_error.to_s).to match(/cannot be set if other_retention_date is nil/)
@@ -217,7 +250,7 @@ RSpec.describe SharedPrint::Phase3Validator do
       [2, 3].each do |ocn|
         cluster_tap_save(
           build(:ht_item, ocns: [ocn]),
-          build(:holding, ocn: ocn, organization: "umich")
+          build(:holding, ocn: ocn, organization: umich)
         )
       end
       p3v.run


### PR DESCRIPTION
Problem (https://hathitrust.atlassian.net/browse/DEV-573): 

We are currently using `committed_date` to determine which "phase" a commitment belongs to. Meaning, when we want to e.g. look up commitments in phase 3, we have to look up "what's the date associated with phase 3" and query on that committed_date. This, in combination with sloppy date formatting and servers in different timezones, has led to issues with timezone confusion.

Proposed solution: 

* We add an integer field called `phase` to `lib/clusterable/commitment.rb`. 
* Keep `committed_date`, but don't use it as a proxy for phase.
* Write and run a piece of single-use code that can add correct `phase` values to commitments, based on date.
* Then make any code that loads commitments require that the user specifies phase.
* Add a mongo index for `commitments.phase`.

Steps toward solution:

* Enabling `bin/inspect_ocn.rb` to look up multiple ocns, and output them in a format that `bash phctl.sh load cluster-file` can load, for testing purposes.
* Added test suite fixture file for commitments (copied from production using the fix to `bin/inspect_ocn.rb`).
* Added `phase` as a field to `Clusterable::Commitment` and a corresponding index.
* Simplified `SharedPrint::Finder` and updated `SharedPrint::Phases`.
* Added a script to get all distinct `committed_date` from production: `lib/shared_print/select_distinct_phases.rb`
* Added a script to set phase on commitments that have a specific committed_date: `lib/shared_print/phase_updater.rb`

---

Guide to files changed:

`bin/inspect_ocn.rb`:                                                                                                                                                                            
Enable lookup of multiple ocns.
Enable output of multiple clusters.
This makes it easier to copy clusters from production and loading them in dev/test (`phctl load cluster-file`)

`lib/clusterable/commitment.rb`:
Added phase field and validation.

`lib/shared_print/finder.rb`:
Enable lookup by phase.
Simplify some of the stuff that was using committed\_date.

`lib/shared_print/phase_3_validator.rb`
Sets `phase` and `committed_date` to appropriate values for phase 3.
Broke apart `run` into `load_all` & `load_one` so I could test loading more directly.

`lib/shared_print/phase_updater.rb`:
Script to set phase on commitments based on their committed\_date.

`lib/shared_print/select_distinct_phases.rb`:
In order to set phase based on committed\_date, we must first have a list of all the committed\_date

`lib/shared_print/phases.rb`:
Added phase constants.

`spec/fixtures/shared_print_umich_phase123.json`:
3 clusters with commitments, for test purposes.

`spec/reports/phase3_oclc_registration_spec.rb`:
Using phase instead of committed\_date.

`spec/shared_print/finder_spec.rb`:
Using phase instead of committed\_date.

`spec/shared_print/phase_3_validator_spec.rb`
Added test for `load_one`, broke out reused vars.