### PR TITLE
Fix broken fix of PhaseUpdater in Shared Print

### DIFF
--- a/lib/shared_print/phase_updater.rb
+++ b/lib/shared_print/phase_updater.rb
@@ -1,50 +1,52 @@
 # frozen_string_literal: true
 
+require "date"
 require "mongo_updater"
 
 # This is an outer wrapper for a MongoUpdater call.
 # Objective: based on commitments.committed_date, set commitments.phase.
 # Usage: bundle exec ruby get_by_date.rb <date_str> <phase>
 # E.g. : bundle exec ruby get_by_date.rb "2023-01-31 00:00:00 UTC" 3
+module SharedPrint
+  class PhaseUpdater
+    def initialize(date, phase)
+      # Get input
+      @date = date
+      @phase = phase
 
-class PhaseUpdater
-  def initialize(date, phase)
-    # Get input
-    @date = date
-    @phase = phase
+      validate!
+      puts "Get commitments with committed_date #{@date}."
+      puts "Set phase to #{@phase}."
+    end
 
-    validate!
-    puts "Get commitments with committed_date #{@date}."
-    puts "Set phase to #{@phase}."
-  end
+    # Make sure date and phase look like they should.
+    def validate!
+      date_rx = /^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\s[A-Z]{3}$/
+      raise ArgumentError, "bad date: #{@date}" unless date_rx.match?(@date)
 
-  # Make sure date and phase look like they should.
-  def validate!
-    date_rx = /^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\s[A-Z]{3}$/
-    raise ArgumentError, "bad date: #{@date}" unless date_rx.match?(@date)
+      @phase = @phase.to_i
+      raise ArgumentError, "bad phase: #{@phase}" unless [0, 1, 2, 3].include?(@phase)
+    rescue ArgumentError => e
+      puts "ERROR: Failed validation: #{e.message}"
+      exit
+    end
 
-    @phase = @phase.to_i
-    raise ArgumentError, "bad phase: #{@phase}" unless [0, 1, 2, 3].include?(@phase)
-  rescue ArgumentError => e
-    puts "ERROR: Failed validation: #{e.message}"
-    exit
-  end
-
-  # Pass on call to MongoUpdater which does all the lifting.
-  def run
-    puts "Started: #{Time.now.utc}"
-    res = MongoUpdater.update_embedded(
-      clusterable: "commitments",
-      matcher: {committed_date: @date},
-      updater: {phase: @phase}
-    )
-    puts res.inspect
-    puts "Finished: #{Time.now.utc}"
+    # Pass on call to MongoUpdater which does all the lifting.
+    def run
+      puts "Started: #{Time.now.utc}"
+      res = MongoUpdater.update_embedded(
+        clusterable: "commitments",
+        matcher: {committed_date: DateTime.parse(@date)},
+        updater: {phase: @phase}
+      )
+      puts res.inspect
+      puts "Finished: #{Time.now.utc}"
+    end
   end
 end
 
 if $0 == __FILE__
   date = ARGV.shift
   phase = ARGV.shift
-  PhaseUpdater.new(date, phase).run
+  SharedPrint::PhaseUpdater.new(date, phase).run
 end

--- a/lib/shared_print/phases.rb
+++ b/lib/shared_print/phases.rb
@@ -2,12 +2,12 @@
 
 module SharedPrint
   class Phases
-    PHASE_0 = 0 # Default, has not associated date
+    PHASE_0 = 0 # Default, has no associated date
     PHASE_1 = 1
     PHASE_2 = 2
     PHASE_3 = 3
-    PHASE_1_DATE = "2017-09-30  00:00:00 UTC"
-    PHASE_2_DATE = "2019-02-28  00:00:00 UTC"
+    PHASE_1_DATE = "2017-09-30 00:00:00 UTC"
+    PHASE_2_DATE = "2019-02-28 00:00:00 UTC"
     PHASE_3_DATE = "2023-01-31 00:00:00 UTC"
 
     # Call .invert on this if you ever need reverse map

--- a/spec/shared_print/phase_updater_spec.rb
+++ b/spec/shared_print/phase_updater_spec.rb
@@ -1,0 +1,42 @@
+require "cluster"
+require "shared_print/finder"
+require "shared_print/phase_updater"
+require "shared_print/phases"
+
+RSpec.describe SharedPrint::PhaseUpdater do
+  before(:each) do
+    Cluster.collection.find.delete_many
+  end
+  it "updates `phase` on commitments based on `committed_date`" do
+    # Make 5 commitments with a known committed_date
+    # and a phase that needs updating.
+    clusterables = []
+    1.upto(5) do |i|
+      clusterables << build(
+        :commitment,
+        ocn: i,
+        phase: SharedPrint::Phases::PHASE_0,
+        committed_date: SharedPrint::Phases::PHASE_1_DATE
+      )
+    end
+    cluster_tap_save(*clusterables)
+    # Verify that we loaded what we think we loaded:
+    # 5 commitments with the same phase and the same date.
+    original_commitments = SharedPrint::Finder.new(phase: [0]).commitments.to_a
+    expect(original_commitments.count).to eq 5
+    expect(original_commitments.map(&:phase).uniq).to eq [SharedPrint::Phases::PHASE_0]
+    expect(original_commitments.map(&:committed_date).uniq).to eq [SharedPrint::Phases::PHASE_1_DATE]
+
+    # Here we want to update to phase 1, to match the phase 1 date.
+    phase_updater = described_class.new(
+      SharedPrint::Phases::PHASE_1_DATE,
+      SharedPrint::Phases::PHASE_1
+    )
+    phase_updater.run
+    # Verify that the commitments now have phase 1.
+    updated_commitments = SharedPrint::Finder.new(phase: [1]).commitments.to_a
+    expect(updated_commitments.count).to eq 5
+    expect(updated_commitments.map(&:phase).uniq).to eq [SharedPrint::Phases::PHASE_1]
+    expect(updated_commitments.map(&:committed_date).uniq).to eq [SharedPrint::Phases::PHASE_1_DATE]
+  end
+end


### PR DESCRIPTION
## What?

This is yet another PR for DEV-573.

* Added `module` block to `lib/shared_print/phase_updater.rb`
* `@date` variable is now parsed as a `DateTime` before being used in query
* Added `spec/shared_print/phase_updater_spec.rb` with one big test

## Why?

The previous PR for DEV-573 (https://github.com/hathitrust/holdings-backend/pull/286) missed a few things, and did not have the desired effect. The test I'm adding here would have showed me what was missing, but I thought I could get away with not writing it. This is a teaching moment.

## For the reviewer

I'm just looking for a quick eyeball.

Turn on "hide whitespace" in the "Files changed" view, or it's going to look like the entire file `lib/shared_print/phase_updater.rb` is a diff.

Like so:
![image](https://github.com/hathitrust/holdings-backend/assets/10210455/b4cad3e8-ff14-4468-827f-aa5b32e6ac31)
