### PR TITLE
PHO-95: holdings with nil enum match any htitems

### DIFF
--- a/bin/setup/setup_dev.sh
+++ b/bin/setup/setup_dev.sh
@@ -2,8 +2,8 @@
 
 $(dirname ${BASH_SOURCE[0]})/setup_test.sh
 
-docker-compose up -d mongo_dev pushgateway redis
-docker-compose run --rm dev bin/setup/wait-for mongo_dev:27017 -- echo "mongo is ready"
-docker-compose exec -T mongo_dev bash /tmp/bin/setup/rs_initiate.sh mongo_dev
-docker-compose run --rm -e MONGOID_ENV=development dev bundle exec ruby lib/tasks/build_database.rb
+docker compose up -d mongo_dev pushgateway redis
+docker compose run --rm dev bin/setup/wait-for mongo_dev:27017 -- echo "mongo is ready"
+docker compose exec -T mongo_dev bash /tmp/bin/setup/rs_initiate.sh mongo_dev
+docker compose run --rm -e MONGOID_ENV=development dev bundle exec ruby lib/tasks/build_database.rb
 

--- a/bin/setup/setup_test.sh
+++ b/bin/setup/setup_test.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-docker-compose build
-docker-compose run --rm dev bundle install
-docker-compose up -d mongo_test mariadb pushgateway
-docker-compose run --rm -e MONGOID_ENV=test dev bin/setup/wait-for mongo_test:27017 -- echo "mongo is ready"
-docker-compose exec -T mongo_test bash /tmp/bin/setup/rs_initiate.sh mongo_test
-docker-compose run --rm -e MONGOID_ENV=test dev bundle exec ruby lib/tasks/build_database.rb
+docker compose build
+docker compose run --rm dev bundle install
+docker compose up -d mongo_test mariadb pushgateway
+docker compose run --rm -e MONGOID_ENV=test dev bin/setup/wait-for mongo_test:27017 -- echo "mongo is ready"
+docker compose exec -T mongo_test bash /tmp/bin/setup/rs_initiate.sh mongo_test
+docker compose run --rm -e MONGOID_ENV=test dev bundle exec ruby lib/tasks/build_database.rb

--- a/lib/overlap/multi_part_overlap.rb
+++ b/lib/overlap/multi_part_overlap.rb
@@ -35,7 +35,7 @@ module Overlap
 
     def matching_holdings
       @matching_holdings ||= @cluster.holdings_by_org[@org]
-                               &.select { |h| h[:n_enum] == @ht_item.n_enum or h[:n_enum] == "" }
+        &.select { |h| h[:n_enum] == @ht_item.n_enum or h[:n_enum].blank? }
       @matching_holdings ||= []
     end
   end

--- a/spec/overlap/multi_part_overlap_spec.rb
+++ b/spec/overlap/multi_part_overlap_spec.rb
@@ -5,23 +5,21 @@ require "overlap/multi_part_overlap"
 
 RSpec.describe Overlap::MultiPartOverlap do
   let(:c) { build(:cluster) }
-  let(:ht_w_ec) { build(:ht_item, :mpm, enum_chron: "1", n_enum: "1", ocns: c.ocns) }
-  let(:ht_wo_ec) { build(:ht_item, :mpm, enum_chron: "", n_enum: "", ocns: c.ocns) }
-  let(:h_w_ec) { build(:holding, ocn: c.ocns.first, enum_chron: "1", n_enum: "1") }
-  let(:h_wo_ec) { build(:holding, ocn: c.ocns.first, enum_chron: "", n_enum: "") }
-  let(:h_wrong_ec) { build(:holding, ocn: c.ocns.first, enum_chron: "2", n_enum: "2") }
-  let(:h_lm) do
+  let(:htitem_with_enumchron) { build(:ht_item, :mpm, enum_chron: "1", n_enum: "1", ocns: c.ocns) }
+  let(:htitem_no_enumchron) { build(:ht_item, :mpm, enum_chron: "", n_enum: "", ocns: c.ocns) }
+  let(:holding_with_enumchron) { build(:holding, ocn: c.ocns.first, enum_chron: "1", n_enum: "1") }
+  let(:holding_lost_missing) do
     build(:holding,
       ocn: c.ocns.first,
-      organization: h_w_ec.organization,
+      organization: holding_with_enumchron.organization,
       n_enum: "1",
       status: "LM")
   end
 
