### PR TITLE
Dev 1454: ht_item_overlap for spms

### DIFF
--- a/lib/calculate_format.rb
+++ b/lib/calculate_format.rb
@@ -12,7 +12,7 @@ class CalculateFormat
   #
   # @param ht_item, the HT item to calculate the format on.
   def item_format(ht_item)
-    if ht_item.bib_fmt == "SE" || @cluster.large?
+    if ht_item.bib_fmt == "SE"
       "ser"
     elsif cluster_has_item_with_enum_and_same_ht_bib_key? ht_item
       "mpm"
@@ -42,7 +42,7 @@ class CalculateFormat
 
   def cluster_has_item_with_enum_and_same_ht_bib_key?(ht_item)
     @cluster.ht_items.any? do |ht|
-      ht.ht_bib_key == ht_item.ht_bib_key && !ht.n_enum.empty?
+      ht.ht_bib_key == ht_item.ht_bib_key && !ht.n_enum&.empty?
     end
   end
 end

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -87,7 +87,7 @@ class Cluster
   end
 
   def item_enums
-    @item_enums ||= ht_items.pluck(:n_enum).uniq
+    @item_enums ||= ht_items.collect(&:n_enum).uniq
   end
 
   # Maps enums to list of orgs that have a holding with that enum

--- a/lib/overlap/ht_item_overlap.rb
+++ b/lib/overlap/ht_item_overlap.rb
@@ -10,7 +10,7 @@ module Overlap
 
     def initialize(ht_item)
       @ht_item = ht_item
-      @cluster = ht_item._parent
+      @cluster = Cluster.for_ocns(ht_item.ocns).first
       @matching_orgs = organizations_with_holdings
       @matching_members = members_with_holdings
     end

--- a/spec/overlap/ht_item_overlap_spec.rb
+++ b/spec/overlap/ht_item_overlap_spec.rb
@@ -3,188 +3,309 @@
 require "spec_helper"
 require "overlap/ht_item_overlap"
 
-RSpec.xdescribe Overlap::HtItemOverlap do
+RSpec.describe Overlap::HtItemOverlap do
+  include_context "with cluster ocns table"
+  include_context "with hathifiles table"
+  include_context "with holdings table"
+
   let(:c) { build(:cluster) }
-  let(:mpm) do
-    build(:ht_item, :mpm,
+
+  let(:spm) do
+    build(
+      :ht_item,
+      :spm,
       ocns: c.ocns,
-      enum_chron: "1",
-      n_enum: "1",
-      billing_entity: "ualberta")
+      collection_code: "PU"
+      # collection_code PU translates to billing_entity=upenn,
+      # as long as Clusterable::HtItem.set_billing_entity uses
+      # collection_code to determine billing_entity.
+    )
   end
-  let(:holding) do
-    build(:holding,
+  let(:spm_holding1) do
+    build(
+      :holding,
+      mono_multi_serial: "spm",
       ocn: c.ocns.first,
-      organization: "umich",
-      enum_chron: "1",
-      n_enum: "1")
+      organization: "umich"
+    )
   end
-  let(:holding2) do
-    build(:holding,
+  let(:spm_holding2) do
+    build(
+      :holding,
+      mono_multi_serial: "spm",
       ocn: c.ocns.first,
-      organization: "smu",
-      enum_chron: "1",
-      n_enum: "1")
+      organization: "smu"
+    )
   end
-  let(:non_match_holding) do
-    build(:holding,
+  let(:spm_holding3) do
+    build(
+      :holding,
+      mono_multi_serial: "spm",
       ocn: c.ocns.first,
-      organization: "stanford",
-      enum_chron: "2",
-      n_enum: "2")
+      organization: "stanford"
+    )
   end
 
