### PR TITLE
DEV-1534 FrequencyTable: implement 'deserialize' method

### DIFF
--- a/lib/frequency_table.rb
+++ b/lib/frequency_table.rb
@@ -33,8 +33,9 @@ class FrequencyTable
     table.keys.sort
   end
 
-  def fetch(organization:, format: nil, bucket: nil)
-    # If bucket is passed and format is not, that's an error.
+  def fetch(organization: nil, format: nil, bucket: nil)
+    return table if organization.nil?
+
     data = table[organization.to_sym] || {}
     if format
       data = data[format.to_sym] || {}

--- a/lib/frequency_table.rb
+++ b/lib/frequency_table.rb
@@ -6,33 +6,45 @@ require "calculate_format"
 require "overlap/ht_item_overlap"
 
 class FrequencyTable
-  def initialize
-    @table = Hash.new do |hash, member|
-      hash[member] = Hash.new { |fmt_hash, fmt| fmt_hash[fmt] = Hash.new(0) }
-    end
+  protected attr_reader :table
+
+  # TODO: the tests would be more readable if we could pass either JSON or a Hash.
+  # Maybe try a `case` on the class of the parameter and parse JSON if it's a String
+  # and deep copy if it's a Hash.
+  def initialize(json: nil)
+    @table = json ? JSON.parse(json, symbolize_names: true) : {}
+  end
+
+  def to_json
+    JSON.generate(table)
+  end
+
+  def ==(other)
+    self.class == other.class && table == other.table
   end
 
   def organizations
-    @table.keys.sort
+    table.keys.sort
   end
 
-  def [](organization)
-    @table[organization.to_sym]
+  def fetch(organization:, format: nil, bucket: nil)
+    # If bucket is passed and format is not, that's an error.
+    data = table[organization.to_sym] || {}
+    if format
+      data = data[format.to_sym] || {}
+      if bucket
+        data = data[bucket.to_s.to_sym] || 0
+      end
+    end
+    data
   end
 
-  # For testing. I don't know if this is useful in the long run.
-  def to_h
-    @table.clone.freeze
-  end
-
-  # Lower-memory alternative to `to_h` for the purposes of `+` and `append!`
   def each
-    @table.each do |key, value|
+    table.each do |key, value|
       yield key, value
     end
   end
 
-  # Create a public #append(ft) method that we can call on a clone?
   def +(other)
     new_obj = self.class.new
     new_obj.append! self
@@ -42,26 +54,26 @@ class FrequencyTable
   # We try to optimize this beyond a deep addition from the leaves inward by
   # checking for missing keys and when possible copying chunks of the operand's
   # data structure.
+  # We use `Marshal` for deep copies and `clone` for shallow copies in order to keep
+  # prevent subsequent changes to the addend from affecting this object.
   def append!(other)
     other.each do |org, data|
       # Example data: org = :umich, data = {:spm=>{1=>1}}
-      #
-      # One could try to optimize this level by detecting missing `org` keys
-      # in the receiver and copying over an entire chunk of data structure from `other`
-      # but subsequent changes to `self` can propagate to `other`.
-      # `Marshal` can't handle the funky initializer on `@data`
-      # ("can't dump hash with default proc") so that deep copy hack doesn't seem
-      # available to us.
+      if !table.key? org
+        table[org] = Marshal.load(Marshal.dump(other.table[org]))
+        next
+      end
+      table[org] = {} unless table.key?(org)
       data.each do |fmt, frequencies|
         # Example data: fmt = :spm, frequencies = {1 => 1}
         #
         # Safe to shallow clone `frequencies` since its keys and values are scalars.
-        if !@table[org].key? fmt
-          @table[org][fmt] = frequencies.clone
+        if !table[org].key? fmt
+          table[org][fmt] = frequencies.clone
           next
         end
         frequencies.each do |bucket, count|
-          @table[org][fmt][bucket] += count
+          table[org][fmt][bucket] += count
         end
       end
     end
@@ -73,15 +85,17 @@ class FrequencyTable
     item_overlap = Overlap::HtItemOverlap.new(ht_item)
     member_count = item_overlap.matching_members.count
     item_overlap.matching_members.each do |org|
