### PR TITLE
DEV-1533 FrequencyTable: implement `+` method

### DIFF
--- a/lib/frequency_table.rb
+++ b/lib/frequency_table.rb
@@ -25,6 +25,49 @@ class FrequencyTable
     @table.clone.freeze
   end
 
+  # Lower-memory alternative to `to_h` for the purposes of `+` and `append!`
+  def each
+    @table.each do |key, value|
+      yield key, value
+    end
+  end
+
+  # Create a public #append(ft) method that we can call on a clone?
+  def +(other)
+    new_obj = self.class.new
+    new_obj.append! self
+    new_obj.append! other
+  end
+
+  # We try to optimize this beyond a deep addition from the leaves inward by
+  # checking for missing keys and when possible copying chunks of the operand's
+  # data structure.
+  def append!(other)
+    other.each do |org, data|
+      # Example data: org = :umich, data = {:spm=>{1=>1}}
+      #
+      # One could try to optimize this level by detecting missing `org` keys
+      # in the receiver and copying over an entire chunk of data structure from `other`
+      # but subsequent changes to `self` can propagate to `other`.
+      # `Marshal` can't handle the funky initializer on `@data`
+      # ("can't dump hash with default proc") so that deep copy hack doesn't seem
+      # available to us.
+      data.each do |fmt, frequencies|
+        # Example data: fmt = :spm, frequencies = {1 => 1}
+        #
+        # Safe to shallow clone `frequencies` since its keys and values are scalars.
+        if !@table[org].key? fmt
+          @table[org][fmt] = frequencies.clone
+          next
+        end
+        frequencies.each do |bucket, count|
+          @table[org][fmt][bucket] += count
+        end
+      end
+    end
+    self
+  end
+
   def add_ht_item(ht_item)
     item_format = CalculateFormat.new(ht_item.cluster).item_format(ht_item).to_sym
     item_overlap = Overlap::HtItemOverlap.new(ht_item)

--- a/spec/frequency_table_spec.rb
+++ b/spec/frequency_table_spec.rb
@@ -74,6 +74,68 @@ RSpec.describe FrequencyTable do
     end
   end
 
+  describe "#append!" do
+    let(:ft1) { described_class.new }
+    let(:ft2) { described_class.new }
+
+    it "returns the reciever" do
+      expect(ft1.append!(ft2).object_id).to eq(ft1.object_id)
+    end
+
+    it "adds organizations" do
+      ft1.add_ht_item ht1
+      ft2.add_ht_item ht2
+      expected_keys = (ft1.to_h.keys + ft2.to_h.keys).uniq.sort
+      expect(ft1.append!(ft2).to_h.keys.sort).to eq(expected_keys)
+    end
+
+    it "adds counts" do
+      ft1.add_ht_item ht1
+      ft2.add_ht_item ht1
+      ft2.add_ht_item ht2
+      expect(ft1.append!(ft2).to_h[:umich][:spm][1]).to eq(2)
+      expect(ft2[:umich][:spm][1]).to eq(1)
+    end
+
+    it "isolates the receiver from subsequent changes to added table" do
+      ft1.add_ht_item ht1
+      ft2.add_ht_item ht2
+      ft1.append! ft2
+      expect(ft2[:upenn][:spm][1]).to eq(1)
+      ft1.add_ht_item ht2
+      expect(ft2[:upenn][:spm][1]).to eq(1)
+    end
+  end
+
+  describe "#+" do
+    let(:ft1) { described_class.new }
+    let(:ft2) { described_class.new }
+
+    it "returns a new FrequencyTable" do
+      ft3 = ft1 + ft2
+      expect(ft3).to be_a(described_class)
+      expect(ft3.object_id).not_to eq(ft1.object_id)
+      expect(ft3.object_id).not_to eq(ft2.object_id)
+    end
+
+    it "returns a FrequencyTable with all organizations in the addends" do
+      ft1.add_ht_item ht1
+      ft2.add_ht_item ht2
+      expected_keys = (ft1.to_h.keys + ft2.to_h.keys).uniq.sort
+      ft3 = ft1 + ft2
+      expect(ft3.to_h.keys.sort).to eq(expected_keys)
+    end
+
+    it "returns a FrequencyTable with all counts in the addends" do
+      ft1.add_ht_item ht1
+      ft2.add_ht_item ht1
+      ft2.add_ht_item ht2
+      ft3 = ft1 + ft2
+      expect(ft3[:umich][:spm][1]).to eq(2)
+      expect(ft3[:upenn][:spm][1]).to eq(1)
+    end
+  end
+
   describe "#serialize" do
     it "returns the expected String" do
       ft.add_ht_item ht1


### PR DESCRIPTION
- We base `+` on a new public method `append!` which does the heavy lifting.
- We discussed a number of possible optimizations, including copying parts of the addend's data structure
  - Unfortunately this approach runs the risk of clone/dup copying by reference and resulting in two FTs sharing data.
  - Added an `each` method so large tables need not be cloned with `to_h`
- If it turns out we don't need to be so rigorous about protecting the internals of this class, we can just make an accessor to `@table`
  - Our implementation of `to_h` (`.clone.freeze`) is flawed in that the return is not a deep copy anyway.