### PR TITLE
Quick fixes for max ocn

### DIFF
--- a/lib/scrub/max_ocn.rb
+++ b/lib/scrub/max_ocn.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
-require "open-uri"
+require "faraday"
 require "services"
 
 OCLC_URL = "https://www.oclc.org/apps/oclc/wwg"
@@ -66,7 +66,7 @@ module Scrub
       if @mock
         IO.read("spec/fixtures/max_oclc_response.json")
       else
-        URI.parse(OCLC_URL).open.read
+        Faraday.get(OCLC_URL).body
       end
     end
 

--- a/spec/scrub/max_ocn_spec.rb
+++ b/spec/scrub/max_ocn_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Scrub::MaxOcn do
     expect(File.exist?(loc)).to be(false)
     smo = described_class.new(mock: true, age_limit: 1)
     smo.ocn
+    FileUtils.touch(loc, mtime: Time.now - 10)
     mtime1 = File.stat(loc).mtime.to_i
-    sleep 2
     smo.ocn
     mtime2 = File.stat(loc).mtime.to_i
     expect(mtime2).to be > mtime1
@@ -42,8 +42,8 @@ RSpec.describe Scrub::MaxOcn do
     expect(File.exist?(loc)).to be(false)
     smo = described_class.new(mock: true, age_limit: 10)
     smo.ocn
+    FileUtils.touch(loc, mtime: Time.now - 1)
     mtime1 = File.stat(loc).mtime.to_i
-    sleep 1
     smo.ocn
     mtime2 = File.stat(loc).mtime.to_i
     expect(mtime2).to eq(mtime1)


### PR DESCRIPTION
Quick fixes for a very minor annoyance with tests that were slower than they needed to be.

* use Faraday instead of open-uri
* use FileUtils.touch instead of sleeping in max_ocn_spec