### PR TITLE
DEV-1562 continued extraction of classes in frequencytable

### DIFF
--- a/lib/frequency_table.rb
+++ b/lib/frequency_table.rb
@@ -29,27 +29,16 @@ class FrequencyTable
     self.class == other.class && table == other.table
   end
 
-  def fetch(organization: nil, format: nil, bucket: nil)
-    return table if organization.nil?
-
-    data = table[organization.to_sym] || {}
-    if format
-      data = data[format.to_sym] || {}
-      if bucket
-        data = data[bucket.to_s.to_sym] || 0
-      end
-    end
-    data
+  def keys
+    table.keys.sort
   end
 
   def frequencies(organization:, format:)
-    
     return [] unless table.key? organization.to_sym
 
     [].tap do |freqs|
-      table[organization.to_sym][format.to_sym]&.each do |bucket, count|
-        #TODO: maybe put the bucket/count into a "readout" object?
-        freqs << [bucket.to_s.to_i, count]
+      table[organization.to_sym][format.to_sym]&.each do |bucket, frequency|
+        freqs << Frequency.new(bucket: bucket, frequency: frequency)
       end
     end
   end
@@ -121,35 +110,28 @@ class FrequencyTable
   end
 end
 
-class OrganizationData
-  attr_accessor :organization
-
-  def initialize(organization:, bucket: nil, frequency: 0)
-    @organization = organization
-    @data = {}
-    if bucket
-      @data[bucket] = frequency
-    end
-  end
-
-  def fetch(format: nil, bucket: nil)
-    if format
-      data = data[format.to_sym] || {}
-      if bucket
-        data = data[bucket.to_s.to_sym] || 0
-      end
-    end
-    data
-  end
-end
-
-class FrequencyData
+# Encapsulate a member count or bucket and its corresponding frequency.
+# Both are integers.
+# This is a "readout" class not used in the FrequencyTable internals.
+class Frequency
   attr_accessor :bucket, :frequency
+
   def initialize(bucket:, frequency:)
-    @bucket = bucket
+    @bucket = bucket.to_s.to_i
     @frequency = frequency
   end
 
-  def 
-end
+  def ==(other)
+    self.class == other.class && bucket == other.bucket && frequency == other.frequency
+  end
 
+  def to_a
+    [bucket, frequency]
+  end
+
+  def to_h
+    {bucket: bucket, frequency: frequency}
+  end
+
+  alias_method :member_count, :bucket
+end

--- a/lib/frequency_table.rb
+++ b/lib/frequency_table.rb
@@ -110,14 +110,27 @@ class FrequencyTable
   end
 end
 
-# Encapsulate a member count or bucket and its corresponding frequency.
+# Encapsulate a member count a.k.a. bucket and its corresponding frequency.
 # Both are integers.
-# This is a "readout" class not used in the FrequencyTable internals.
+# This is an immutable "readout" class not used in the FrequencyTable internals
+# (mainly so FrequencyTable JSON can use all native types).
 class Frequency
   attr_accessor :bucket, :frequency
 
+  # Bucket may be from serialized data with symbolized hash keys, so we take care
+  # to turn it into an Integer.
+  # (This initializer lets you get away with passing `bucket` as a lot of different
+  # classes that cast to Integer via String; it's really only intended to be used with
+  # Integer/Symbol/String, however.)
   def initialize(bucket:, frequency:)
-    @bucket = bucket.to_s.to_i
+    @bucket = if bucket.is_a?(Integer)
+      bucket
+    else
+      bucket.to_s.to_i
+    end
+    if !frequency.is_a?(Integer)
+      raise "frequency initialized with unknown class #{frequency.class}"
+    end
     @frequency = frequency
   end
 

--- a/lib/frequency_table.rb
+++ b/lib/frequency_table.rb
@@ -42,6 +42,18 @@ class FrequencyTable
     data
   end
 
+  def frequencies(organization:, format:)
+    
+    return [] unless table.key? organization.to_sym
+
+    [].tap do |freqs|
+      table[organization.to_sym][format.to_sym]&.each do |bucket, count|
+        #TODO: maybe put the bucket/count into a "readout" object?
+        freqs << [bucket.to_s.to_i, count]
+      end
+    end
+  end
+
   def each
     table.each do |key, value|
       yield key, value
