### PR TITLE
DEV-1458: instantiate (but not persist) holdings & fetch associated cluster

### DIFF
--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -14,19 +14,26 @@ require "cluster_error"
 # - htitems
 # - commitments
 class Cluster
-  attr_reader :ocns
+  attr_reader :ocns, :id
 
   def self.db
     Services.holdings_db
   end
 
-  def initialize(ocns: [])
+  def initialize(id: nil, ocns: [])
+    @id = id
     @ocns = ocns
   end
 
   def self.find(id:)
     ocns = db[:cluster_ocns].select(:ocn).where(cluster_id: id).map(:ocn)
-    new(ocns: ocns)
+    new(id: id, ocns: ocns)
+  end
+
+  def self.for_ocns(ocns)
+    db[:cluster_ocns].select(:cluster_id).distinct.where(ocn: ocns).map do |row|
+      find(id: row[:cluster_id])
+    end
   end
 
   def ocn_resolutions

--- a/lib/clusterable/holding.rb
+++ b/lib/clusterable/holding.rb
@@ -56,7 +56,7 @@ module Clusterable
     # field :issn, type: String
 
     def cluster
-      Cluster.for_ocns([ocn])
+      Cluster.for_ocns([ocn]).first
     end
 
     # validates_presence_of :ocn, :organization, :mono_multi_serial, :date_received

--- a/lib/clusterable/holding.rb
+++ b/lib/clusterable/holding.rb
@@ -8,7 +8,36 @@ module Clusterable
   # A holding
   class Holding
     include EnumChron
+
+    ACCESSOR_ATTRS =
+      [
+        :ocn,
+        :local_id,
+        :enum_chron,
+        :n_enum,
+        :n_chron,
+        :n_enum_chron,
+        :status,
+        :condition,
+        :gov_doc_flag,
+        :mono_multi_serial,
+        :date_received,
+        :country_code,
+        :weight,
+        :uuid,
+        :issn
+      ]
+    READER_ATTRS = [:organization]
+    ALL_ATTRS = ACCESSOR_ATTRS + READER_ATTRS
+
+    EQUALITY_EXCLUDED_ATTRS = [:uuid, :date_received]
+    EQUALITY_ATTRS = (ALL_ATTRS - EQUALITY_EXCLUDED_ATTRS)
+
+    ACCESSOR_ATTRS.each { |attr| attr_accessor attr }
+    READER_ATTRS.each { |attr| attr_reader attr }
+
     # Changes to the field list must be reflected in `==` and `same_as`
+    # XXX: save for now for when we create the table schema
     # field :ocn, type: Integer
     # field :organization, type: String
     # field :local_id, type: String
@@ -26,21 +55,23 @@ module Clusterable
     # field :uuid, type: String
     # field :issn, type: String
 
-    # EQUALITY_EXCLUDED_FIELDS = ["_id", "uuid", "date_received"].freeze
-
-    # embedded_in :cluster
+    def cluster
+      Cluster.for_ocns([ocn])
+    end
 
     # validates_presence_of :ocn, :organization, :mono_multi_serial, :date_received
     # validates_inclusion_of :mono_multi_serial, in: ["mix", "mon", "spm", "mpm", "ser"]
 
-    def initialize(params = nil)
+    def initialize(params = {})
       params&.transform_keys!(&:to_sym)
-      super
+      ALL_ATTRS.each do |attr|
+        send(attr.to_s + "=", params[attr]) if params[attr]
+      end
       set_organization_data if organization
     end
 
     def organization=(organization)
-      super
+      @organization = organization
       set_organization_data
     end
 
@@ -86,11 +117,11 @@ module Clusterable
     # @param other, another holding
     def ==(other)
       self.class == other.class &&
-        (fields.keys - EQUALITY_EXCLUDED_FIELDS).all? do |attr|
+        EQUALITY_ATTRS.all? do |attr|
           self_attr = public_send(attr)
           other_attr = other.public_send(attr)
 
-          (self_attr == other_attr) or (self_attr.blank? and other_attr.blank?)
+          (self_attr == other_attr) or (blank?(self_attr) and blank?(other_attr))
         end
     end
 