-  before(:each) do
-    Cluster.each(&:delete)
-    c.save
-    Clustering::ClusterHtItem.new(mpm).cluster.tap(&:save)
-    Clustering::ClusterHolding.new(holding).cluster.tap(&:save)
-    Clustering::ClusterHolding.new(holding2).cluster.tap(&:save)
-    Clustering::ClusterHolding.new(non_match_holding).cluster.tap(&:save)
+  # we end up inserting the same kinds of things...
+  # this adds the given item and holdings to cluster c
+  def cluster_item_holdings(item:, holdings:)
+    import_cluster_ocns(1 => c.ocns)
+    insert_htitem(item)
+    holdings.each { |holding| insert_holding(holding) }
   end
 
-  describe "#organizations_with_holdings" do
-    it "returns all organizations that overlap with an item" do
-      c.reload
-      overlap = described_class.new(c.ht_items.first)
-      # billing_entity: ualberta, holdings: smu, umich, non_matching: stanford
-      expect(overlap.organizations_with_holdings.count).to eq(4)
+  context "with an spm cluster and spm holdings" do
+    describe "#organizations_with_holdings" do
+      before(:each) do
+        cluster_item_holdings(item: spm, holdings: [spm_holding1, spm_holding2, spm_holding3])
+      end
+
+      it "returns all organizations that overlap with an item" do
+        overlap = described_class.new(c.ht_items.first)
+        # billing_entity: upenn, holdings: smu, umich, non_matching: stanford
+        expect(overlap.organizations_with_holdings.count).to eq(4)
+      end
+
+      it "only returns unique organizations" do
+        # i.e. if we add another holding for an org that already holds,
+        # organizations_with_holdings.count should stay the same
+        overlap = described_class.new(c.ht_items.first)
+        expect(c.holdings.count).to eq(3)
+        expect(overlap.organizations_with_holdings.count).to eq(4)
+        # add 1 more holding to a member that already holds
+        insert_holding(
+          build(
+            :holding,
+            mono_multi_serial: "spm",
+            ocn: c.ocns.first,
+            organization: "smu"
+          )
+        )
+        # Number of holdings goes up, overlap.organizations_with_holdings.count does not
+        expect(c.holdings.count).to eq(4)
+        overlap = described_class.new(c.ht_items.first)
+        expect(overlap.organizations_with_holdings.count).to eq(4)
+      end
     end
 
-    it "member should match mpm if none of their holdings match" do
-      c.reload
-      overlap = described_class.new(c.ht_items.first)
-      expect(overlap.organizations_with_holdings).to include("stanford")
-    end
+    describe "members_with_holdings" do
+      # Add a fake non-member with a holding,
+      # and see that it is included in overlap.organizations_with_holdings,
+      # but excluded from overlap.members_with_holdings.
+      let(:non_member_holding) do
+        Services.ht_organizations.add_temp(
+          DataSources::HTOrganization.new(
+            inst_id: "non_member",
+            country_code: "xx",
+            weight: 1.0,
+            status: false
+          )
+        )
+        build(
+          :holding,
+          ocn: c.ocns.first,
+          organization: "non_member"
+        )
+      end
 