@@ -108,3 +120,36 @@ class FrequencyTable
     Marshal.load(Marshal.dump(obj))
   end
 end
+
+class OrganizationData
+  attr_accessor :organization
+
+  def initialize(organization:, bucket: nil, frequency: 0)
+    @organization = organization
+    @data = {}
+    if bucket
+      @data[bucket] = frequency
+    end
+  end
+
+  def fetch(format: nil, bucket: nil)
+    if format
+      data = data[format.to_sym] || {}
+      if bucket
+        data = data[bucket.to_s.to_sym] || 0
+      end
+    end
+    data
+  end
+end
+
+class FrequencyData
+  attr_accessor :bucket, :frequency
+  def initialize(bucket:, frequency:)
+    @bucket = bucket
+    @frequency = frequency
+  end
+
+  def 
+end
+

--- a/lib/reports/cost_report.rb
+++ b/lib/reports/cost_report.rb
@@ -111,8 +111,8 @@ module Reports
       # HScore for a particular format
       define_method :"#{format}_total" do |member|
         total = 0.0
-        frequency_table.frequencies(organization: member, format: format).each do |num_orgs, freq|
-          total += freq.to_f / num_orgs
+        frequency_table.frequencies(organization: member, format: format).each do |freq|
+          total += freq.frequency.to_f / freq.member_count
         end
         total
       end

--- a/lib/reports/cost_report.rb
+++ b/lib/reports/cost_report.rb
@@ -111,8 +111,8 @@ module Reports
       # HScore for a particular format
       define_method :"#{format}_total" do |member|
         total = 0.0
-        frequency_table.fetch(organization: member, format: format).each do |num_orgs, freq|
-          total += freq.to_f / num_orgs.to_s.to_i
+        frequency_table.frequencies(organization: member, format: format).each do |num_orgs, freq|
+          total += freq.to_f / num_orgs
         end
         total
       end

--- a/spec/frequency_table_spec.rb
+++ b/spec/frequency_table_spec.rb
@@ -42,6 +42,26 @@ RSpec.describe FrequencyTable do
     end
   end
 
+  describe "#frequencies" do
+    let(:ft1) { described_class.new(data: umich_data) }
+
+    it "returns an Enumerable" do
+      expect(ft1.frequencies(organization: :umich, format: :spm)).to be_a(Enumerable)
+    end
+
+    it "returns the expected frequency data" do
+      expect(ft1.frequencies(organization: :umich, format: :spm)).to eq([[1, 1]])
+    end
+
+    it "returns empty Array for unattested organization" do
+      expect(ft1.frequencies(organization: :nobody_here_by_that_name, format: :spm)).to eq([])
+    end
+  
+    it "returns empty Array for unattested format" do
+      expect(ft1.frequencies(organization: :umich, format: :mpm)).to eq([])
+    end
+  end
+
   describe "#append!" do
     let(:ft1) { described_class.new(data: umich_data) }
     let(:ft2) { described_class.new(data: upenn_data) }
@@ -125,6 +145,21 @@ RSpec.describe FrequencyTable do
     it "produces JSON String that parses to a Hash" do
       expect(ft_with_data.to_json).to be_a(String)
       expect(JSON.parse(ft_with_data.to_json)).to be_a(Hash)
+    end
+  end
+end
+
+
+RSpec.describe OrganizationData do
+  describe ".new" do
+    it "creates a `#{described_class}`" do
+      expect(described_class.new(organization: :umich)).to be_a(described_class)
+    end
+  end
+
+  describe "#organization" do
+    it "returns the organization" do
+      expect(described_class.new(organization: :umich).organization).to eq(:umich)
     end
   end
 end

--- a/spec/frequency_table_spec.rb
+++ b/spec/frequency_table_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe FrequencyTable do
     it "operates on a copy of the initializer data" do
       ft = described_class.new(data: umich_data)
       umich_data[:umich][:spm][:"1"] = 10
-      expect(ft.fetch(organization: :umich, format: :spm, bucket: 1)).to eq(1)
+      expect(ft.frequencies(organization: :umich, format: :spm).map(&:to_a)).to eq([[1, 1]])
     end
 
     it "accepts JSON" do
@@ -32,9 +32,7 @@ RSpec.describe FrequencyTable do
 
     it "round-trips JSON" do
       round_tripped = described_class.new(data: ft_with_data.to_json)