-  let(:h_brt_wd) do
+  let(:holding_brittle_withdrawn) do
     build(:holding,
       ocn: c.ocns.first,
-      organization: h_w_ec.organization,
+      organization: holding_with_enumchron.organization,
       n_enum: "1",
       condition: "BRT",
       status: "WD")
@@ -30,113 +28,123 @@ RSpec.describe Overlap::MultiPartOverlap do
   before(:each) do
     Cluster.each(&:delete)
     c.save
-    Clustering::ClusterHtItem.new(ht_w_ec).cluster.tap(&:save)
+    Clustering::ClusterHtItem.new(htitem_with_enumchron).cluster.tap(&:save)
   end
 
   describe "#matching_holdings" do
     it "finds holdings that match on enum" do
-      cluster = Clustering::ClusterHolding.new(h_w_ec).cluster.tap(&:save)
-      overlap = described_class.new(cluster, h_w_ec.organization, ht_w_ec)
+      cluster = Clustering::ClusterHolding.new(holding_with_enumchron).cluster.tap(&:save)
+      overlap = described_class.new(cluster, holding_with_enumchron.organization, htitem_with_enumchron)
       expect(overlap.matching_holdings).to be_a(Enumerable)
       expect(overlap.matching_holdings.count).to eq(1)
     end
 
     it "finds holdings with no enum" do
-      cluster = Clustering::ClusterHolding.new(h_wo_ec).cluster.tap(&:save)
-      overlap = described_class.new(cluster, h_wo_ec.organization, ht_w_ec)
+      holding_without_enumchron = build(:holding, ocn: c.ocns.first, enum_chron: "", n_enum: "")
+      cluster = Clustering::ClusterHolding.new(holding_without_enumchron).cluster.tap(&:save)
+      overlap = described_class.new(cluster, holding_without_enumchron.organization, htitem_with_enumchron)
+      expect(overlap.matching_holdings).to be_a(Enumerable)
+      expect(overlap.matching_holdings.count).to eq(1)
+    end
+
+    it "finds holdings with nil enum" do
+      holding_nil_enumchron = build(:holding, ocn: c.ocns.first, enum_chron: "", n_enum: nil)
+      cluster = Clustering::ClusterHolding.new(holding_nil_enumchron).cluster.tap(&:save)
+      overlap = described_class.new(cluster, holding_nil_enumchron.organization, htitem_with_enumchron)
       expect(overlap.matching_holdings).to be_a(Enumerable)
       expect(overlap.matching_holdings.count).to eq(1)
     end
 
     it "does not find holdings with enum when ht item has no enum" do
-      ht_w_ec.update_attributes(n_enum: "")
-      cluster = Clustering::ClusterHolding.new(h_w_ec).cluster.tap(&:save)
-      overlap = described_class.new(cluster, h_w_ec.organization, ht_w_ec)
+      htitem_with_enumchron.update_attributes(n_enum: "")
+      cluster = Clustering::ClusterHolding.new(holding_with_enumchron).cluster.tap(&:save)
+      overlap = described_class.new(cluster, holding_with_enumchron.organization, htitem_with_enumchron)
       expect(overlap.matching_holdings).to be_a(Enumerable)
       expect(overlap.matching_holdings.count).to eq(0)
     end
 
     it "chron is ignored for matching purposes" do
-      ht_w_ec.update_attributes(n_chron: "Aug")
-      ht_w_ec.update_attributes(n_enum_chron: "\tAug")
-      cluster = Clustering::ClusterHolding.new(h_w_ec).cluster.tap(&:save)
-      overlap = described_class.new(cluster, h_w_ec.organization, ht_w_ec)
-      expect(h_w_ec.n_enum_chron).not_to eq(ht_w_ec.n_enum_chron)
+      htitem_with_enumchron.update_attributes(n_chron: "Aug")
+      htitem_with_enumchron.update_attributes(n_enum_chron: "\tAug")
+      cluster = Clustering::ClusterHolding.new(holding_with_enumchron).cluster.tap(&:save)
+      overlap = described_class.new(cluster, holding_with_enumchron.organization, htitem_with_enumchron)
+      expect(holding_with_enumchron.n_enum_chron).not_to eq(htitem_with_enumchron.n_enum_chron)
       expect(overlap.matching_holdings.count).to eq(1)
     end
 
     it "does not find holdings with the wrong enum" do