-      @table[org.to_sym][item_format][member_count] += 1
+      increment(organization: org, format: item_format, bucket: member_count)
     end
   end
 
-  def serialize
-    [].tap do |data|
-      @table.sort.each do |org, freq_data|
-        data << [org, JSON.generate(freq_data)].join("\t")
-      end
-    end.join "\n"
+  def increment(organization:, format:, bucket:)
+    org = organization.to_sym
+    fmt = format.to_sym
+    bucket = bucket.to_s.to_sym
+    table[org] = {} unless table.key?(org)
+    table[org][fmt] = {} unless table[org].key?(fmt)
+    table[org][fmt][bucket] = 0 unless table[org][fmt].key?(bucket)
+    table[org][fmt][bucket] += 1
   end
 end

--- a/lib/frequency_table.rb
+++ b/lib/frequency_table.rb
@@ -29,10 +29,6 @@ class FrequencyTable
     self.class == other.class && table == other.table
   end
 
-  def organizations
-    table.keys.sort
-  end
-
   def fetch(organization: nil, format: nil, bucket: nil)
     return table if organization.nil?
 

--- a/lib/reports/cost_report.rb
+++ b/lib/reports/cost_report.rb
@@ -99,7 +99,7 @@ module Reports
     def dump_frequency_table(dump_fn = "freq.txt")
       FileUtils.mkdir_p(Settings.cost_report_freq_path)
       File.open(File.join(Settings.cost_report_freq_path, dump_fn), "w") do |dump_file|
-        dump_file.puts(frequency_table.serialize)
+        dump_file.puts(frequency_table.to_json)
       end
     end
 
@@ -111,8 +111,8 @@ module Reports
       # HScore for a particular format
       define_method :"#{format}_total" do |member|
         total = 0.0
-        frequency_table[member.to_sym][format].each do |num_orgs, freq|
-          total += freq.to_f / num_orgs
+        frequency_table.fetch(organization: member, format: format).each do |num_orgs, freq|
+          total += freq.to_f / num_orgs.to_s.to_i
         end
         total
       end

--- a/spec/frequency_table_spec.rb
+++ b/spec/frequency_table_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe FrequencyTable do
   let(:ft) { described_class.new }
   let(:umich_data) { {umich: {spm: {"1": 1}}} }
   let(:upenn_data) { {upenn: {spm: {"1": 1}}} }
-  let(:ft_data) { umich_data.merge upenn_data }
-  let(:ft_with_data) { described_class.new(data: ft_data) }
+  let(:ft_with_data) { described_class.new(data: umich_data.merge(upenn_data)) }
 
   describe ".new" do
     it "creates a `FrequencyTable`" do
@@ -33,23 +32,13 @@ RSpec.describe FrequencyTable do
 
     it "round-trips JSON" do
       round_tripped = described_class.new(data: ft_with_data.to_json)
-      expect(round_tripped.organizations.sort).to eq [:umich, :upenn].sort
+      expect(round_tripped.fetch.keys.sort).to eq [:umich, :upenn].sort
       expect(round_tripped.fetch(organization: :umich)).to eq(ft_with_data.fetch(organization: :umich))
       expect(round_tripped.fetch(organization: :upenn)).to eq(ft_with_data.fetch(organization: :upenn))
     end
 
     it "raises on unhandled types" do
       expect { described_class.new(data: 3.14159) }.to raise_error(RuntimeError)
-    end
-  end
-
-  describe "#organizations" do
-    it "returns empty Array when initialized" do
-      expect(ft.organizations).to eq([])
-    end
-
-    it "returns each org in the cluster" do
-      expect(ft_with_data.organizations).to eq([:umich, :upenn])
     end
   end
 
@@ -62,8 +51,8 @@ RSpec.describe FrequencyTable do
     end
 
     it "adds organizations" do
