### PR TITLE
DEV-1526: fixes to get the old style HT003.*.tsv holdings files to load

### DIFF
--- a/lib/clusterable/holding.rb
+++ b/lib/clusterable/holding.rb
@@ -107,7 +107,7 @@ module Clusterable
     def self.batch_add(batch)
       columns = table.columns
       rows = batch.map { |h| columns.map { |c| h.public_send(c) } }
-      table.import(columns, rows)
+      table.insert_ignore.import(columns, rows)
     end
 
     def date_received=(date)

--- a/lib/clusterable/holding.rb
+++ b/lib/clusterable/holding.rb
@@ -50,6 +50,8 @@ module Clusterable
         fields[7] = "mpm"
       when "serial"
         fields[7] = "ser"
+      when ""
+        fields[7] = "mix"
       end
 
       # The old tsv files likely don't have a uuid

--- a/lib/clusterable/holding.rb
+++ b/lib/clusterable/holding.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-require "services"
 require "clusterable/base"
-require "json"
 require "enum_chron"
+require "json"
+require "securerandom"
+require "services"
 
 module Clusterable
   # A holding
@@ -36,19 +37,41 @@ module Clusterable
       # OCN  BIB  MEMBER_ID  STATUS  CONDITION  DATE  ENUM_CHRON  TYPE  \
       # ISSN  N_ENUM  N_CHRON  GOV_DOC UUID
       fields = holding_line.split("\t")
-      {ocn: fields[0].to_i,
-       local_id: fields[1],
-       organization: fields[2],
-       status: fields[3],
-       condition: fields[4],
-       date_received: DateTime.parse(fields[5]),
-       enum_chron: fields[6],
-       mono_multi_serial: fields[7],
-       issn: fields[8],
-       n_enum: fields[9],
-       n_chron: fields[10],
-       gov_doc_flag: !fields[11].to_i.zero?,
-       uuid: fields[12]}
+
+      if fields[3].empty?
+        fields[3] = "CH"
+      end
+
+      # The old tsv files likely have the old holdings.type (mono|multi|serial)
+      case fields[7]
+      when "mono"
+        fields[7] = "spm"
+      when "multi"
+        fields[7] = "mpm"
+      when "serial"
+        fields[7] = "ser"
+      end
+
+      # The old tsv files likely don't have a uuid
+      if fields[12].nil?
+        fields[12] = SecureRandom.uuid
+      end
+
+      {
+        ocn: fields[0].to_i,
+        local_id: fields[1],
+        organization: fields[2],
+        status: fields[3],
+        condition: fields[4],
+        date_received: DateTime.parse(fields[5]),
+        enum_chron: fields[6],
+        mono_multi_serial: fields[7],
+        issn: fields[8],
+        n_enum: fields[9],
+        n_chron: fields[10],
+        gov_doc_flag: !fields[11].to_i.zero?,
+        uuid: fields[12]
+      }
     end
 
     def self.new_from_holding_file_line(line)

--- a/lib/sidekiq_jobs.rb
+++ b/lib/sidekiq_jobs.rb
@@ -82,6 +82,7 @@ module Jobs
         Services.logger.info "Adding Print Holdings from #{filename}."
         Loader::FileLoader.new(batch_loader: Loader::HoldingLoader.for(filename))
           .load(filename, skip_header_match: /\A\s*OCN/)
+        Services.logger.info "Finished Adding Print Holdings from #{filename}."
       end
     end
   end

--- a/spec/clusterable/holding_spec.rb
+++ b/spec/clusterable/holding_spec.rb
@@ -115,6 +115,30 @@ RSpec.describe Clusterable::Holding do
     end
   end
 
+  describe "#{described_class}.holding_to_record" do
+    # Prepares strings from the old style holdings file format
+    # (HT003_#{organization}.#{mono_multi_serial}.tsv) for loading.
+    # ht003_ser_str has no status, no uuid and its mono_multi_serial is outdated
+    let(:ht003_mon_str) {"1\t99106\tallegheny\tCH\t\t2020-09-29\t\tmono\t\t\t\t0"}
+    let(:ht003_mul_str) {"2\t99106\tallegheny\tCH\t\t2020-09-29\tv.1\tmulti\t\t1\t\t0"}
+    let(:ht003_ser_str) {"3\t99106\tallegheny\t\t\t2020-09-29\t\tserial\t\t\t\t0"}
+    let(:fixed_mon_cols) { described_class.holding_to_record(ht003_mon_str) }
+    let(:fixed_mul_cols) { described_class.holding_to_record(ht003_mul_str) }
+    let(:fixed_ser_cols) { described_class.holding_to_record(ht003_ser_str) }
+
+    it "adds status if missing" do
+      expect(fixed_ser_cols[:status]).to eq "CH"
+    end
+    it "adds uuid if missing" do
+      expect(fixed_ser_cols[:uuid]).to match(/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/)
+    end
+    it "fixes mono_multi_serial if outdated" do
+      expect(fixed_mon_cols[:mono_multi_serial]).to eq "spm"
+      expect(fixed_mul_cols[:mono_multi_serial]).to eq "mpm"
+      expect(fixed_ser_cols[:mono_multi_serial]).to eq "ser"
+    end
+  end
+
   describe "#new_from_holding_file_line" do
     it "turns a holdings file line into a new Holding" do
       line = "100000252\t005556200\tumich\tCH\t\t2019-10-24\t\tspm\t\t\t\t0"

