### PR TITLE
DEV-1569: invoke cost report workflow via phctl

### DIFF
--- a/lib/phctl.rb
+++ b/lib/phctl.rb
@@ -109,6 +109,15 @@ module PHCTL
       run_common_job(Reports::CostReport, options)
     end
 
+    desc "costreport-workflow --ht-item-count NUM --ht-item-pd-count NUM (--chunk-size SIZE)", "Dump records from solr, split into chunks of chunk-size records, generate frequency tables for each chunk, sum the resulting frequency tables, and generate a cost report based on that table."
+    option :chunk_size, type: :numeric, default: 10000
+    option :ht_item_count, type: :numeric
+    option :ht_item_pd_count, type: :numeric
+    option :inline_callback_test, type: :boolean
+    def costreport_workflow
+      run_common_job(CostReportWorkflow, options)
+    end
+
     desc "frequency-table SOLR_RECORDS OUTFILE", "Generate a frequency table from in-copyright items in solr records (newline-delimited JSON, with fields at least id, format, oclc, oclc_search, ht_json)"
     def frequency_table(solr_records, output_file = solr_records + ".freqtable.json")
       run_common_job(Reports::FrequencyTableFromSolr, options, solr_records, output_file)

--- a/lib/reports/cost_report.rb
+++ b/lib/reports/cost_report.rb
@@ -37,8 +37,8 @@ module Reports
 
       File.open(output_filename, "w") do |fh|
         fh.puts "Target cost: #{target_cost}"
-        fh.puts "Num volumes: #{Clusterable::HtItem.count}"
-        fh.puts "Num pd volumes: #{Clusterable::HtItem.pd_count}"
+        fh.puts "Num volumes: #{ht_item_count}"
+        fh.puts "Num pd volumes: #{ht_item_pd_count}"
         fh.puts "Cost per volume: #{cost_per_volume}"
         fh.puts "Total weight: #{total_weight}"
         fh.puts "PD Cost: #{pd_cost}"
@@ -57,6 +57,8 @@ module Reports
       target_cost: Settings.target_cost,
       lines: 5000,
       logger: Services.logger,
+      ht_item_pd_count: nil,
+      ht_item_count: nil,
       precomputed_frequency_table_file: nil,
       precomputed_frequency_table_dir: nil,
       precomputed_frequency_table: read_freq_tables(precomputed_frequency_table_dir,
@@ -69,11 +71,21 @@ module Reports
       @target_cost = target_cost.to_f
       @maxlines = lines
       @logger = logger
+      @ht_item_pd_count ||= ht_item_pd_count
+      @ht_item_count ||= ht_item_count
 
       # If not set, frequency_table will call compile_frequency_table.
       # If you pass a precomputed frequency table, do not modify it after passing it in.
       # This warning is in the place of actually implementing proper cloning.
       @frequency_table = precomputed_frequency_table
+    end
+
+    def ht_item_pd_count
+      @ht_item_pd_count ||= Clusterable::HtItem.pd_count
+    end
+
+    def ht_item_count
+      @ht_item_count ||= Clusterable::HtItem.count
     end
 
     def active_members
@@ -82,7 +94,7 @@ module Reports
     end
 
     def cost_per_volume
-      @cost_per_volume ||= target_cost / Clusterable::HtItem.count.to_f
+      @cost_per_volume ||= target_cost / ht_item_count.to_f
     end
 
     def total_weight
@@ -90,7 +102,7 @@ module Reports
     end
 
     def pd_cost
-      @pd_cost ||= cost_per_volume * Clusterable::HtItem.pd_count
+      @pd_cost ||= cost_per_volume * ht_item_pd_count
     end
 
     def pd_cost_for_member(member)

--- a/lib/sidekiq_jobs.rb
+++ b/lib/sidekiq_jobs.rb
@@ -1,5 +1,6 @@
 require "services"
 require "sidekiq"
+require "cost_report_workflow"
 require "concordance_processing"
 require "loader/cluster_loader"
 require "loader/file_loader"

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -102,13 +102,16 @@ RSpec.describe "phctl integration" do
   # SharedPrintOps - integration tests are in the respective SharedPrint class
 
   describe "Report" do
-    include_context "with complete data for one cluster"
+    include_context "with mocked solr response"
 
-    it "CostReport produces output" do
-      phctl(*%w[report costreport])
+    it "CostReportWorkflow produces output" do
+      # item counts match what we have in the mock solr response
+      phctl(*%w[report costreport-workflow --ht-item-count 16 --ht-item-pd-count 5 --inline-callback-test])
       year = Time.new.year.to_s
-      expect(File.read(Dir.glob("#{ENV["TEST_TMP"]}/cost_reports/#{year}/*").first))
-        .to match(/Target cost: 9999/)
+
+      costreport = File.read(Dir.glob("#{ENV["TEST_TMP"]}/cost_reports/#{year}/*").first)
+      expect(costreport).to match(/Num volumes: 16/)
+      expect(costreport).to match(/Num pd volumes: 5/)
     end
 
     xit "Estimate produces output" do

--- a/spec/phctl_spec.rb
+++ b/spec/phctl_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "PHCTL::PHCTL", type: :sidekiq_fake do
     %w[report shared-print-phase-count --phase 1] => Jobs::Common,
     # Has wrappers in holdings/jobs
     %w[report member-counts infile outpath] => Jobs::Common,
+    %w[report costreport-workflow] => Jobs::Common,
     %w[report costreport] => Jobs::Common,
     %w[report costreport --organization
       someinst --target-cost 123456] => Jobs::Common,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ require "fixtures/organizations"
 
 require_relative "support/cluster_fixture_data"
 require_relative "support/holdings_tables"
+require_relative "support/mock_solr_response"
 
 SimpleCov::Formatter::LcovFormatter.config do |c|
   c.report_with_single_file = true

--- a/spec/support/mock_solr_response.rb
+++ b/spec/support/mock_solr_response.rb
@@ -1,0 +1,25 @@
+RSpec.shared_context "with mocked solr response" do
+  before(:each) do
+    stub_request(:get, "http://localhost:8983/solr/catalog/select?cursorMark=*&fl=ht_json,id,oclc,oclc_search,title,format&fq=ht_rightscode:(ic%20op%20und%20nobody%20pd-pvt)&q=*:*&rows=5000&sort=id%20asc&wt=json")
+      .with(
+        headers: {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "User-Agent" => "Faraday v2.12.2"
+        }
+      )
+      .to_return(status: 200,
+        body: File.read(fixture("solr_response.json")),
+        headers: {
+          "Content-type" => "application/json"
+        })
+  end
+
+  around(:each) do |example|
+    ClimateControl.modify(
+      SOLR_URL: "http://localhost:8983/solr/catalog"
+    ) do
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
Just a quick change to add the ability to invoke the workflow via phctl.

I'm not sure `costreport-workflow` is the right name here, and there's potential confusion for this vs. `phctl report costreport`. I'm also not sure whether we want to continue to retain the ability for `CostReport` to build a frequency table itself vs. needing to take one -- I don't know that we need to fix it now, but it may be related insofar as what needs to be exposed via phctl.