-      expected_keys = (ft1.organizations + ft2.organizations).uniq.sort
-      expect(ft1.append!(ft2).organizations).to eq(expected_keys)
+      expected_keys = (ft1.fetch.keys + ft2.fetch.keys).uniq.sort
+      expect(ft1.append!(ft2).fetch.keys).to eq(expected_keys)
     end
 
     it "adds counts" do
@@ -83,7 +72,7 @@ RSpec.describe FrequencyTable do
       ft2.increment(organization: :upenn, format: :ser, bucket: 1)
       ft2.increment(organization: :upenn, format: :spm, bucket: 10)
       ft2.increment(organization: :umich, format: :spm, bucket: 1)
-      expect(ft1.organizations).not_to include(:smu)
+      expect(ft1.fetch.keys).not_to include(:smu)
       expect(ft1.fetch(organization: :upenn, format: :ser)).to eq({})
       expect(ft1.fetch(organization: :upenn, format: :spm, bucket: 10)).to eq(0)
       expect(ft1.fetch(organization: :upenn, format: :spm, bucket: 1)).to eq(1)
@@ -102,9 +91,9 @@ RSpec.describe FrequencyTable do
     end
 
     it "returns a FrequencyTable with all organizations in the addends" do
-      expected_keys = (ft1.organizations + ft2.organizations).uniq.sort
+      expected_keys = (ft1.fetch.keys + ft2.fetch.keys).uniq.sort
       ft3 = ft1 + ft2
-      expect(ft3.organizations).to eq(expected_keys)
+      expect(ft3.fetch.keys.sort).to eq(expected_keys)
     end
 
     it "returns a FrequencyTable with all counts in the addends" do

--- a/spec/frequency_table_spec.rb
+++ b/spec/frequency_table_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe FrequencyTable do
       expect(round_tripped.fetch(organization: :umich)).to eq(ft_with_data.fetch(organization: :umich))
       expect(round_tripped.fetch(organization: :upenn)).to eq(ft_with_data.fetch(organization: :upenn))
     end
+
+    it "raises on unhandled types" do
+      expect { described_class.new(data: 3.14159) }.to raise_error(RuntimeError)
+    end
   end
 
   describe "#organizations" do

--- a/spec/reports/cost_report_spec.rb
+++ b/spec/reports/cost_report_spec.rb
@@ -262,8 +262,7 @@ RSpec.describe Reports::CostReport do
 
       it "handles multiple HT copies of the same spm" do
         load_test_data(spm, ht_copy)
-        expect(cr.frequency_table.organizations.count).to eq 1
-        expect(cr.frequency_table.fetch(organization: spm.billing_entity)).to eq({spm: {"1": 2}})
+        expect(cr.frequency_table.fetch).to eq({spm.billing_entity.to_sym => {spm: {"1": 2}}})
       end
 
       it "handles multiple copies of the same spm and holdings" do
@@ -285,7 +284,7 @@ RSpec.describe Reports::CostReport do
         load_test_data(spm, ht_copy)
         expected_freq = {upenn: {spm: {"1": 1}},
                          umich: {spm: {"1": 1}}}
-        expect(cr.frequency_table.organizations.count).to eq 2
+        expect(cr.frequency_table.fetch.keys.count).to eq 2
         expect(cr.frequency_table.fetch).to eq(expected_freq)
       end
     end

--- a/spec/reports/cost_report_spec.rb
+++ b/spec/reports/cost_report_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Reports::CostReport do
       JSON
     }
     let(:pft) { FrequencyTable.new(data: json) }
-    let(:cr) { described_class.new(cost: 10, precomputed_frequency_table: pft) }
+    let(:cr) { described_class.new(target_cost: 10, precomputed_frequency_table: pft) }
     before(:each) do
       # add 3 items & 2 holdings
       load_test_data(spm, mpm, ht_allow, holding, holding2)

--- a/spec/reports/cost_report_spec.rb
+++ b/spec/reports/cost_report_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Reports::CostReport do
       ft = FrequencyTable.new
       cr = described_class.new(precomputed_frequency_table: ft)
       # expect hash in == hash out
-      expect(cr.frequency_table.to_h).to eq ft.to_h
+      expect(cr.frequency_table).to eq ft
     end
 
     it "a populated frequency table can be passed to CostReport" do
