### PR TITLE
Dev 1516 rename oclc concordance fields

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -7,7 +7,7 @@ if ENV["REDIS_SIDEKIQ_RW_HOST"] && ENV["REDIS_SIDEKIQ_RW_PASSWORD"]
   Services.register(:redis_config) do
     {
       host: ENV["REDIS_SIDEKIQ_RW_HOST"],
-      password: ENV["REDIS_SIDEKIQ_RW_PASSWORD"],
+      password: ENV["REDIS_SIDEKIQ_RW_PASSWORD"]
     }
   end
 else

--- a/lib/clusterable/ocn_resolution.rb
+++ b/lib/clusterable/ocn_resolution.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Clusterable
-  # A mapping from a deprecated OCN to a resolved OCN
+  # A mapping from a deprecated/variant OCN to a resolved/canonical OCN
   class OCNResolution < Clusterable::Base
-    attr_accessor :deprecated, :resolved
+    attr_accessor :variant, :canonical
     #    include Mongoid::Document
     #
     #    # store_in collection: "resolutions", database: "test", client: "default"
@@ -28,10 +28,10 @@ module Clusterable
       return to_enum(__method__, ocns) unless block_given?
 
       ocns = ocns.to_a
-      dataset = table.where(oclc: ocns).or(canonical: ocns)
+      dataset = table.where(variant: ocns).or(canonical: ocns)
 
       dataset.each do |row|
-        yield new(deprecated: row[:oclc], resolved: row[:canonical])
+        yield new(variant: row[:variant], canonical: row[:canonical])
       end
     end
 
@@ -44,11 +44,11 @@ module Clusterable
     end
 
     def ocns
-      [deprecated, resolved]
+      [variant, canonical]
     end
 
     def batch_with?(other)
-      resolved == other.resolved
+      canonical == other.canonical
     end
 
     def save
@@ -58,7 +58,7 @@ module Clusterable
       #
       # Use replace rather than insert so if the row already exists, this is a
       # no-op.
-      table.replace([:oclc, :canonical], [deprecated, resolved])
+      table.replace([:variant, :canonical], [variant, canonical])
     end
 
     alias_method :save!, :save

--- a/lib/clustering/cluster_ocn_resolution.rb
+++ b/lib/clustering/cluster_ocn_resolution.rb
@@ -33,8 +33,8 @@ module Clustering
       Retryable.with_transaction do
         Cluster.where(ocns: {"$all": resolution.ocns}).each do |c|
           c.ocn_resolutions.delete_if do |candidate|
-            candidate.deprecated == resolution.deprecated &&
-              candidate.resolved == resolution.resolved
+            candidate.variant == resolution.variant &&
+              candidate.canonical == resolution.canonical
           end
           Reclusterer.new(c, resolution.ocns).recluster
         end

--- a/lib/concordance_processing.rb
+++ b/lib/concordance_processing.rb
@@ -10,11 +10,11 @@ class ConcordanceProcessing
     fout = File.open(fout, "w")
 
     c = ConcordanceValidation::Concordance.new(fin)
-    c.raw_to_resolved.each_key do |raw|
-      next if c.raw_to_resolved[raw].count.zero?
+    c.variant_to_canonical.each_key do |variant|
+      next if c.variant_to_canonical[variant].count.zero?
 
       begin
-        sub = c.compile_sub_graph(raw)
+        sub = c.compile_sub_graph(variant)
         c.detect_cycles(*sub)
       rescue => e
         log.puts e
@@ -22,14 +22,14 @@ class ConcordanceProcessing
         next
       end
       begin
-        # checks for multiple terminal ocns
-        _terminal = c.terminal_ocn(raw)
+        # checks for multiple canonical ocns
+        _canonical = c.canonical_ocn(variant)
       rescue => e
         log.puts e
         next
       end
 
-      fout.puts [raw, c.terminal_ocn(raw)].join("\t")
+      fout.puts [variant, c.canonical_ocn(variant)].join("\t")
     end
 
     log.close

--- a/lib/concordance_validation/delta.rb
+++ b/lib/concordance_validation/delta.rb
@@ -21,8 +21,8 @@ module ConcordanceValidation
         if old_conc_lines.include? line
           old_conc_lines.delete(line)
         else
-          dead_ocn, resolved_ocn = line.chomp.split("\t")
-          adds[resolved_ocn] << dead_ocn
+          variant_ocn, canonical_ocn = line.chomp.split("\t")
+          adds[canonical_ocn] << variant_ocn
         end
       end
       write(File.open(diff_out_path + ".adds", "w"), adds)
