### PR TITLE
DEV-1613 enable & fix skipped tests in spec/scrub_runner

### DIFF
--- a/lib/clusterable/holding.rb
+++ b/lib/clusterable/holding.rb
@@ -19,6 +19,10 @@ module Clusterable
 
     attr_reader :date_received, :enum_chron
 
+    def self.count
+      Services.holdings_db[:holdings].count
+    end
+
     def cluster
       @cluster ||= Cluster.for_ocns([ocn])
     end

--- a/spec/scrub/scrub_runner_spec.rb
+++ b/spec/scrub/scrub_runner_spec.rb
@@ -95,7 +95,6 @@ RSpec.describe Scrub::ScrubRunner do
       FileUtils.cp(fixture_file, remote_d.holdings_current)
       remote_file = sr.check_new_files.first
       expect { sr.run_file(remote_file) }.to change { Clusterable::Holding.count }.by(6)
-      
       # Expect log file to end up in the remote dir
       log = "umich_mon_#{Time.new.strftime("%Y%m%d")}.log"
       expect(File.exist?(File.join(remote_d.holdings_current, log))).to be true

--- a/spec/scrub/scrub_runner_spec.rb
+++ b/spec/scrub/scrub_runner_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "clusterable/holding"
 require "data_sources/directory_locator"
 require "data_sources/ht_organizations"
 require "date"
@@ -10,6 +11,8 @@ require "scrub/scrub_runner"
 require "spec_helper"
 
 RSpec.describe Scrub::ScrubRunner do
+  include_context "with tables for holdings"
+
   let(:org1) { "umich" }
   # Only set force_holding_loader_cleanup_test to true in testing.
   let(:sr) { described_class.new(org1, {"force_holding_loader_cleanup_test" => true}) }
@@ -74,24 +77,27 @@ RSpec.describe Scrub::ScrubRunner do
     end
   end
 
-  xdescribe "#run" do
+  describe "#run" do
     it "checks a member for new files and scrubs+loads them" do
       remote_d = DataSources::DirectoryLocator.new(Settings.remote_member_data, org1)
       remote_d.ensure!
       # Copy fixture to "dropbox" so there is a "new file" to "download",
       FileUtils.cp(fixture_file, remote_d.holdings_current)
-      expect { sr.run }.to change { cluster_count(:holdings) }.by(6)
+      #expect { sr.run }.to change { cluster_count(:holdings) }.by(6)
+      expect { sr.run }.to change { Clusterable::Holding.count }.by(6)
     end
   end
 
-  xdescribe "#run_file" do
+  describe "#run_file" do
     it "run for a specific remote file" do
       remote_d = DataSources::DirectoryLocator.new(Settings.remote_member_data, org1)
       remote_d.ensure!
       # Copy fixture to "dropbox" so there is a "new file" to "download",
       FileUtils.cp(fixture_file, remote_d.holdings_current)
       remote_file = sr.check_new_files.first
-      expect { sr.run_file(remote_file) }.to change { cluster_count(:holdings) }.by(6)
+      #expect { sr.run_file(remote_file) }.to change { cluster_count(:holdings) }.by(6)
+      expect { sr.run_file(remote_file) }.to change { Clusterable::Holding.count }.by(6)
+      
       # Expect log file to end up in the remote dir
       log = "umich_mon_#{Time.new.strftime("%Y%m%d")}.log"
       expect(File.exist?(File.join(remote_d.holdings_current, log))).to be true
@@ -109,7 +115,8 @@ RSpec.describe Scrub::ScrubRunner do
           file.puts i
         end
       end
-      expect { sr.run_file(remote_file) }.to change { cluster_count(:holdings) }.by(0)
+      #expect { sr.run_file(remote_file) }.to change { cluster_count(:holdings) }.by(0)
+      expect { sr.run_file(remote_file) }.to change { Clusterable::Holding.count }.by(0)
       # Log should have been uploaded.
       log = "umich_mon_#{Time.new.strftime("%Y%m%d")}.log"
       expect(File.exist?(File.join(remote_d.holdings_current, log))).to be true
@@ -119,7 +126,8 @@ RSpec.describe Scrub::ScrubRunner do
         org1,
         {"force" => true, "force_holding_loader_cleanup_test" => true}
       )
-      expect { sr_force.run_file(remote_file) }.to change { cluster_count(:holdings) }.by(6)
+      #expect { sr_force.run_file(remote_file) }.to change { cluster_count(:holdings) }.by(6)
+      expect { sr_force.run_file(remote_file) }.to change { Clusterable::Holding.count }.by(6)
     end
   end
 end

--- a/spec/scrub/scrub_runner_spec.rb
+++ b/spec/scrub/scrub_runner_spec.rb
@@ -83,7 +83,6 @@ RSpec.describe Scrub::ScrubRunner do
       remote_d.ensure!
       # Copy fixture to "dropbox" so there is a "new file" to "download",
       FileUtils.cp(fixture_file, remote_d.holdings_current)
-      #expect { sr.run }.to change { cluster_count(:holdings) }.by(6)
       expect { sr.run }.to change { Clusterable::Holding.count }.by(6)
     end
   end
@@ -95,7 +94,6 @@ RSpec.describe Scrub::ScrubRunner do
       # Copy fixture to "dropbox" so there is a "new file" to "download",
       FileUtils.cp(fixture_file, remote_d.holdings_current)
       remote_file = sr.check_new_files.first
-      #expect { sr.run_file(remote_file) }.to change { cluster_count(:holdings) }.by(6)
       expect { sr.run_file(remote_file) }.to change { Clusterable::Holding.count }.by(6)
       
       # Expect log file to end up in the remote dir
@@ -115,7 +113,6 @@ RSpec.describe Scrub::ScrubRunner do
           file.puts i
         end
       end
-      #expect { sr.run_file(remote_file) }.to change { cluster_count(:holdings) }.by(0)
       expect { sr.run_file(remote_file) }.to change { Clusterable::Holding.count }.by(0)
       # Log should have been uploaded.
       log = "umich_mon_#{Time.new.strftime("%Y%m%d")}.log"
@@ -126,7 +123,6 @@ RSpec.describe Scrub::ScrubRunner do
         org1,
         {"force" => true, "force_holding_loader_cleanup_test" => true}
       )
-      #expect { sr_force.run_file(remote_file) }.to change { cluster_count(:holdings) }.by(6)
       expect { sr_force.run_file(remote_file) }.to change { Clusterable::Holding.count }.by(6)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -145,6 +145,8 @@ def fixture(filename)
   File.join(__dir__, "fixtures", filename)
 end
 
+# This does not work. We now use CLusterable::Holding.count for scrub_runner_spec.rb
+# For commitments and ht_items we recommend a `count` method on the appropriate class.
 def cluster_count(field)
   Cluster.each.map { |c| c.public_send(field).count }.reduce(0, :+)
 end


### PR DESCRIPTION
- Add `Clusterable::Holding.count` method to take the place of moribund spec helper `cluster_count`
- Add comment with future work breadcrumb in spec helper `cluster_count`