### PR TITLE
DEV-1614 consider tracking holdings files via `Loader::LoadedFile`

### DIFF
--- a/lib/loader/holding_loader.rb
+++ b/lib/loader/holding_loader.rb
@@ -73,7 +73,7 @@ module Loader
       timestamp = options["loaded_file"].match(/\d{4}-\d\d-\d\d-\d{6}/)[0]
       time = Time.strptime(timestamp, "%Y-%m-%d-%H%M%S")
       loaded_file_hash = {
-        filename: options["loaded_file"],
+        filename: options["raw_file"],
         produced: time.to_date,
         loaded: time,
         source: options["organization"],

--- a/lib/loader/holding_loader.rb
+++ b/lib/loader/holding_loader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "utils/file_transfer"
+require "loader/loaded_file"
 
 module Loader
   # Constructs batches of Holdings from incoming file data
@@ -68,6 +69,20 @@ module Loader
       )
       Services.logger.info "moving loaded file to scrubber.member_loaded"
       FileUtils.mv(options["loaded_file"], options["loaded_dir"])
+
+      timestamp = options["loaded_file"].match(/\d{4}-\d\d-\d\d-\d{6}/)[0]
+      time = Time.strptime(timestamp, "%Y-%m-%d-%H%M%S")
+      loaded_file_hash = {
+        filename: options["loaded_file"],
+        produced: time.to_date,
+        loaded: time,
+        source: options["organization"],
+        type: "holding"
+      }
+      Services.logger.info "saving holdings_loaded_files entry (#{loaded_file_hash})"
+      loaded_file = Loader::LoadedFile.new(loaded_file_hash)
+      loaded_file.save
+
       Services.logger.info "cleanup done"
     end
   end

--- a/lib/scrub/scrub_runner.rb
+++ b/lib/scrub/scrub_runner.rb
@@ -78,6 +78,7 @@ module Scrub
         batch = Sidekiq::Batch.new
         batch.description = "Holdings load for #{@organization}'s #{scrubber_out_file}"
         cleanup_data = {
+          "raw_file" => file["Name"],
           "tmp_chunk_dir" => chunker.tmp_chunk_dir,
           "organization" => @organization,
           "scrub_log" => scrubber.logger_path,

--- a/spec/factories/loaded_file.rb
+++ b/spec/factories/loaded_file.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "date"
 require "faker"
 require "loader/loaded_file"
 
@@ -8,7 +9,7 @@ FactoryBot.define do
     to_create(&:save)
 
     filename { Faker::File.file_name(ext: ["tsv", "json"].sample) }
-    produced { Faker::Date.between(from: 1.week.ago, to: 1.year.ago) }
+    produced { Faker::Date.between(from: Date.today - 7, to: Date.today - 365) }
     loaded { Faker::Time.backward(days: 5) }
     source { ["hathitrust", "oclc", "umich"].sample }
     type { ["holdings", "concordance", "hathifile"].sample }

--- a/spec/loader/loaded_file_spec.rb
+++ b/spec/loader/loaded_file_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "loader/loaded_file"
 
-RSpec.xdescribe Loader::LoadedFile do
+RSpec.describe Loader::LoadedFile do
   around(:each) do |example|
     described_class.db.transaction(rollback: :always, auto_savepoint: true) do
       example.run

--- a/spec/scrub/scrub_runner_spec.rb
+++ b/spec/scrub/scrub_runner_spec.rb
@@ -105,7 +105,6 @@ RSpec.describe Scrub::ScrubRunner do
       expect(File.exist?(File.join(remote_d.holdings_current, log))).to be true
       # expect to see a row in holdings_loaded_files with filename=fixture_file_name
       expect(count_loaded_files).to eq(1)
-      
     end
     it "will refuse a file if it breaks Settings.scrub_line_count_diff_max" do
       remote_d = DataSources::DirectoryLocator.new(Settings.remote_member_data, org1)

--- a/spec/scrub/scrub_runner_spec.rb
+++ b/spec/scrub/scrub_runner_spec.rb
@@ -16,7 +16,12 @@ RSpec.describe Scrub::ScrubRunner do
   let(:org1) { "umich" }
   # Only set force_holding_loader_cleanup_test to true in testing.
   let(:sr) { described_class.new(org1, {"force_holding_loader_cleanup_test" => true}) }
-  let(:fixture_file) { "spec/fixtures/umich_mon_full_20220101.tsv" }
+  let(:fixture_file_name) { "umich_mon_full_20220101.tsv" }
+  let(:fixture_file) { fixture(fixture_file_name) }
+
+  def count_loaded_files
+    Services.holdings_db[:holdings_loaded_files].where(filename: fixture_file_name).count
+  end
 
   before(:each) do
     FileUtils.touch(Settings.rclone_config_path)
@@ -98,6 +103,9 @@ RSpec.describe Scrub::ScrubRunner do
       # Expect log file to end up in the remote dir
       log = "umich_mon_#{Time.new.strftime("%Y%m%d")}.log"
       expect(File.exist?(File.join(remote_d.holdings_current, log))).to be true
+      # expect to see a row in holdings_loaded_files with filename=fixture_file_name
+      expect(count_loaded_files).to eq(1)
+      
     end
     it "will refuse a file if it breaks Settings.scrub_line_count_diff_max" do
       remote_d = DataSources::DirectoryLocator.new(Settings.remote_member_data, org1)
@@ -123,6 +131,8 @@ RSpec.describe Scrub::ScrubRunner do
         {"force" => true, "force_holding_loader_cleanup_test" => true}
       )
       expect { sr_force.run_file(remote_file) }.to change { Clusterable::Holding.count }.by(6)
+      # expect to see a row in holdings_loaded_files with filename=fixture_file_name
+      expect(count_loaded_files).to eq(1)
     end
   end
 end


### PR DESCRIPTION
- Enable tests for `Loader::LoadedFile`
  - TODO make this a standalone class rather than Sequel model?
- Write holdings_loaded_files entry in the loader cleanup phase
- Add `holdings_loaded_files` checks to scrub runner spec