@@ -105,7 +105,7 @@ RSpec.describe Reports::CostReport do
       ft.add_ht_item(spm)
       cr = described_class.new(precomputed_frequency_table: ft)
       # expect hash in == hash out
-      expect(cr.frequency_table.to_h).to eq ft.to_h
+      expect(cr.frequency_table).to eq ft
     end
 
     it "ignores PD items" do
@@ -118,7 +118,7 @@ RSpec.describe Reports::CostReport do
         collection_code: "PU"
       )
       load_test_data(pd_item)
-      expect(cr.frequency_table[:upenn][:mpm]).to eq({})
+      expect(cr.frequency_table.fetch(organization: :upenn, format: :mpm)).to eq({})
     end
 
     it "counts OCN-less items" do
@@ -131,7 +131,7 @@ RSpec.describe Reports::CostReport do
         collection_code: "PU"
       )
       load_test_data ocnless_item
-      expect(cr.frequency_table[:upenn][:spm]).to eq({1 => 1})
+      expect(cr.frequency_table.fetch(organization: :upenn, format: :spm)).to eq({"1": 1})
     end
   end
 
@@ -156,22 +156,31 @@ RSpec.describe Reports::CostReport do
 
     it "includes only member holdings" do
       load_test_data(spm, holding, holding2, non_member_holding)
-      expect(cr.frequency_table[:umich][:spm]).to eq({2 => 1})
-      expect(cr.frequency_table[:upenn][:spm]).to eq({2 => 1})
-      expect(cr.frequency_table[:non_member]).to eq({})
+      expect(cr.frequency_table.fetch(organization: :umich, format: :spm)).to eq({"2": 1})
+      expect(cr.frequency_table.fetch(organization: :upenn, format: :spm)).to eq({"2": 1})
+      expect(cr.frequency_table.fetch(organization: :non_member)).to eq({})
     end
   end
 
   describe "HScores and Costs" do
+    let(:json) {
+      <<~JSON
+        {
+          "umich":{
+            "mpm":{"3":1},
+            "spm":{"1":5,"2":3}
+          },
+          "smu":{
+            "ser":{"1":2,"2":1}
+          }
+        }
+      JSON
+    }
+    let(:pft) { FrequencyTable.new(json: json) }
+    let(:cr) { described_class.new(cost: 10, precomputed_frequency_table: pft) }
     before(:each) do
       # add 3 items & 2 holdings
       load_test_data(spm, mpm, ht_allow, holding, holding2)
-
-      cr.frequency_table[:umich][:spm][1] = 5
-      cr.frequency_table[:umich][:spm][2] = 3
-      cr.frequency_table[:umich][:mpm][3] = 1
-      cr.frequency_table[:smu][:ser][1] = 2
-      cr.frequency_table[:smu][:ser][2] = 1
       cr.instance_variable_set(:@num_volumes, 12)
     end
 
@@ -219,7 +228,7 @@ RSpec.describe Reports::CostReport do
       it "computes the extra costs allotted to members" do
         # we have no IC items that don't have a billing entity
         expect(cr.extra_per_member).to be_within(0.0001).of(0)
-        cr.frequency_table[:hathitrust][:spm][1] = 1
+        cr.frequency_table.increment(organization: :hathitrust, format: :spm, bucket: :"1")
         expect(cr.extra_per_member).to be_within(0.0001).of(cr.cost_per_volume / 6)
       end
     end
@@ -253,12 +262,14 @@ RSpec.describe Reports::CostReport do
 
       it "handles multiple HT copies of the same spm" do
         load_test_data(spm, ht_copy)
-        expect(cr.frequency_table.to_h).to eq(spm.billing_entity.to_sym => {spm: {1 => 2}})
+        expect(cr.frequency_table.organizations.count).to eq 1
+        expect(cr.frequency_table.fetch(organization: spm.billing_entity)).to eq({spm: {"1": 2}})
       end
 
       it "handles multiple copies of the same spm and holdings" do
         load_test_data(spm, ht_copy, spm_holding)
