### PR TITLE
Fix sidekiq initialzer for updated redis library

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,10 +9,11 @@ if ENV["REDIS_MASTER_SET_NAME"] && ENV["REDIS_HEADLESS_SERVICE"]
   Services.register(:redis_config) do
     # https://github.com/mperham/sidekiq/issues/5194
     {
-      host: ENV["REDIS_MASTER_SET_NAME"],
+      name: ENV["REDIS_MASTER_SET_NAME"],
       password: ENV["REDIS_PASSWORD"],
+      sentinel_password: ENV["REDIS_PASSWORD"],
       sentinels: Resolv.getaddresses(ENV["REDIS_HEADLESS_SERVICE"]).map do |address|
-        {host: address, port: 26379, password: ENV["REDIS_PASSWORD"]}
+        {host: address, port: 26379}
       end
     }
   end


### PR DESCRIPTION
Wasn't tested with redis sentinel in development

N.B. I tested this updated config by starting sidekiq manually in a phctl pod with the updated config. Appeared to work OK.