### PR TITLE
DEV-1449: schema updates for holdings/hathifile loading

### DIFF
--- a/sql/005_cluster_ocns.sql
+++ b/sql/005_cluster_ocns.sql
@@ -2,8 +2,8 @@ USE `ht_repository`;
 
 DROP TABLE IF EXISTS `cluster_ocns`;
 CREATE TABLE `cluster_ocns` (
-  cluster_id int NOT NULL,
-  ocn int NOT NULL,
+  cluster_id int unsigned NOT NULL,
+  ocn bigint unsigned NOT NULL,
   PRIMARY KEY (ocn),
   INDEX (cluster_id)
 ) ENGINE=InnoDB;

--- a/sql/006_holdings.sql
+++ b/sql/006_holdings.sql
@@ -15,5 +15,7 @@ CREATE TABLE `holdings` (
   `mono_multi_serial` enum('mix', 'mon', 'spm', 'mpm', 'ser') NOT NULL,
   `date_received` date NOT NULL,
   `uuid`         char(36) NOT NULL,
-  `issn`         varchar(255) NULL
+  `issn`         varchar(255) NULL,
+  KEY (`ocn`),
+  KEY (`organization`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/sql/007_oclc_concordance.sql
+++ b/sql/007_oclc_concordance.sql
@@ -2,8 +2,8 @@ use `ht_repository`;
 
 DROP TABLE IF EXISTS `oclc_concordance`;
 CREATE TABLE `oclc_concordance` (
-  `oclc` int(10) unsigned NOT NULL,
-  `canonical` int(10) unsigned DEFAULT NULL,
+  `oclc` bigint unsigned NOT NULL,
+  `canonical` bigint unsigned DEFAULT NULL,
   PRIMARY KEY (`oclc`,`canonical`),
   INDEX (`canonical`)
 ) ENGINE=InnoDB


### PR DESCRIPTION
* ocn uses bigint -- while the maximum real OCN fits comfortably in 32 bits, it's possible we'll have other non-OCN numbers come through, and validation practices differ across different things (hathifiles, holdings, etc)

* index ocn and organization for holdings