-        expect(cr.frequency_table.to_h).to eq(spm.billing_entity.to_sym => {spm: {1 => 2}})
+        expect(cr.frequency_table.organizations.count).to eq 1
+        expect(cr.frequency_table.fetch(organization: spm.billing_entity)).to eq({spm: {"1": 2}})
       end
 
       it "multiple holdings lead to one hshare" do
@@ -266,16 +277,17 @@ RSpec.describe Reports::CostReport do
         mpm_holding.n_enum = "1"
         mpm_holding.mono_multi_serial = "mpm"
         load_test_data(spm, spm_holding, mpm_holding)
-        expect(cr.frequency_table.to_h).to eq(spm.billing_entity.to_sym => {spm: {1 => 1}})
+        expect(cr.frequency_table.organizations.count).to eq 1
+        expect(cr.frequency_table.fetch(organization: spm.billing_entity)).to eq({spm: {"1": 1}})
       end
 
       it "HtItem billing entity derived matches are independent of all others in the cluster" do
         # two ht items, one upenn, one michigan
         ht_copy.collection_code = "MIU"
         load_test_data(spm, ht_copy)
-        expected_freq = {upenn: {spm: {1 => 1}},
-                         umich: {spm: {1 => 1}}}
-        expect(cr.frequency_table.to_h).to eq(expected_freq)
+        expect(cr.frequency_table.organizations.count).to eq 2
+        expect(cr.frequency_table.fetch(organization: :upenn)).to eq({spm: {"1": 1}})
+        expect(cr.frequency_table.fetch(organization: :umich)).to eq({spm: {"1": 1}})
       end
     end
 
@@ -284,7 +296,7 @@ RSpec.describe Reports::CostReport do
 
       it "assigns mpm shares to empty enum chron holdings" do
         load_test_data(mpm, mpm_wo_ec)
-        expect(cr.frequency_table[mpm_wo_ec.organization]).to eq(mpm: {2 => 1})
+        expect(cr.frequency_table.fetch(organization: mpm_wo_ec.organization)).to eq(mpm: {"2": 1})
       end
     end
 
@@ -299,7 +311,7 @@ RSpec.describe Reports::CostReport do
 
       it "gives mpm shares when enum_chron does not match anything" do
         load_test_data(mpm, mpm_wrong_ec)
-        expect(cr.frequency_table[mpm_wrong_ec.organization]).to eq(mpm: {2 => 1})
+        expect(cr.frequency_table.fetch(organization: mpm_wrong_ec.organization)).to eq(mpm: {"2": 1})
       end
     end
 
@@ -340,7 +352,7 @@ RSpec.describe Reports::CostReport do
         load_test_data(ht_serial, ht_serial2, holding_serial)
         # ht_serial.billing_entity + holding_serial.org and
         # ht_serial2.billing_entity + holding_serial.org
-        expect(cr.frequency_table[holding_serial.organization]).to eq(ser: {2 => 2})
+        expect(cr.frequency_table.fetch(organization: holding_serial.organization)).to eq(ser: {"2": 2})
       end
     end
   end
@@ -427,7 +439,7 @@ RSpec.describe Reports::CostReport do
       # umich has 1 instance of a spm held by 1 org (umich)
       # umich has 1 instance of a ser held by 2 org (umich and utexas)
       # umich has 2 instance of a mpm held by 3 org ([smu, umich, utexas] and [smu, umich, upenn])
-      expect(cr.frequency_table[:umich]).to eq(spm: {1 => 1}, ser: {2 => 1}, mpm: {3 => 2})
+      expect(cr.frequency_table.fetch(organization: :umich)).to eq(spm: {"1": 1}, ser: {"2": 1}, mpm: {"3": 2})
       # 1/2 of the ht_serial
       # 1 of the ht_spm
       # 1/3 of ht_mpm1 (with SMU and upenn)
@@ -435,7 +447,7 @@ RSpec.describe Reports::CostReport do
       expect(cr.total_hscore(:umich)).to be_within(0.0001).of(1 / 2.0 + 1.0 + 1 / 3.0 + 1 / 3.0)
       # 1 instance of a ser held by 2 orgs (umich and utexas)
       # 1 instance of a mpm held by 3 orgs (smu, umich, utexas)
