### PR TITLE
bugfix for DEV-562: make SharedPrint::Finder phase queries more specific

### DIFF
--- a/lib/shared_print/finder.rb
+++ b/lib/shared_print/finder.rb
@@ -82,7 +82,8 @@ module SharedPrint
       (@deprecated.nil? || @deprecated == commitment.deprecated?) &&
         empty_or_include?(@organization, commitment.organization) &&
         empty_or_include?(@ocn, commitment.ocn) &&
-        empty_or_include?(@local_id, commitment.local_id)
+        empty_or_include?(@local_id, commitment.local_id) &&
+        empty_or_include?(@phase, commitment.phase)
     end
 
     # A commitment matches e.g. the @ocn acriterion if @ocn == []


### PR DESCRIPTION
Further fix for: https://hathitrust.atlassian.net/browse/DEV-562

`SharedPrint::Finder.new(phase: [x]).commitments` should only yield commitments with `phase: x`, but the released code was missing a condition and was erroneously yielding _all commitments in a cluster_ if any one of the commitments in the cluster had `phase: x`.

This PR adds that missing condition and adds the tests to prove it's doing the right thing.