### PR TITLE
Use a persistent volume for mariadb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,8 @@ services:
     healthcheck:
       <<: *healthcheck-defaults
       test: [ "CMD", "healthcheck.sh", "--su-mysql", "--connect", "--innodb_initialized" ]
+    volumes:
+      - data_db:/var/lib/mysql
 
   pushgateway:
     image: prom/pushgateway


### PR DESCRIPTION
This ensures data for development persists across restarts of the container.