### PR TITLE
DEV-1490: enable loading holdings

### DIFF
--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -120,7 +120,7 @@ class Cluster
     dataset = table.select(:cluster_id).distinct
 
     dataset.each do |row|
-      yield(find(id: row[:id]))
+      yield(find(id: row[:cluster_id]))
     end
   end
 

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -153,15 +153,6 @@ class Cluster
     Clusterable::Holding.with_ocns(ocns)
   end
 
-  UPDATE_LAST_MODIFIED = {"$currentDate" => {last_modified: true}}.freeze
-  def add_holdings(*items)
-    push_to_field(:holdings, items.flatten, UPDATE_LAST_MODIFIED)
-  end
-
-  def add_ht_items(*items)
-    push_to_field(:ht_items, items.flatten, UPDATE_LAST_MODIFIED)
-  end
-
   # Add a Set of new OCLC numbers to this cluster.
   #
   # Raises a duplicate key error if these OCLC numbers are already in some other

--- a/lib/clusterable/holding.rb
+++ b/lib/clusterable/holding.rb
@@ -154,6 +154,12 @@ module Clusterable
       Services.ht_organizations[organization].weight
     end
 
+    def save
+      self.class.table.insert(to_hash)
+    end
+
+    alias_method :save!, :save
+
     private
 
     def blank?(value)

--- a/lib/clusterable/holding.rb
+++ b/lib/clusterable/holding.rb
@@ -22,12 +22,11 @@ module Clusterable
         :condition,
         :gov_doc_flag,
         :mono_multi_serial,
-        :date_received,
         :uuid,
         :issn
       ]
 
-    READER_ATTRS = []
+    READER_ATTRS = [:date_received]
     ALL_ATTRS = ACCESSOR_ATTRS + READER_ATTRS
 
     EQUALITY_EXCLUDED_ATTRS = [:uuid, :date_received]
@@ -46,7 +45,7 @@ module Clusterable
     def initialize(params = {})
       params&.transform_keys!(&:to_sym)
       ALL_ATTRS.each do |attr|
-        send(attr.to_s + "=", params[attr]) if params[attr]
+        send(attr.to_s + "=", params[attr]) if params.has_key?(attr)
       end
     end
 
@@ -125,6 +124,16 @@ module Clusterable
       (self == other) &&
         (date_received == other.date_received) &&
         (uuid == other.uuid)
+    end
+
+    def date_received=(date)
+      if date.respond_to?(:to_date)
+        @date_received = date.to_date
+      elsif date.respond_to?(:to_s)
+        @date_received = Date.parse(date)
+      else
+        raise ArgumentError "Can't convert #{date} to date or parse as date"
+      end
     end
 
     def batch_with?(other)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -3,17 +3,17 @@
 require "spec_helper"
 require "phctl"
 
-RSpec.xdescribe "phctl integration" do
+RSpec.describe "phctl integration" do
   def phctl(*args)
     PHCTL::PHCTL.start(args)
   end
 
-  before(:each) do
-    Cluster.each(&:delete)
-  end
+  include_context "with cluster ocns table"
+  include_context "with hathifiles table"
+  include_context "with holdings table"
 
   describe "load" do
-    describe "commitments" do
+    xdescribe "commitments" do
       it "loads json file" do
         expect { phctl("load", "commitments", fixture("sp_commitment.ndj")) }
           .to change { cluster_count(:commitments) }.by(1)
@@ -37,12 +37,12 @@ RSpec.xdescribe "phctl integration" do
       end
     end
 
-    it "HtItems loads hathifiles" do
+    it "HtItems creates clusters with ocns in hathifile" do
       expect { phctl("load", "ht_items", fixture("hathifile_sample.txt")) }
-        .to change { cluster_count(:ht_items) }.by(5)
+        .to change { Cluster.count }.by(5)
     end
 
-    it "Concordance loads concordance diffs" do
+    xit "Concordance loads concordance diffs" do
       Settings.concordance_path = fixture("concordance")
       expect { phctl(*%w[load concordance 2022-08-01]) }
         .to change { cluster_count(:ocn_resolutions) }.by(5)
@@ -53,13 +53,13 @@ RSpec.xdescribe "phctl integration" do
         .to change { cluster_count(:holdings) }.by(10)
     end
 
-    it "ClusterFile loads json clusters" do
+    xit "ClusterFile loads json clusters" do
       expect { phctl("load", "cluster_file", fixture("cluster_2503661.json")) }
         .to change { Cluster.count }.by(1)
     end
   end
 
-  describe "Cleanup" do
+  xdescribe "Cleanup" do
     it "Holdings removes old holdings" do
       phctl("load", "holdings", fixture("umich_fake_testdata.ndj"))
       expect { phctl(*%w[cleanup holdings umich 2022-01-01]) }
@@ -103,7 +103,7 @@ RSpec.xdescribe "phctl integration" do
 
   # SharedPrintOps - integration tests are in the respective SharedPrint class
 
-  describe "Report" do
+  xdescribe "Report" do
     before(:each) do
       phctl("load", "cluster_file", fixture("cluster_2503661.json"))
     end

--- a/spec/loader/holding_loader_spec.rb
+++ b/spec/loader/holding_loader_spec.rb
@@ -3,7 +3,9 @@
 require "spec_helper"
 require "loader/holding_loader"
 
-RSpec.xdescribe Loader::HoldingLoader do
+RSpec.describe Loader::HoldingLoader do
+  include_context "with holdings table"
+
   let(:uuid) { SecureRandom.uuid }
   let(:line) do
     [
@@ -33,6 +35,9 @@ RSpec.xdescribe Loader::HoldingLoader do
   end
 
   describe "#load" do
+    include_context "with cluster ocns table"
+    include_context "with holdings table"
+
     before(:each) { Cluster.each(&:delete) }
 
     it "persists a batch of holdings" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -134,7 +134,7 @@ def fixture(filename)
 end
 
 def cluster_count(field)
-  Cluster.all.map { |c| c.public_send(field).count }.reduce(0, :+)
+  Cluster.each.map { |c| c.public_send(field).count }.reduce(0, :+)
 end
 
 def Settings.reload!

--- a/sql/006_holdings.sql
+++ b/sql/006_holdings.sql
@@ -11,7 +11,7 @@ CREATE TABLE `holdings` (
   `n_enum_chron` varchar(255) NULL,
   `status`       enum('CH', 'LM', 'WD') NULL,
   `condition`    enum('BRT', '') NULL,
-  `gov_doc_flag` tinyint(1) DEFAULT '0' NOT NULL,
+  `gov_doc_flag` tinyint(1),
   `mono_multi_serial` enum('mix', 'mon', 'spm', 'mpm', 'ser') NOT NULL,
   `date_received` date NOT NULL,
   `uuid`         char(36) NOT NULL,


### PR DESCRIPTION
To be merged after #326

This adds saving holdings at a basic level but doesn't enable updating or deleting holdings.

This also enables some integration specs, including for loading holdings & creating the clustering for htitems (which will help with DEV-1486 / DEV-1487)