-      expect(round_tripped.fetch.keys.sort).to eq [:umich, :upenn].sort
-      expect(round_tripped.fetch(organization: :umich)).to eq(ft_with_data.fetch(organization: :umich))
-      expect(round_tripped.fetch(organization: :upenn)).to eq(ft_with_data.fetch(organization: :upenn))
+      expect(round_tripped).to eq(ft_with_data)
     end
 
     it "raises on unhandled types" do
@@ -44,19 +42,21 @@ RSpec.describe FrequencyTable do
 
   describe "#frequencies" do
     let(:ft1) { described_class.new(data: umich_data) }
+    let(:freqs) { ft1.frequencies(organization: :umich, format: :spm) }
 
-    it "returns an Enumerable" do
-      expect(ft1.frequencies(organization: :umich, format: :spm)).to be_a(Enumerable)
+    it "returns an Array" do
+      expect(freqs).to be_a(Array)
     end
 
     it "returns the expected frequency data" do
-      expect(ft1.frequencies(organization: :umich, format: :spm)).to eq([[1, 1]])
+      expect(freqs.first).to be_a(Frequency)
+      expect(freqs.map(&:to_a)).to eq([[1, 1]])
     end
 
     it "returns empty Array for unattested organization" do
       expect(ft1.frequencies(organization: :nobody_here_by_that_name, format: :spm)).to eq([])
     end
-  
+
     it "returns empty Array for unattested format" do
       expect(ft1.frequencies(organization: :umich, format: :mpm)).to eq([])
     end
@@ -71,18 +71,18 @@ RSpec.describe FrequencyTable do
     end
 
     it "adds organizations" do
-      expected_keys = (ft1.fetch.keys + ft2.fetch.keys).uniq.sort
-      expect(ft1.append!(ft2).fetch.keys).to eq(expected_keys)
+      expected_keys = (ft1.keys + ft2.keys).uniq.sort
+      expect(ft1.append!(ft2).keys).to eq(expected_keys)
     end
 
     it "adds counts" do
       ft2.increment(organization: :umich, format: :spm, bucket: 1)
-      expect(ft1.append!(ft2).fetch(organization: :umich, format: :spm, bucket: 1)).to eq(2)
+      expect(ft1.append!(ft2).frequencies(organization: :umich, format: :spm).map(&:to_a)).to eq([[1, 2]])
     end
 
     it "adds formats" do
       ft2.increment(organization: :umich, format: :mpm, bucket: 10)
-      expect(ft1.append!(ft2).fetch(organization: :umich, format: :mpm, bucket: 10)).to eq(1)
+      expect(ft1.append!(ft2).frequencies(organization: :umich, format: :mpm).map(&:to_a)).to eq([[10, 1]])
     end
 
     it "isolates the receiver from subsequent changes to added table" do
@@ -92,10 +92,9 @@ RSpec.describe FrequencyTable do
       ft2.increment(organization: :upenn, format: :ser, bucket: 1)
       ft2.increment(organization: :upenn, format: :spm, bucket: 10)
       ft2.increment(organization: :umich, format: :spm, bucket: 1)
-      expect(ft1.fetch.keys).not_to include(:smu)
-      expect(ft1.fetch(organization: :upenn, format: :ser)).to eq({})
-      expect(ft1.fetch(organization: :upenn, format: :spm, bucket: 10)).to eq(0)
-      expect(ft1.fetch(organization: :upenn, format: :spm, bucket: 1)).to eq(1)
+      expect(ft1.keys).not_to include(:smu)
+      expect(ft1.frequencies(organization: :upenn, format: :ser)).to eq([])
+      expect(ft1.frequencies(organization: :upenn, format: :spm).map(&:to_a)).to eq([[1, 1]])
     end
   end
 
@@ -111,16 +110,16 @@ RSpec.describe FrequencyTable do
     end
 
     it "returns a FrequencyTable with all organizations in the addends" do
-      expected_keys = (ft1.fetch.keys + ft2.fetch.keys).uniq.sort
+      expected_keys = (ft1.keys + ft2.keys).uniq.sort
       ft3 = ft1 + ft2
-      expect(ft3.fetch.keys.sort).to eq(expected_keys)
+      expect(ft3.keys.sort).to eq(expected_keys)
     end
 
     it "returns a FrequencyTable with all counts in the addends" do
       ft2.increment(organization: :umich, format: :spm, bucket: 1)
       ft3 = ft1 + ft2