-    it "does not include non-matching organizations that match something else" do
-      mpm2 = build(:ht_item, :mpm,
+      it "excludes organizations that are not members" do
+        cluster_item_holdings(
+          item: spm,
+          holdings: [spm_holding1, spm_holding2, spm_holding3, non_member_holding]
+        )
+
+        overlap = described_class.new(c.ht_items.first)
+        # billing_entity: ualberta, holdings: smu, umich, excluded: non_member, non_matching: stanford
+        expect(overlap.organizations_with_holdings.count).to eq(5)
+        expect(overlap.members_with_holdings.count).to eq(4)
+      end
+    end
+  end
+
+  context "with an mpm cluster and mpm holdings" do
+    let(:mpm) do
+      build(:ht_item, :mpm,
         ocns: c.ocns,
-        enum_chron: "2",
-        n_enum: "2",
+        enum_chron: "1",
+        n_enum: "1",
         billing_entity: "ualberta")
-      Clustering::ClusterHtItem.new(mpm2).cluster.tap(&:save)
-      c.reload
-      overlap = described_class.new(c.ht_items.where(n_enum: "2").first)
-      expect(overlap.ht_item.n_enum).to eq("2")
-      expect(overlap.organizations_with_holdings).not_to include("umich")
     end
-
-    it "only returns unique organizations" do
-      Clustering::ClusterHolding.new(holding).cluster.tap(&:save)
-      c.reload
-      expect(CalculateFormat.new(c).cluster_format).to eq("mpm")
-      overlap = described_class.new(c.ht_items.first)
-      expect(overlap.organizations_with_holdings.count).to eq(4)
-    end
-
-    it "matches if holding enum is ''" do
-      empty_holding = build(:holding,
-        ocn: c.ocns.first,
-        organization: "upenn",
-        enum_chron: "",
-        n_enum: "")
-      Clustering::ClusterHolding.new(empty_holding).cluster.tap(&:save)
-      c.reload
-      overlap = described_class.new(c.ht_items.first)
-      expect(overlap.organizations_with_holdings).to include("upenn")
-    end
-
-    it "matches if holding enum is '', but chron exists" do
-      almost_empty_holding = build(:holding,
-        ocn: c.ocns.first,
-        organization: "upenn",
-        enum_chron: "Aug",
-        n_enum: "",
-        n_chron: "Aug")
-      Clustering::ClusterHolding.new(almost_empty_holding).cluster.tap(&:save)
-      c.reload
-      overlap = described_class.new(c.ht_items.first)
-      expect(overlap.organizations_with_holdings).to include("upenn")
-    end
-
-    it "does not match if ht item enum is ''" do
-      empty_mpm = build(:ht_item, :mpm,
-        ocns: c.ocns,
-        billing_entity: "ualberta",
-        enum_chron: "",
-        n_enum: "")
-      Clustering::ClusterHtItem.new(empty_mpm).cluster.tap(&:save)
-      c.reload
-      overlap = described_class.new(c.ht_items.where(enum_chron: "").first)
-      expect(overlap.organizations_with_holdings).to eq([non_match_holding.organization,
-        empty_mpm.billing_entity])
-    end
-  end
-
-  describe "members_with_holdings" do
-    let(:non_member_holding) do
-      Services.ht_organizations.add_temp(
-        DataSources::HTOrganization.new(inst_id: "non_member", country_code: "xx",
-          weight: 1.0, status: false)
-      )
+    let(:mpm_holding1) do
       build(:holding,
         ocn: c.ocns.first,
-        organization: "non_member")
+        organization: "umich",
+        enum_chron: "1",
+        n_enum: "1")
+    end
+    let(:mpm_holding2) do
+      build(:holding,
+        ocn: c.ocns.first,
+        organization: "smu",
+        enum_chron: "1",
+        n_enum: "1")
+    end
+    let(:mpm_non_match_holding) do
+      build(:holding,
+        ocn: c.ocns.first,
+        organization: "stanford",
+        enum_chron: "2",
+        n_enum: "2")
     end
 
-    it "excludes organizations that are not members" do
-      Clustering::ClusterHolding.new(non_member_holding).cluster.tap(&:save)
-      c.reload
-      overlap = described_class.new(c.ht_items.first)
-      # billing_entity: ualberta, holdings: smu, umich, excluded: non_member, non_matching: stanford
-      expect(overlap.organizations_with_holdings.count).to eq(5)
-      expect(overlap.members_with_holdings.count).to eq(4)
-    end
-  end
+    # skipping mpm tests until ht_item enumchrons are working
+    xdescribe "#organizations_with_holdings" do
+      before(:each) do
+        import_cluster_ocns(
+          1 => c.ocns
+        )
+        insert_htitem(mpm)
+        [mpm_holding1, mpm_holding2, mpm_non_match_holding].each do |holding|
+          insert_holding(holding)
+        end
+      end
 