@@ -31,9 +31,9 @@ module ConcordanceValidation
     end
 
     def write(fout, diffs)
-      diffs.keys.sort.each do |resolved_ocn|
-        diffs[resolved_ocn].each do |dead_ocn|
-          fout.puts [dead_ocn, resolved_ocn].join("\t")
+      diffs.keys.sort.each do |canonical_ocn|
+        diffs[canonical_ocn].each do |variant_ocn|
+          fout.puts [variant_ocn, canonical_ocn].join("\t")
         end
       end
       fout.flush
@@ -55,8 +55,8 @@ module ConcordanceValidation
 
     def deletes_from_remaining_lines(lines)
       lines.each do |line|
-        dead_ocn, resolved_ocn = line.chomp.split("\t")
-        deletes[resolved_ocn] << dead_ocn
+        variant_ocn, canonical_ocn = line.chomp.split("\t")
+        deletes[canonical_ocn] << variant_ocn
       end
     end
   end

--- a/lib/loader/ocn_resolution_loader.rb
+++ b/lib/loader/ocn_resolution_loader.rb
@@ -7,8 +7,8 @@ module Loader
   # Constructs batches of HtItems from incoming file data
   class OCNResolutionLoader
     def item_from_line(line)
-      (deprecated, resolved) = line.split.map(&:to_i)
-      Clusterable::OCNResolution.new(deprecated: deprecated, resolved: resolved)
+      (variant, canonical) = line.split.map(&:to_i)
+      Clusterable::OCNResolution.new(variant: variant, canonical: canonical)
     end
 
     def load(batch)

--- a/lib/ocn_concordance_diffs.rb
+++ b/lib/ocn_concordance_diffs.rb
@@ -7,7 +7,7 @@ require "loader/file_loader"
 require "loader/ocn_resolution_loader"
 
 # Responsible for locating and loading a pair of diffs from an OCN concordance.
-# Both files contain OCNResolutions represented as deprecated, resolved pairs
+# Both files contain OCNResolutions represented as variant, canonical (resolved) pairs
 # One file contains OCNResolutions to add, the other contains OCNResolutions to
 # delete.
 #

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -675,8 +675,8 @@ RSpec.describe Cluster do
     it "gets OCN resolution rules for merged OCNs" do
       create(:cluster, ocns: [5, 7])
       create(:cluster, ocns: [6, 8])
-      create(:ocn_resolution, resolved: 5, deprecated: 7)
-      create(:ocn_resolution, resolved: 6, deprecated: 8)
+      create(:ocn_resolution, canonical: 5, variant: 7)
+      create(:ocn_resolution, canonical: 6, variant: 8)
 
       expect(merged_cluster.ocn_resolutions.count).to eq(2)
     end

--- a/spec/clusterable/ocn_resolution_spec.rb
+++ b/spec/clusterable/ocn_resolution_spec.rb
@@ -4,51 +4,51 @@ require "spec_helper"
 require "clusterable/ocn_resolution"
 
 RSpec.describe Clusterable::OCNResolution do
-  let(:deprecated) { double(:deprecated) }
-  let(:resolved) { double(:resolved) }
+  let(:variant) { double(:variant) }
+  let(:canonical) { double(:canonical) }
   let(:another_ocn) { double(:another) }
 
   let(:resolution) do
-    described_class.new(deprecated: deprecated, resolved: resolved)
+    described_class.new(variant: variant, canonical: canonical)
   end
 
   it "can be created" do
     expect(resolution).to be_a(described_class)
   end
 
-  it "returns the deprecated ocn" do
-    expect(resolution.deprecated).to eq(deprecated)
+  it "returns the variant ocn" do
+    expect(resolution.variant).to eq(variant)
   end
 
-  it "returns the resolved ocn" do
-    expect(resolution.resolved).to eq(resolved)
+  it "returns the canonical ocn" do
+    expect(resolution.canonical).to eq(canonical)
   end
 
   it "returns both ocns" do
-    expect(resolution.ocns).to eq([deprecated, resolved])
+    expect(resolution.ocns).to eq([variant, canonical])
   end
 
   describe "==" do
     it "is equal if both ocns are the same" do
-      expect(described_class.new(deprecated: deprecated, resolved: resolved))
-        .to eq(described_class.new(deprecated: deprecated, resolved: resolved))
+      expect(described_class.new(variant: variant, canonical: canonical))
+        .to eq(described_class.new(variant: variant, canonical: canonical))
     end
   end
 
   describe "#batch_with?" do