-      cluster = Clustering::ClusterHolding.new(h_wrong_ec).cluster.tap(&:save)
-      overlap = described_class.new(cluster, h_wrong_ec.organization, ht_w_ec)
+      holding_wrong_enumchron = build(:holding, ocn: c.ocns.first, enum_chron: "2", n_enum: "2")
+      cluster = Clustering::ClusterHolding.new(holding_wrong_enumchron).cluster.tap(&:save)
+      overlap = described_class.new(cluster, holding_wrong_enumchron.organization, htitem_with_enumchron)
       expect(overlap.matching_holdings).to be_a(Enumerable)
       expect(overlap.matching_holdings.count).to eq(0)
     end
 
     it "does not find holdings if they have the wrong organization" do
-      cluster = Clustering::ClusterHolding.new(h_w_ec).cluster.tap(&:save)
-      overlap = described_class.new(cluster, "not_an_org", ht_w_ec)
+      cluster = Clustering::ClusterHolding.new(holding_with_enumchron).cluster.tap(&:save)
+      overlap = described_class.new(cluster, "not_an_org", htitem_with_enumchron)
       expect(overlap.matching_holdings.count).to eq(0)
     end
   end
 
   describe "#copy_count" do
     it "provides the correct copy count" do
-      Clustering::ClusterHolding.new(h_w_ec).cluster.tap(&:save)
-      cluster = Clustering::ClusterHolding.new(h_lm).cluster.tap(&:save)
-      mpo = described_class.new(cluster, h_w_ec.organization, ht_w_ec)
+      Clustering::ClusterHolding.new(holding_with_enumchron).cluster.tap(&:save)
+      cluster = Clustering::ClusterHolding.new(holding_lost_missing).cluster.tap(&:save)
+      mpo = described_class.new(cluster, holding_with_enumchron.organization, htitem_with_enumchron)
       expect(mpo.copy_count).to eq(2)
     end
 
     it "returns 0 copies if wrong organization" do
-      cluster = Clustering::ClusterHolding.new(h_w_ec).cluster.tap(&:save)
-      mpo = described_class.new(cluster, "not_an_org", ht_w_ec)
+      cluster = Clustering::ClusterHolding.new(holding_with_enumchron).cluster.tap(&:save)
+      mpo = described_class.new(cluster, "not_an_org", htitem_with_enumchron)
       expect(mpo.copy_count).to be(0)
     end
 
     it "returns 1 copy if billing_entity matches" do
-      ht_w_ec.update_attributes(billing_entity: "different_org")
+      htitem_with_enumchron.update_attributes(billing_entity: "different_org")
       c.reload
-      mpo = described_class.new(c, "different_org", ht_w_ec)
+      mpo = described_class.new(c, "different_org", htitem_with_enumchron)
       expect(mpo.copy_count).to be(1)
     end
 
     it "returns 1 copy if org has a non-matching holding" do
-      nmh = build(:holding, ocn: ht_w_ec.ocns.first, n_enum: "not matched")
+      nmh = build(:holding, ocn: htitem_with_enumchron.ocns.first, n_enum: "not matched")
       cluster = Clustering::ClusterHolding.new(nmh).cluster.tap(&:save)
-      mpo = described_class.new(cluster, nmh.organization, ht_w_ec)
+      mpo = described_class.new(cluster, nmh.organization, htitem_with_enumchron)
       expect(mpo.copy_count).to be(1)
     end
   end
 
   describe "#brt_count" do
     it "provides the correct brt count" do
-      cluster = Clustering::ClusterHolding.new(h_brt_wd).cluster.tap(&:save)
-      mpo = described_class.new(cluster, h_brt_wd.organization, ht_w_ec)
+      cluster = Clustering::ClusterHolding.new(holding_brittle_withdrawn).cluster.tap(&:save)
+      mpo = described_class.new(cluster, holding_brittle_withdrawn.organization, htitem_with_enumchron)
       expect(mpo.brt_count).to eq(1)
     end
   end
 
   describe "#wd_count" do
     it "provides the correct wd count" do
-      cluster = Clustering::ClusterHolding.new(h_brt_wd).cluster.tap(&:save)
-      mpo = described_class.new(cluster, h_brt_wd.organization, ht_w_ec)
+      cluster = Clustering::ClusterHolding.new(holding_brittle_withdrawn).cluster.tap(&:save)
+      mpo = described_class.new(cluster, holding_brittle_withdrawn.organization, htitem_with_enumchron)
       expect(mpo.wd_count).to eq(1)
     end
   end
 
   describe "#lm_count" do
     it "provides the correct lm count" do