-  describe "#h_share" do
-    let(:keio_item) do
-      build(:ht_item, :mpm,
-        ocns: c.ocns,
-        collection_code: "KEIO",
-        enum_chron: "1")
+      it "returns all organizations that overlap with an item" do
+        overlap = described_class.new(c.ht_items.first)
+        # billing_entity: ualberta, holdings: smu, umich, non_matching: stanford
+        expect(overlap.organizations_with_holdings.count).to eq(4)
+      end
+
+      it "member should match mpm if none of their holdings match" do
+        overlap = described_class.new(c.ht_items.first)
+        expect(overlap.organizations_with_holdings).to include("stanford")
+      end
+
+      it "does not include non-matching organizations that match something else" do
+        mpm2 = build(:ht_item, :mpm,
+          ocns: c.ocns,
+          enum_chron: "2",
+          n_enum: "2",
+          billing_entity: "ualberta")
+        Clustering::ClusterHtItem.new(mpm2).cluster.tap(&:save)
+        c.reload
+        overlap = described_class.new(c.ht_items.where(n_enum: "2").first)
+        expect(overlap.ht_item.n_enum).to eq("2")
+        expect(overlap.organizations_with_holdings).not_to include("umich")
+      end
+
+      it "only returns unique organizations" do
+        Clustering::ClusterHolding.new(holding).cluster.tap(&:save)
+        c.reload
+        expect(CalculateFormat.new(c).cluster_format).to eq("mpm")
+        overlap = described_class.new(c.ht_items.first)
+        expect(overlap.organizations_with_holdings.count).to eq(4)
+      end
+
+      it "matches if holding enum is ''" do
+        empty_holding = build(:holding,
+          ocn: c.ocns.first,
+          organization: "upenn",
+          enum_chron: "",
+          n_enum: "")
+        Clustering::ClusterHolding.new(empty_holding).cluster.tap(&:save)
+        c.reload
+        overlap = described_class.new(c.ht_items.first)
+        expect(overlap.organizations_with_holdings).to include("upenn")
+      end
+
+      it "matches if holding enum is '', but chron exists" do
+        almost_empty_holding = build(:holding,
+          ocn: c.ocns.first,
+          organization: "upenn",
+          enum_chron: "Aug",
+          n_enum: "",
+          n_chron: "Aug")
+        Clustering::ClusterHolding.new(almost_empty_holding).cluster.tap(&:save)
+        c.reload
+        overlap = described_class.new(c.ht_items.first)
+        expect(overlap.organizations_with_holdings).to include("upenn")
+      end
+
+      it "does not match if ht item enum is ''" do
+        empty_mpm = build(:ht_item, :mpm,
+          ocns: c.ocns,
+          billing_entity: "ualberta",
+          enum_chron: "",
+          n_enum: "")
+        Clustering::ClusterHtItem.new(empty_mpm).cluster.tap(&:save)
+        c.reload
+        overlap = described_class.new(c.ht_items.where(enum_chron: "").first)
+        expect(overlap.organizations_with_holdings).to eq([mpm_non_match_holding.organization,
+          empty_mpm.billing_entity])
+      end
     end
 
-    let(:ucm_item) do
-      Services.ht_organizations.add_temp(
-        DataSources::HTOrganization.new(inst_id: "ucm", country_code: "es",
-          weight: 1.0, status: true)
-      )
-      build(:ht_item, :mpm,
-        ocns: c.ocns,
-        collection_code: "UCM",
-        enum_chron: "1")
-    end
+    describe "#h_share" do
+      it "returns 0 for a member that is not a holder" do
+        cluster_item_holdings(item: spm, holdings: [])
+        overlap = described_class.new(c.ht_items.first)
+        expect(overlap.h_share("umich")).to eq(0)
+      end
 
-    it "returns ratio of organizations" do
-      c.reload
-      overlap = described_class.new(c.ht_items.first)
-      expect(overlap.h_share("umich")).to eq(1.0 / 4)
-    end
+      it "returns 1 for a member who is the only holder" do
+        cluster_item_holdings(item: spm, holdings: [])
+        overlap = described_class.new(c.ht_items.first)
+        expect(overlap.h_share("upenn")).to eq(1)
+      end
 