@@ -107,15 +138,18 @@ module Clusterable
       ocn == other.ocn
     end
 
+    def to_hash
+      ALL_ATTRS.map { |a| [a, send(a)] }.to_h
+    end
+
     # Turn a holding into a hash key for quick lookup
     # in e.g. cluster_holding.find_old_holdings.
     def update_key
-      raise "not implemented"
-      as_document
-        .slice(*(fields.keys - EQUALITY_EXCLUDED_FIELDS))
+      to_hash
+        .slice(*EQUALITY_ATTRS)
         # fold blank strings & nil to same update key, as in
         # equality above
-        .transform_values { |f| f.blank? ? nil : f }
+        .transform_values { |f| blank?(f) ? nil : f }
         .hash
     end
 
@@ -124,6 +158,10 @@ module Clusterable
     def set_organization_data
       self.country_code = Services.ht_organizations[organization].country_code
       self.weight = Services.ht_organizations[organization].weight
+    end
+
+    def blank?(value)
+      value == "" || value.nil?
     end
   end
 end

--- a/lib/clusterable/ht_item.rb
+++ b/lib/clusterable/ht_item.rb
@@ -7,9 +7,20 @@ module Clusterable
   class HtItem
     include EnumChron
 
-    ACCESSOR_ATTRS = [:ocns, :item_id, :ht_bib_key, :rights, :access, :bib_fmt, :n_enum, :n_chron, :n_enum_chron, :billing_entity, :enum_chron]
+    ACCESSOR_ATTRS = [
+      :ocns,
+      :item_id,
+      :ht_bib_key,
+      :rights,
+      :access,
+      :bib_fmt,
+      :n_enum,
+      :n_chron,
+      :n_enum_chron,
+      :billing_entity,
+      :enum_chron
+    ]
     READER_ATTRS = [:collection_code]
-
     ALL_ATTRS = ACCESSOR_ATTRS + READER_ATTRS
 
     ACCESSOR_ATTRS.each { |attr| attr_accessor attr }

--- a/spec/clusterable/holding_spec.rb
+++ b/spec/clusterable/holding_spec.rb
@@ -4,28 +4,19 @@ require "spec_helper"
 require "clusterable/holding"
 require "cluster"
 
-RSpec.xdescribe Clusterable::Holding do
-  let(:c) { create(:cluster) }
-  let(:h) { build(:holding, :all_fields) }
+RSpec.describe Clusterable::Holding do
+  let(:holdings_org) { "umich" }
+  let(:h) { build(:holding, :all_fields, organization: holdings_org) }
   let(:h2) { h.clone }
 
-  it "does not have a parent" do
-    expect(build(:holding)._parent).to be_nil
-  end
-
-  it "has a parent" do
-    c.holdings << build(:holding)
-    expect(c.holdings.first._parent).to be(c)
-  end
-
-  it "normalizes enum_chron" do
+  xit "normalizes enum_chron" do
     holding = build(:holding, enum_chron: "v.1 Jul 1999")
     expect(holding.n_enum).to eq("1")
     expect(holding.n_chron).to eq("Jul 1999")
     expect(holding.n_enum_chron).to eq("1\tJul 1999")
   end
 
-  it "does nothing if given an empty enum_chron" do
+  xit "does nothing if given an empty enum_chron" do
     holding = build(:holding, enum_chron: "")
     expect(holding.n_enum).to eq("")
     expect(holding.n_chron).to eq("")
@@ -34,7 +25,7 @@ RSpec.xdescribe Clusterable::Holding do
 
   describe "#==" do
     it "== is true if all fields match except date_received and uuid" do
-      h2.date_received = Date.yesterday
+      h2.date_received = Date.today - 1
       h2.uuid = SecureRandom.uuid
       expect(h).to eq(h2)
     end
@@ -60,25 +51,27 @@ RSpec.xdescribe Clusterable::Holding do
       end
     end
 