-      expect(cr.frequency_table[:utexas]).to eq(ser: {2 => 1}, mpm: {3 => 1})
+      expect(cr.frequency_table.fetch(organization: :utexas)).to eq(ser: {"2": 1}, mpm: {"3": 1})
     end
 
     it "produces .tsv output" do

--- a/spec/reports/cost_report_spec.rb
+++ b/spec/reports/cost_report_spec.rb
@@ -268,8 +268,7 @@ RSpec.describe Reports::CostReport do
 
       it "handles multiple copies of the same spm and holdings" do
         load_test_data(spm, ht_copy, spm_holding)
-        expect(cr.frequency_table.organizations.count).to eq 1
-        expect(cr.frequency_table.fetch(organization: spm.billing_entity)).to eq({spm: {"1": 2}})
+        expect(cr.frequency_table.fetch).to eq({spm.billing_entity.to_sym => {spm: {"1": 2}}})
       end
 
       it "multiple holdings lead to one hshare" do
@@ -277,17 +276,17 @@ RSpec.describe Reports::CostReport do
         mpm_holding.n_enum = "1"
         mpm_holding.mono_multi_serial = "mpm"
         load_test_data(spm, spm_holding, mpm_holding)
-        expect(cr.frequency_table.organizations.count).to eq 1
-        expect(cr.frequency_table.fetch(organization: spm.billing_entity)).to eq({spm: {"1": 1}})
+        expect(cr.frequency_table.fetch).to eq({spm.billing_entity.to_sym => {spm: {"1": 1}}})
       end
 
       it "HtItem billing entity derived matches are independent of all others in the cluster" do
         # two ht items, one upenn, one michigan
         ht_copy.collection_code = "MIU"
         load_test_data(spm, ht_copy)
+        expected_freq = {upenn: {spm: {"1": 1}},
+                         umich: {spm: {"1": 1}}}
         expect(cr.frequency_table.organizations.count).to eq 2
-        expect(cr.frequency_table.fetch(organization: :upenn)).to eq({spm: {"1": 1}})
-        expect(cr.frequency_table.fetch(organization: :umich)).to eq({spm: {"1": 1}})
+        expect(cr.frequency_table.fetch).to eq(expected_freq)
       end
     end
 

--- a/spec/reports/cost_report_spec.rb
+++ b/spec/reports/cost_report_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Reports::CostReport do
         }
       JSON
     }
-    let(:pft) { FrequencyTable.new(json: json) }
+    let(:pft) { FrequencyTable.new(data: json) }
     let(:cr) { described_class.new(cost: 10, precomputed_frequency_table: pft) }
     before(:each) do
       # add 3 items & 2 holdings


### PR DESCRIPTION
- Opted to use JSON as the serialization format rather than the pre-existing custom jobby.
  - As a result, all keys are symbolized including the bucket name
    - E.g., `{1 => 1}` at a leaf node becomes `{:"1" => 1}`
    - One-line change in `lib/frequency_table.rb` with the needed conversion to symbol.
- Further work to try to hide the details of the underlying Hash implementation.
  - Remove `to_h` method and replace with `fetch` taking keywords.
  - Remove default_proc in the underlying hash. Maintaining it while implementing `+` and deserialization became painful and confusing.
- Related to the above, further work to make sure `FrequencyTable` is operating on a copy of data from outside and not subject to inadvertent data sharing.
  - That said, the data returned by `#fetch` is not a copy. Futz with it at your peril.
- To make the tests more comprehensible, can pass a Hash to the `FrequencyTable` initializer rather than populating with `add_ht_item`
  - There's a `CostReport` spec that used to futz with the internal `FrequencyTable` data, updated to now use JSON, could be further updated to take a Hash.

Outstanding questions:
- Is the use of Symbols for the buckets, instead of integers, going to be a problem?
- Is the use of pure JSON for the serialization format going to be a problem? (i.e., do we have existing files we must maintain compatibility with?)