--- a/spec/clusterable/holding_spec.rb
+++ b/spec/clusterable/holding_spec.rb
@@ -23,6 +23,22 @@ RSpec.describe Clusterable::Holding do
     expect(holding.n_enum_chron).to eq("")
   end
 
+  describe "#batch_add" do
+    include_context "with tables for holdings"
+
+    it "inserts multiple holdings" do
+      described_class.batch_add([build(:holding), build(:holding)])
+      expect(Services.holdings_table.count).to eq(2)
+    end
+
+    it "ignores duplicate holdings" do
+      described_class.batch_add([h])
+      expect(Services.holdings_table.count).to eq(1)
+      described_class.batch_add([h, build(:holding)])
+      expect(Services.holdings_table.count).to eq(2)
+    end
+  end
+
   describe "#cluster" do
     include_context "with tables for holdings"
 

--- a/spec/clusterable/holding_spec.rb
+++ b/spec/clusterable/holding_spec.rb
@@ -119,9 +119,9 @@ RSpec.describe Clusterable::Holding do
     # Prepares strings from the old style holdings file format
     # (HT003_#{organization}.#{mono_multi_serial}.tsv) for loading.
     # ht003_ser_str has no status, no uuid and its mono_multi_serial is outdated
-    let(:ht003_mon_str) {"1\t99106\tallegheny\tCH\t\t2020-09-29\t\tmono\t\t\t\t0"}
-    let(:ht003_mul_str) {"2\t99106\tallegheny\tCH\t\t2020-09-29\tv.1\tmulti\t\t1\t\t0"}
-    let(:ht003_ser_str) {"3\t99106\tallegheny\t\t\t2020-09-29\t\tserial\t\t\t\t0"}
+    let(:ht003_mon_str) { "1\t99106\tallegheny\tCH\t\t2020-09-29\t\tmono\t\t\t\t0" }
+    let(:ht003_mul_str) { "2\t99106\tallegheny\tCH\t\t2020-09-29\tv.1\tmulti\t\t1\t\t0" }
+    let(:ht003_ser_str) { "3\t99106\tallegheny\t\t\t2020-09-29\t\tserial\t\t\t\t0" }
     let(:fixed_mon_cols) { described_class.holding_to_record(ht003_mon_str) }
     let(:fixed_mul_cols) { described_class.holding_to_record(ht003_mul_str) }
     let(:fixed_ser_cols) { described_class.holding_to_record(ht003_ser_str) }

--- a/spec/reports/cost_report_spec.rb
+++ b/spec/reports/cost_report_spec.rb
@@ -272,6 +272,7 @@ RSpec.describe Reports::CostReport do
 
       it "multiple holdings lead to one hshare" do
         mpm_holding = spm_holding.clone
+        mpm_holding.uuid = SecureRandom.uuid
         mpm_holding.n_enum = "1"
         mpm_holding.mono_multi_serial = "mpm"
         load_test_data(spm, spm_holding, mpm_holding)

--- a/sql/000_schema.sql
+++ b/sql/000_schema.sql
@@ -83,7 +83,7 @@ CREATE TABLE `holdings` (
   `gov_doc_flag` tinyint(1),
   `mono_multi_serial` enum('mix', 'mon', 'spm', 'mpm', 'ser') NOT NULL,
   `date_received` date NOT NULL,
-  `uuid`         char(36) NOT NULL,
+  `uuid`         char(36) NOT NULL, -- TODO: make unique and deal with the consequences of that
   `issn`         varchar(255) NULL,
   KEY (`ocn`),
   KEY (`organization`)

--- a/sql/000_schema.sql
+++ b/sql/000_schema.sql
@@ -83,7 +83,7 @@ CREATE TABLE `holdings` (
   `gov_doc_flag` tinyint(1),
   `mono_multi_serial` enum('mix', 'mon', 'spm', 'mpm', 'ser') NOT NULL,
   `date_received` date NOT NULL,
-  `uuid`         char(36) NOT NULL, -- TODO: make unique and deal with the consequences of that
+  `uuid`         char(36) PRIMARY KEY NOT NULL,
   `issn`         varchar(255) NULL,
   KEY (`ocn`),
   KEY (`organization`)


### PR DESCRIPTION
In order to "load all the data" we need to be able to load the legacy .tsv format.

There were a few small changes needed to the tsv-loader, presumably because the holdings table definitions have changed some since last we tried loading data this old.

Lines were rejected if they: lacked status, or lacked uuid, or had an outdated mono_multi_serial value. Luckily the correct or dummy value is easy to figure out. 

(I noticed that there are currently no uniqueness constraints on the `holdings` table. I think we need to figure that out, so that one cannot accidentally load the same holdings file over and over again and grow the holdings table each time. However, I don't think it is necessary to figure that out right now.)