-      cluster = Clustering::ClusterHolding.new(h_lm).cluster.tap(&:save)
-      mpo = described_class.new(cluster, h_lm.organization, ht_w_ec)
+      cluster = Clustering::ClusterHolding.new(holding_lost_missing).cluster.tap(&:save)
+      mpo = described_class.new(cluster, holding_lost_missing.organization, htitem_with_enumchron)
       expect(mpo.lm_count).to eq(1)
     end
   end
 
   describe "#access_count" do
     it "provides the correct access count" do
-      Clustering::ClusterHolding.new(h_lm).cluster.tap(&:save)
-      cluster = Clustering::ClusterHolding.new(h_brt_wd).cluster.tap(&:save)
-      mpo = described_class.new(cluster, h_brt_wd.organization, ht_w_ec)
+      Clustering::ClusterHolding.new(holding_lost_missing).cluster.tap(&:save)
+      cluster = Clustering::ClusterHolding.new(holding_brittle_withdrawn).cluster.tap(&:save)
+      mpo = described_class.new(cluster, holding_brittle_withdrawn.organization, htitem_with_enumchron)
       expect(mpo.access_count).to eq(2)
     end
   end


### PR DESCRIPTION
## Background

A partner reported that an OCLC number they hold did not appear to match any items in HathiTrust in their "ETAS overlap report".

* A HathiTrust item is considered to be a multipart monograph (MPM) if it does NOT have format SE (serial) and ANY item on the same catalog record has an enum:
  https://github.com/hathitrust/holdings-backend/blob/main/lib/calculate_format.rb#L17
  https://github.com/hathitrust/holdings-backend/blob/main/lib/calculate_format.rb#L43-L47

Whether a holding matches a cluster (i.e. one or more catalog records sharing a set of equivalent OCNs) or a HathiTrust item is dependent on context.
* Cost report: For MPMs, If a member reports holding an OCN but none of their reported enums match any of the enums on a HathiTrust item, they are still considered to hold it for the purposes of whether they pay a share of the cost for that item: https://github.com/hathitrust/holdings-backend/blob/main/lib/overlap/ht_item_overlap.rb#L27
* Production holdings table (used for ETAS access): As with the cost report, we check `organizations_with_holdings_but_no_matches.include?(@org)` for `copy_count`: https://github.com/hathitrust/holdings-backend/blob/main/lib/overlap/multi_part_overlap.rb#L10-L14 in the production holdings table
* ETAS overlap report: This uses _only_ `matching_holdings`, which does NOT account for the case when no member-reported enum matches any enum for items in HathiTrust: https://github.com/hathitrust/holdings-backend/blob/main/lib/overlap/multi_part_overlap.rb#L36-L40 ; https://github.com/hathitrust/holdings-backend/blob/main/lib/reports/etas_organization_overlap_report.rb#L82. The intended semantics appear to be that a holding matches an item either if their `n_enum` matches, or if the holding has no reported `n_enum`.
 
This behavior is complex and confusing because it was replicated from the old holdings system without a comprehensive review of the requirements (that is, the requirements were taken to be the observed behavior of the old system.)

https://hathitrust.atlassian.net/browse/HT-2726
https://hathitrust.atlassian.net/browse/HT-2727

Changing the behavior overall is out of scope here (either changing the behavior for the ETAS overlap report so that it includes cases where no enum matches, or my preferred option of doing away with enum-based matching entirely as we do with serials)

See also the investigation and notes on https://hathitrust.atlassian.net/jira/core/projects/TTO/board?groupBy=status&selectedIssue=TTO-168

## This change

This change allows holdings with `nil` normalized enumeration (`n_enum`) to match HathiTrust items. This appears to be an unanticipated case with the data, but does not change the underlying semantics of matching. Such holdings/items will match and appear in the ETAS overlap report. 

Separately, we should determine whether the data loading process is unexpectedly loading `nil` values for `n_enum`, or if this is a byproduct of data from the old system.

Because the cost report and production overlap table already consider such cases to match via `organizations_with_holdings_but_no_matches`, this should only affect the ETAS overlap report -- that is, the items/holdings already match for the cost report and production holdings table.