### PR TITLE
DEV-1616: remove phctl "cleanup holdings"

### DIFF
--- a/lib/phctl.rb
+++ b/lib/phctl.rb
@@ -52,18 +52,6 @@ module PHCTL
     end
   end
 
-  class Cleanup < JobCommand
-    desc "holdings INST DATE", "Deletes holdings for INST that were last updated prior to DATE."
-    def holdings(inst, date)
-      run_job(Jobs::Cleanup::Holdings, inst, date)
-    end
-
-    desc "duplicate_holdings", "Cleans duplicate holdings from all clusters"
-    def duplicate_holdings
-      CleanupDuplicateHoldings.queue_jobs
-    end
-  end
-
   class Concordance < JobCommand
     desc "validate INFILE OUTFILE", "Validate a concordance file"
     def validate(infile, outfile)
@@ -254,8 +242,5 @@ module PHCTL
 
     desc "sp", "Shared print operations"
     subcommand "sp", SharedPrintOps
-
-    desc "cleanup", "Cleanup operations"
-    subcommand "cleanup", Cleanup
   end
 end

--- a/lib/sidekiq_jobs.rb
+++ b/lib/sidekiq_jobs.rb
@@ -62,15 +62,6 @@ module Jobs
     end
   end
 
-  module Cleanup
-    class Holdings
-      include Sidekiq::Job
-      def perform(instid, date)
-        Clustering::ClusterHolding.delete_old_holdings(instid, Date.parse(date))
-      end
-    end
-  end
-
   module Concordance
     class Validate
       include Sidekiq::Job

--- a/spec/clusterable/ht_item_spec.rb
+++ b/spec/clusterable/ht_item_spec.rb
@@ -173,4 +173,32 @@ RSpec.describe Clusterable::HtItem do
       expect(no_ocn1.batch_with?(no_ocn3)).to be false
     end
   end
+
+  describe "Factory (spec/factories/ht_item.rb)" do
+    it "can specify billing_entity" do
+      ht_item = build(:ht_item, billing_entity: "umich")
+      expect(ht_item.billing_entity).to eq "umich"
+    end
+    it "can specify collection_code" do
+      ht_item = build(:ht_item, collection_code: "MIU")
+      expect(ht_item.collection_code).to eq "MIU"
+    end
+    it "makes sure collection_code and billing_entity belong to the same org" do
+      ht_item_with_billing_entity = build(:ht_item, billing_entity: "umich")
+      expect(ht_item_with_billing_entity.collection_code).to eq "MIU"
+
+      # Clusterable::HtItem.collection_code= takes care of this for us,
+      # by setting the proper billing_entity given a collection_code
+      ht_item_with_collection_code = build(:ht_item, collection_code: "MIU")
+      expect(ht_item_with_collection_code.billing_entity).to eq "umich"
+    end
+    it "bases collection_code on billing_entity in case they don't match" do
+      ht_item_with_mismatch = build(:ht_item, billing_entity: "umich", collection_code: "PU")
+      expect(ht_item_with_mismatch.collection_code).to eq "MIU"
+    end
+    it "makes billing_entity and collection_code match if neither are specified" do
+      ht_item_with_neither = build(:ht_item)
+      expect([["umich", "MIU"], ["upenn", "PU"]]).to include [ht_item_with_neither.billing_entity, ht_item_with_neither.collection_code]
+    end
+  end
 end

--- a/spec/factories/ht_item.rb
+++ b/spec/factories/ht_item.rb
@@ -28,5 +28,21 @@ FactoryBot.define do
       bib_fmt { "SE" }
       enum_chron { "V.#{rand(200).to_int}" }
     end
+
+    # The collection_code and billing_entity must "belong to" the same organization.
+    # Not putting this in the main class, because this is only addressing wonky tests.
+    after(:build) do |ht_item, context|
+      query = {
+        billing_entity: context.billing_entity,
+        content_provider_cluster: context.billing_entity,
+        responsible_entity: context.billing_entity
+      }
+      collection_codes = Services.holdings_db[:ht_collections][query]
+
+      # If the collection_code does not belong to the billing_entity, make it.
+      if !collection_codes.nil? && context.collection_code != collection_codes[:collection]
+        context.collection_code = collection_codes[:collection]
+      end
+    end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -41,14 +41,6 @@ RSpec.describe "phctl integration" do
     end
   end
 
-  xdescribe "Cleanup" do
-    it "Holdings removes old holdings" do
-      phctl("load", "holdings", fixture("umich_fake_testdata.ndj"))
-      expect { phctl(*%w[cleanup holdings umich 2022-01-01]) }
-        .to change { cluster_count(:holdings) }.by(-10)
-    end
-  end
-
   describe "Concordance" do
     it "Validate produces output and log" do
       def cleanup(output)

--- a/spec/overlap/cluster_overlap_spec.rb
+++ b/spec/overlap/cluster_overlap_spec.rb
@@ -6,15 +6,17 @@ require "overlap/cluster_overlap"
 RSpec.describe Overlap::ClusterOverlap do
   include_context "with tables for holdings"
 
-  let(:spm) { build(:ht_item, enum_chron: "", billing_entity: "ucr") }
+  let(:spm) { build(:ht_item, enum_chron: "", billing_entity: "upenn") }
   let(:ocns) { spm.ocns }
   let(:cluster) { Cluster.for_ocns(ocns) }
   let(:holding) { build(:holding, ocn: ocns.first, organization: "umich") }
   let(:holding2) do
-    build(:holding,
+    build(
+      :holding,
       ocn: ocns.first,
       organization: "smu",
-      condition: "brt")
+      condition: "brt"
+    )
   end
 
   before(:each) do

--- a/spec/phctl_spec.rb
+++ b/spec/phctl_spec.rb
@@ -6,7 +6,6 @@ require "phctl"
 RSpec.describe "PHCTL::PHCTL", type: :sidekiq_fake do
   commands = {
     %w[load holdings somefile] => Jobs::Load::Holdings,
-    %w[cleanup holdings instid date] => Jobs::Cleanup::Holdings,
     %w[concordance validate infile outfile] => Jobs::Concordance::Validate,
     %w[concordance delta oldfile newfile] => Jobs::Concordance::Delta,
     %w[sp update infile] => Jobs::Common,


### PR DESCRIPTION
Another holdings cleanup thing that we no longer need.
Not very connected, so deleting a couple of blocks of code should do it.
Fixed an unrelated brittle test in `spec/overlap/cluster_overlap_spec.rb` while I was doing it