-    it "assigns an h_share to hathitrust for KEIO items" do
-      Clustering::ClusterHtItem.new(keio_item).cluster.tap(&:save)
-      c.reload
-      overlap = described_class.new(c.ht_items.last)
-      expect(c.ht_items.last.billing_entity).to eq("hathitrust")
-      expect(overlap.h_share("hathitrust")).to eq(1.0 / 4)
-      expect(overlap.h_share("umich")).to eq(1.0 / 4)
-    end
+      it "returns ratio of organizations" do
+        # that is, if there are 4 holders, each holder gets a 1/4 share.
+        cluster_item_holdings(item: spm, holdings: [spm_holding1, spm_holding2, spm_holding3])
+        overlap = described_class.new(c.ht_items.first)
+        expect(overlap.h_share(spm.billing_entity)).to eq(1.0 / 4)
+        expect(overlap.h_share(spm_holding1.organization)).to eq(1.0 / 4)
+        expect(overlap.h_share(spm_holding2.organization)).to eq(1.0 / 4)
+        expect(overlap.h_share(spm_holding3.organization)).to eq(1.0 / 4)
+      end
 
-    it "assigns an h_share to UCM as it would anyone else" do
-      Clustering::ClusterHtItem.new(ucm_item).cluster.tap(&:save)
-      c.reload
-      overlap = described_class.new(c.ht_items.last)
-      expect(c.ht_items.last.billing_entity).to eq("ucm")
-      expect(overlap.h_share("ucm")).to eq(1.0 / 4)
-      expect(overlap.h_share("umich")).to eq(1.0 / 4)
-    end
+      # skipping keio & ucm tests for now
+      # TODO: enable them when ht_item enumchrons are working
+      xdescribe "#h_share: special rules for hathitrust, keio & ucm" do
+        let(:keio_item) do
+          build(
+            :ht_item,
+            :mpm,
+            ocns: c.ocns,
+            collection_code: "KEIO",
+            enum_chron: "1"
+          )
+        end
 
-    it "returns 0 if not held" do
-      c.reload
-      overlap = described_class.new(c.ht_items.first)
-      expect(overlap.h_share("upenn")).to eq(0)
+        let(:ucm_item) do
+          Services.ht_organizations.add_temp(
+            DataSources::HTOrganization.new(
+              inst_id: "ucm",
+              country_code: "es",
+              weight: 1.0,
+              status: true
+            )
+          )
+          build(
+            :ht_item,
+            :mpm,
+            ocns: c.ocns,
+            collection_code: "UCM",
+            enum_chron: "1"
+          )
+        end
+        it "assigns an h_share to hathitrust for KEIO items" do
+          Clustering::ClusterHtItem.new(keio_item).cluster.tap(&:save)
+          c.reload
+          overlap = described_class.new(c.ht_items.last)
+          expect(c.ht_items.last.billing_entity).to eq("hathitrust")
+          expect(overlap.h_share("hathitrust")).to eq(1.0 / 4)
+          expect(overlap.h_share("umich")).to eq(1.0 / 4)
+        end
+
+        it "assigns an h_share to UCM as it would anyone else" do
+          Clustering::ClusterHtItem.new(ucm_item).cluster.tap(&:save)
+          c.reload
+          overlap = described_class.new(c.ht_items.last)
+          expect(c.ht_items.last.billing_entity).to eq("ucm")
+          expect(overlap.h_share("ucm")).to eq(1.0 / 4)
+          expect(overlap.h_share("umich")).to eq(1.0 / 4)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Context: https://hathitrust.atlassian.net/browse/DEV-1454

Small changes to:
* `lib/calculate_format.rb`
* `lib/cluster.rb`
* `lib/overlap/ht_item_overlap.rb`
... in order to get `lib/overlap/ht_item_overlap.rb` to run.

Remaining changes to `spec/overlap/ht_item_overlap_spec.rb` consisting either of:
* Re-organizing tests to make it cleaner which ones are enabled/disabled
* Modifying enabled tests so they work
* Disabling tests related to mpms, copying relevant tests and making them about spms
* Adding a few extra tests for good measure

Test:
```
bundle exec rspec spec/overlap/ht_item_overlap_spec.rb
bundle exec rspec
```