-    let(:resolution1) { build(:ocn_resolution, deprecated: 123, resolved: 456) }
-    let(:resolution2) { build(:ocn_resolution, deprecated: 312, resolved: 456) }
-    let(:resolution3) { build(:ocn_resolution, deprecated: 123, resolved: 789) }
+    let(:resolution1) { build(:ocn_resolution, variant: 123, canonical: 456) }
+    let(:resolution2) { build(:ocn_resolution, variant: 312, canonical: 456) }
+    let(:resolution3) { build(:ocn_resolution, variant: 123, canonical: 789) }
 
-    it "batches items with the same resolved OCN" do
+    it "batches items with the same canonical OCN" do
       expect(resolution1.batch_with?(resolution2)).to be true
     end
 
-    it "does not batch items with different deprecated and resolved OCNS" do
+    it "does not batch items with different variant and canonical OCNS" do
       expect(resolution2.batch_with?(resolution3)).to be false
     end
 
-    it "does not batch items with the same deprecated but different resolved OCN" do
+    it "does not batch items with the same variant but different canonical OCN" do
       expect(resolution1.batch_with?(resolution3)).to be false
     end
   end

--- a/spec/clustering/cluster_ht_item_spec.rb
+++ b/spec/clustering/cluster_ht_item_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Clustering::ClusterHtItem do
     xcontext "with concordance rules" do
       it "can add an HTItem" do
         resolution = build(:ocn_resolution)
-        htitem = build(:ht_item, ocns: [resolution.deprecated])
+        htitem = build(:ht_item, ocns: [resolution.variant])
         create(:cluster, ocns: resolution.ocns, ocn_resolutions: [resolution])
         c = described_class.new(htitem).cluster
         expect(c.valid?).to be true
@@ -212,7 +212,7 @@ RSpec.describe Clustering::ClusterHtItem do
 
       # No longer necessary. Reclusterer will determine if it actually needs to be reclustered.
       it "reclusters if an HTItem loses an OCN that is not in a concordance rule" do
