### PR TITLE
DEV-1459: retrieve htitems in cluster

### DIFF
--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -31,8 +31,10 @@ class Cluster
   end
 
   def self.for_ocns(ocns)
-    db[:cluster_ocns].select(:cluster_id).distinct.where(ocn: ocns).map do |row|
-      find(id: row[:cluster_id])
+    return to_enum(__method__, ocns) unless block_given?
+
+    db[:cluster_ocns].select(:cluster_id).distinct.where(ocn: ocns).each do |row|
+      yield find(id: row[:cluster_id])
     end
   end
 
@@ -41,7 +43,7 @@ class Cluster
   end
 
   def ht_items
-    []
+    Clusterable::HtItem.with_ocns(ocns)
   end
 
   def commitments

--- a/spec/clusterable/ht_item_spec.rb
+++ b/spec/clusterable/ht_item_spec.rb
@@ -3,39 +3,15 @@
 require "spec_helper"
 require "clusterable/ht_item"
 require "cluster"
-require "hathifiles_database"
 
 RSpec.describe Clusterable::HtItem do
-  before(:all) do
-    hf_db = HathifilesDatabase.new(Services.holdings_db.uri)
-    hf_db.recreate_tables!
-  end
-
-  before(:each) do
-    Services.hathifiles_table.truncate
-  end
-
+  include_context "with hathifiles table"
   let(:ocn_rand) { rand(1_000_000).to_i }
   let(:item_id_rand) { rand(1_000_000).to_s }
   let(:ht_bib_key_rand) { rand(1_000_000).to_i }
   let(:htitem) { build(:ht_item) }
   let(:htitem_hash) { htitem.to_hash }
   let(:c) { create(:cluster, ocns: htitem_hash[:ocns]) }
-
-  def insert_htitem(htitem)
-    new_htitem_attrs = {
-      htid: htitem.item_id,
-      bib_num: htitem.ht_bib_key,
-      rights_code: htitem.rights,
-      access: htitem.access == "allow",
-      bib_fmt: htitem.bib_fmt,
-      description: htitem.enum_chron,
-      collection_code: htitem.collection_code,
-      oclc: htitem.ocns.join(",")
-    }
-
-    Services.hathifiles_table.insert(new_htitem_attrs)
-  end
 
   it "can be created" do
     expect(described_class.new(htitem_hash)).to be_a(described_class)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require "sidekiq/batch"
 require "rspec-sidekiq"
 require "fileutils"
 require_relative "support/cluster_ocn_table"
+require_relative "support/hathifiles_table"
 
 SimpleCov::Formatter::LcovFormatter.config do |c|
   c.report_with_single_file = true

--- a/spec/support/hathifiles_table.rb
+++ b/spec/support/hathifiles_table.rb
@@ -1,0 +1,32 @@
+require "hathifiles_database"
+require "services"
+
+RSpec.shared_context "with hathifiles table" do
+  before(:all) do
+    hf_db = HathifilesDatabase.new(Services.holdings_db.uri)
+    hf_db.recreate_tables!
+  end
+
+  before(:each) do
+    Services.hathifiles_table.truncate
+  end
+
+  # e.g. insert_htitem(build(:ht_item))
+  def insert_htitem(htitem)
+    new_htitem_attrs = {
+      htid: htitem.item_id,
+      bib_num: htitem.ht_bib_key,
+      rights_code: htitem.rights,
+      access: htitem.access == "allow",
+      bib_fmt: htitem.bib_fmt,
+      description: htitem.enum_chron,
+      collection_code: htitem.collection_code,
+      oclc: htitem.ocns.join(",")
+    }
+
+    Services.hathifiles_table.insert(new_htitem_attrs)
+    htitem.ocns.each do |ocn|
+      Services.hathifiles_ocn_table.insert(htid: htitem.item_id, value: ocn)
+    end
+  end
+end


### PR DESCRIPTION
* Retrieve distinct ht items with a specific set of OCNs
* Support context for adding ht items
* Change functions that return mapped rows to enumerators (to avoid unnecessarily pulling all rows into memory)