-    # can't just skip -- fields is not defined
-    #    (described_class.fields.keys - ["date_received", "uuid", "_id"]).each do |attr|
-    #      it "== is false if #{attr} doesn't match" do
-    #        # ensure attribute in h2 is different from h but
-    #        # of the same logical type
-    #
-    #        case h[attr]
-    #        when String
-    #          h2[attr] = "#{h[attr]}junk"
-    #        when Numeric
-    #          h2[attr] = h[attr] + 1
-    #        when true, false, nil
-    #          h2[attr] = !h[attr]
-    #        end
-    #
-    #        expect(h[attr]).not_to eq(h2[attr])
-    #        expect(h).not_to eq(h2)
-    #      end
-    #     end
+    described_class::EQUALITY_ATTRS.each do |attr|
+      it "== is false if #{attr} doesn't match" do
+        # ensure attribute in h2 is different from h but
+        # of the same logical type
+
+        case h.send(attr)
+        when holdings_org
+          # need to have an actual organization
+          h2.send(attr.to_s + "=", "upenn")
+        when String
+          h2.send(attr.to_s + "=", "#{h.send(attr)}junk")
+        when Numeric
+          h2.send(attr.to_s + "=", h.send(attr) + 1)
+        when true, false, nil
+          h2.send(attr.to_s + "=", !h.send(attr))
+        end
+
+        expect(h.send(attr)).not_to eq(h2.send(attr))
+        expect(h).not_to eq(h2)
+      end
+    end
   end
 
   describe "#same_as?" do
@@ -89,7 +82,7 @@ RSpec.xdescribe Clusterable::Holding do
     end
 
     it "same_as is not true if date_received does not match" do
-      h2.date_received = Date.yesterday
+      h2.date_received = Date.today - 1
       expect(h).not_to be_same_as(h2)
     end
   end

--- a/spec/clusterable/holding_spec.rb
+++ b/spec/clusterable/holding_spec.rb
@@ -23,6 +23,22 @@ RSpec.describe Clusterable::Holding do
     expect(holding.n_enum_chron).to eq("")
   end
 
+  describe "#cluster" do
+    include_context "with cluster ocns table"
+
+    it "can get the cluster with the holding ocn" do
+      import_cluster_ocns({1 => [1001, 1002]})
+
+      holding = build(:holding, ocn: 1001)
+      expect(holding.cluster.ocns).to include(1001)
+    end
+
+    it "returns nil if there is no cluster with that ocn" do
+      holding = build(:holding, ocn: 9999)
+      expect(holding.cluster).to be(nil)
+    end
+  end
+
   describe "#==" do
     it "== is true if all fields match except date_received and uuid" do
       h2.date_received = Date.today - 1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require "services"
 require "sidekiq/batch"
 require "rspec-sidekiq"
 require "fileutils"
+require_relative "support/cluster_ocn_table"
 
 SimpleCov::Formatter::LcovFormatter.config do |c|
   c.report_with_single_file = true

--- a/spec/support/cluster_ocn_table.rb
+++ b/spec/support/cluster_ocn_table.rb
@@ -1,0 +1,21 @@
+RSpec.shared_context "with cluster ocns table" do
+  let(:cluster_ocns_table) { Services.holdings_db[:cluster_ocns] }
+  before(:each) { cluster_ocns_table.truncate }
+
+  # import a data structure like
+  # {
+  #   cid1 => [ ocn1, ocn2, ocn3 ],
+  #   cid2 => [ ocn4, ocn5 ]
+  #   ...
+  # }
+  def import_cluster_ocns(cluster_ocns)
+    data = []
+    cluster_ocns.each do |cluster_id, ocns|
+      ocns.each do |ocn|
+        data << [cluster_id, ocn]
+      end
+    end
+
+    cluster_ocns_table.import([:cluster_id, :ocn], data)
+  end
+end


### PR DESCRIPTION
This:

* adds the ability to instantiate `Holding`, basically the same as what we did with `HtItem`. While there may eventually be a superclass to extract here (and for other Clusterables,) I think I want to wait until at least we're handling the OCLC resolution table and the classes support validation & saving.
* adds a support context for populating the table mapping OCNs to cluster IDs
* adds the ability to find a cluster by OCN.

See also comments on individual commits.