-        resolution = build(:ocn_resolution, deprecated: 1, resolved: 2)
+        resolution = build(:ocn_resolution, variant: 1, canonical: 2)
         htitem = build(:ht_item, ocns: [2, 3])
         old_cluster = create(:cluster, ocns: [1, 2, 3],
           ocn_resolutions: [resolution],
@@ -228,7 +228,7 @@ RSpec.describe Clustering::ClusterHtItem do
       end
 
       it "updates cluster.ocns if an HTItem loses an OCN that is not in a concordance rule" do
-        resolution = build(:ocn_resolution, deprecated: 1, resolved: 2)
+        resolution = build(:ocn_resolution, variant: 1, canonical: 2)
         htitem = build(:ht_item, ocns: [2, 3])
         create(:cluster, ocns: [1, 2, 3],
           ocn_resolutions: [resolution],
@@ -244,7 +244,7 @@ RSpec.describe Clustering::ClusterHtItem do
       end
 
       it "does not recluster if an HTItem loses an OCN that is in the concordance" do
-        resolution = build(:ocn_resolution, deprecated: 1, resolved: 2)
+        resolution = build(:ocn_resolution, variant: 1, canonical: 2)
         htitem = build(:ht_item, ocns: [1, 2])
         old_cluster = create(:cluster, ocns: [1, 2],
           ocn_resolutions: [resolution],
@@ -260,7 +260,7 @@ RSpec.describe Clustering::ClusterHtItem do
       end
 
       it "does not recluster if an HTItem changes from one OCN to another in the concordance" do
-        resolution = build(:ocn_resolution, deprecated: 1, resolved: 2)
+        resolution = build(:ocn_resolution, variant: 1, canonical: 2)
         htitem = build(:ht_item, ocns: [1])
         old_cluster = create(:cluster, ocns: [1, 2],
           ocn_resolutions: [resolution],
@@ -279,7 +279,7 @@ RSpec.describe Clustering::ClusterHtItem do
         htitem = build(:ht_item, ocns: [3])
 
         old_cluster = create(:cluster, ocns: [1, 2, 3],
-          ocn_resolutions: [build(:ocn_resolution, deprecated: 1, resolved: 2)],
+          ocn_resolutions: [build(:ocn_resolution, variant: 1, canonical: 2)],
           ht_items: [htitem,
             build(:ht_item, ocns: [1, 3])])
 
@@ -350,7 +350,7 @@ RSpec.describe Clustering::ClusterHtItem do
       it "does not recluster if all the old HTItems's OCNs are covered by concordance rules" do
         htitem = build(:ht_item, ocns: [1, 2])
         old_cluster = create(:cluster, ocns: [1, 2],
-          ocn_resolutions: [build(:ocn_resolution, deprecated: 1, resolved: 2)],
+          ocn_resolutions: [build(:ocn_resolution, variant: 1, canonical: 2)],
           ht_items: [htitem, build(:ht_item, ocns: [1])])
 
         htitem.ocns = [3]

--- a/spec/clustering/reclusterer_spec.rb
+++ b/spec/clustering/reclusterer_spec.rb
@@ -8,9 +8,9 @@ require "clustering/cluster_ocn_resolution"
 
 RSpec.xdescribe Clustering::Reclusterer do
   let(:glue) { build(:ocn_resolution) }
-  let(:ht_item) { build(:ht_item, ocns: [glue.deprecated]) }
-  let(:holding) { build(:holding, ocn: glue.resolved) }
-  let(:comm) { build(:commitment, ocn: glue.resolved) }
+  let(:ht_item) { build(:ht_item, ocns: [glue.variant]) }
+  let(:holding) { build(:holding, ocn: glue.canonical) }
+  let(:comm) { build(:commitment, ocn: glue.canonical) }
 
   context "when removing glue from Item/Holding/Commitment cluster" do
     before(:each) do
@@ -29,14 +29,14 @@ RSpec.xdescribe Clustering::Reclusterer do
 
     it "moves ht_item, holding, and comm to new clusters" do
       Clustering::ClusterOCNResolution.new(glue).delete
-      expect(Cluster.find_by(ocns: glue.deprecated).ht_items.count).to eq(1)
-      expect(Cluster.find_by(ocns: glue.resolved).holdings.count).to eq(1)
-      expect(Cluster.find_by(ocns: glue.resolved).commitments.count).to eq(1)
+      expect(Cluster.find_by(ocns: glue.variant).ht_items.count).to eq(1)
+      expect(Cluster.find_by(ocns: glue.canonical).holdings.count).to eq(1)
+      expect(Cluster.find_by(ocns: glue.canonical).commitments.count).to eq(1)
     end
   end
 
   context "when removing non-glue from cluster" do
-    let(:nonglue) { build(:ocn_resolution, ocns: [glue.resolved, 666]) }
+    let(:nonglue) { build(:ocn_resolution, ocns: [glue.canonical, 666]) }
 
     before(:each) do
       Cluster.each(&:delete)
@@ -111,7 +111,7 @@ RSpec.xdescribe Clustering::Reclusterer do
 
     it "returns false if removed_ocns are all in other clusterable_ocn_tuples" do
       cluster = Cluster.first
-      reclusterer = described_class.new(cluster, [glue.resolved, 999])
+      reclusterer = described_class.new(cluster, [glue.canonical, 999])
       expect(reclusterer.ocns_changed?).to be false
     end
   end

--- a/spec/concordance_validation/concordance_spec.rb
+++ b/spec/concordance_validation/concordance_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe ConcordanceValidation::Concordance do
   describe "terminal_ocn" do
     it "can find root ocns" do
       chained = described_class.new("spec/concordance_validation/data/chained.tsv")
-      expect(chained.terminal_ocn(1)).to eq(3)
+      expect(chained.canonical_ocn(1)).to eq(3)
     end
 
     it "complains if there are multiple terminal ocns" do
       multi = described_class.new("spec/concordance_validation/data/multiple_terminal.tsv")
-      expect { multi.terminal_ocn(1) }.to \
+      expect { multi.canonical_ocn(1) }.to \
         raise_error("OCN:1 resolves to multiple ocns: 2, 3")
     end
   end
@@ -37,13 +37,13 @@ RSpec.describe ConcordanceValidation::Concordance do
   describe "described_class.new" do
     it "builds a basic concordance structure" do
       chained_file = "spec/concordance_validation/data/chained.tsv"
-      expect(described_class.new(chained_file).raw_to_resolved).to \
+      expect(described_class.new(chained_file).variant_to_canonical).to \
         eq(1 => [2], 2 => [3])
     end
 
     it "handles gzipped files" do
       chained_gzip_file = "spec/concordance_validation/data/chained.tsv.gz"
-      expect(described_class.new(chained_gzip_file).raw_to_resolved).to \
+      expect(described_class.new(chained_gzip_file).variant_to_canonical).to \
         eq(1 => [2], 2 => [3])
     end
   end

--- a/spec/disabled/clustering/cluster_commitment_spec.rb
+++ b/spec/disabled/clustering/cluster_commitment_spec.rb
@@ -80,7 +80,7 @@ RSpec.xdescribe Clustering::ClusterCommitment do
     }
     let(:ocn1) { 1 }
     let(:ocn2) { 2 }
-    let(:reso) { build(:ocn_resolution, deprecated: ocn1, resolved: ocn2) }
+    let(:reso) { build(:ocn_resolution, variant: ocn1, canonical: ocn2) }
 
     let(:finder) { SharedPrint::Finder.new(ocn: [ocn1, ocn2]) }
     it "Puts commitments together when their clusters merge." do

--- a/spec/disabled/shared_print/updater_spec.rb
+++ b/spec/disabled/shared_print/updater_spec.rb
@@ -141,7 +141,7 @@ RSpec.xdescribe SharedPrint::Updater do
 
     it "can update to an ocn on the same cluster" do
       # set up a cluster with ocn1 and ocn2
-      resolution = build(:ocn_resolution, deprecated: ocn1, resolved: ocn2)
+      resolution = build(:ocn_resolution, variant: ocn1, canonical: ocn2)
       cluster = build(:cluster, ocns: [ocn1, ocn2])
       cluster.save
       cluster.add_ocn_resolutions([resolution])

--- a/spec/factories/ocn_resolution.rb
+++ b/spec/factories/ocn_resolution.rb
@@ -4,7 +4,7 @@ require "clusterable/ocn_resolution"
 
 FactoryBot.define do
   factory :ocn_resolution, class: "Clusterable::OCNResolution" do
-    deprecated { rand(1..1_000_000) }
-    resolved { deprecated + rand(1..1_000_000) }
+    variant { rand(1..1_000_000) }
+    canonical { variant + rand(1..1_000_000) }
   end
 end

--- a/spec/loader/ocn_resolution_loader_spec.rb
+++ b/spec/loader/ocn_resolution_loader_spec.rb
@@ -6,8 +6,8 @@ require "loader/ocn_resolution_loader"
 RSpec.describe Loader::OCNResolutionLoader do
   let(:line) do
     [
-      "123", # deprecated
-      "456" # resolved
+      "123", # variant
+      "456" # canonical
     ].join("\t")
   end
 
@@ -15,8 +15,8 @@ RSpec.describe Loader::OCNResolutionLoader do
     let(:resolution) { described_class.new.item_from_line(line) }
 
     it { expect(resolution).to be_a(Clusterable::OCNResolution) }
-    it { expect(resolution.deprecated).to eq 123 }
-    it { expect(resolution.resolved).to eq 456 }
+    it { expect(resolution.variant).to eq 123 }
+    it { expect(resolution.canonical).to eq 456 }
   end
 
   describe "#load" do
@@ -24,14 +24,14 @@ RSpec.describe Loader::OCNResolutionLoader do
 
     it "persists a batch of OCNResolutions" do
       resolution1 = build(:ocn_resolution)
-      resolution2 = build(:ocn_resolution, resolved: resolution1.resolved)
+      resolution2 = build(:ocn_resolution, canonical: resolution1.canonical)
 
       described_class.new.load([resolution1, resolution2])
 
       expect(Cluster.count).to eq(1)
       expect(Cluster.first.ocn_resolutions.count).to eq(2)
       expect(Cluster.first.ocns)
-        .to contain_exactly(resolution1.resolved, resolution1.deprecated, resolution2.deprecated)
+        .to contain_exactly(resolution1.canonical, resolution1.variant, resolution2.variant)
     end
   end
 end

--- a/sql/000_schema.sql
+++ b/sql/000_schema.sql
@@ -91,8 +91,8 @@ CREATE TABLE `holdings` (
 
 DROP TABLE IF EXISTS `oclc_concordance`;
 CREATE TABLE `oclc_concordance` (
-  `oclc` bigint unsigned NOT NULL,
+  `variant` bigint unsigned NOT NULL,
   `canonical` bigint unsigned DEFAULT NULL,
-  PRIMARY KEY (`oclc`,`canonical`),
+  PRIMARY KEY (`variant`,`canonical`),
   INDEX (`canonical`)
 ) ENGINE=InnoDB


### PR DESCRIPTION
- The names we dislike least: `variant` and `canonical`
   - `oclc_concordance.oclc` becomes `oclc_concordance.variant`
   - `oclc_concordance.canonical` stays the same
   - `OCNResolution` exposes `variant` in place of `deprecated` and `canonical` in place of `resolved`
- Everything else is a big old find and replace, so lots of very predictable name changes.