-      expect(ft3.fetch(organization: :umich, format: :spm, bucket: 1)).to eq(2)
-      expect(ft3.fetch(organization: :upenn, format: :spm, bucket: 1)).to eq(1)
+      expect(ft3.frequencies(organization: :umich, format: :spm).map(&:to_a)).to eq([[1, 2]])
+      expect(ft3.frequencies(organization: :upenn, format: :spm).map(&:to_a)).to eq([[1, 1]])
     end
   end
 
@@ -137,7 +136,7 @@ RSpec.describe FrequencyTable do
       Cluster.create(ocns: ht_item.ocns)
       insert_htitem ht_item
       ft.add_ht_item(ht_item)
-      expect(ft.fetch(organization: :umich, format: :spm, bucket: 1)).to eq(1)
+      expect(ft.frequencies(organization: :umich, format: :spm).map(&:to_a)).to eq([[1, 1]])
     end
   end
 
@@ -149,17 +148,42 @@ RSpec.describe FrequencyTable do
   end
 end
 
+RSpec.describe Frequency do
+  let(:freq) { described_class.new(bucket: 1, frequency: 2) }
 
-RSpec.describe OrganizationData do
   describe ".new" do
     it "creates a `#{described_class}`" do
-      expect(described_class.new(organization: :umich)).to be_a(described_class)
+      expect(freq).to be_a(described_class)
     end
   end
 
-  describe "#organization" do
-    it "returns the organization" do
-      expect(described_class.new(organization: :umich).organization).to eq(:umich)
+  describe "#bucket" do
+    it "returns the bucket" do
+      expect(freq.bucket).to eq(1)
+    end
+  end
+
+  describe "#member_count" do
+    it "returns the bucket under the `member_count` alias" do
+      expect(freq.member_count).to eq(1)
+    end
+  end
+
+  describe "#frequency" do
+    it "returns the frequency" do
+      expect(freq.frequency).to eq(2)
+    end
+  end
+
+  describe "#to_a" do
+    it "returns [bucket, frequency]" do
+      expect(freq.to_a).to eq([1, 2])
+    end
+  end
+
+  describe "#to_h" do
+    it "returns {bucket => bucket, frequency => frequency}" do
+      expect(freq.to_h).to eq({bucket: 1, frequency: 2})
     end
   end
 end

--- a/spec/frequency_table_spec.rb
+++ b/spec/frequency_table_spec.rb
@@ -155,6 +155,16 @@ RSpec.describe Frequency do
     it "creates a `#{described_class}`" do
       expect(freq).to be_a(described_class)
     end
+
+    it "accepts symbolized bucket and returns integer" do
+      from_bucket_sym = described_class.new(bucket: :"1", frequency: 2)
+      expect(from_bucket_sym).to be_a(described_class)
+      expect(from_bucket_sym.bucket).to eq(1)
+    end
+
+    it "raises on non-Integer frequency" do
+      expect { described_class.new(bucket: 1, frequency: Date.new) }.to raise_error(RuntimeError)
+    end
   end
 
   describe "#bucket" do

--- a/spec/reports/cost_report_spec.rb
+++ b/spec/reports/cost_report_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Reports::CostReport do
         collection_code: "PU"
       )
       load_test_data(pd_item)
-      expect(cr.frequency_table.fetch(organization: :upenn, format: :mpm)).to eq({})
+      expect(cr.frequency_table.frequencies(organization: :upenn, format: :mpm)).to eq([])
     end
 
     it "counts OCN-less items" do
@@ -132,6 +132,7 @@ RSpec.describe Reports::CostReport do
       )
       load_test_data ocnless_item
       expect(cr.frequency_table.fetch(organization: :upenn, format: :spm)).to eq({"1": 1})
+      expect(cr.frequency_table.frequencies(organization: :upenn, format: :spm)).to eq([[1, 1]])
     end
   end
 


### PR DESCRIPTION
- Add FrequencyTable#frequencies method.
- Remove FrequencyTable#fetch method altogether.
- Add `FrequencyTable#keys` to replace the existing `.fetch.keys` trope.
- New `Frequency` class returned by `#frequencies`.
- Use updated classes and methods in Cost Report specs, breaking out commonly used frequency data into `let`s for direct comparison.