### PR TITLE
DEV-1590: API for ETAS access queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,10 @@ gem "trilogy"
 gem "zinzout"
 gem "puma"
 gem "rack-session"
+gem "rackup"
 gem "sidekiq"
 gem "sidekiq-batch", git: "https://github.com/breamware/sidekiq-batch"
+gem "sinatra"
 gem "solr_cursorstream"
 
 group :test do
@@ -28,6 +30,7 @@ group :test do
   gem "factory_bot"
   gem "faker"
   gem "hathifiles_database", git: "https://github.com/hathitrust/hathifiles_database.git", branch: "main"
+  gem "rack-test"
   gem "rspec"
   gem "rspec-sidekiq"
   gem "simplecov"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,8 @@ GEM
     method_source (1.1.0)
     milemarker (1.0.1)
     minitest (5.25.4)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
     mysql2 (0.5.6)
     net-http (0.6.0)
       uri
@@ -148,9 +150,17 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.12)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.1.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rackup (2.2.1)
+      rack (>= 3)
     rainbow (3.1.1)
     rake (13.2.1)
     rbs (3.8.1)
@@ -209,6 +219,7 @@ GEM
       ruby-lsp (~> 0.23.0)
     ruby-prof (1.7.1)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     securerandom (0.4.1)
     sequel (5.90.0)
       bigdecimal
@@ -225,6 +236,13 @@ GEM
     simplecov-html (0.13.1)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
     solr_cursorstream (0.2.0)
       faraday
       faraday-retry
@@ -248,6 +266,7 @@ GEM
     stream (0.5.5)
     stringio (3.1.5)
     thor (1.3.2)
+    tilt (2.6.0)
     trilogy (2.9.0)
     tty-color (0.6.0)
     tty-cursor (0.7.1)
@@ -294,6 +313,8 @@ DEPENDENCIES
   puma
   push_metrics!
   rack-session
+  rack-test
+  rackup
   rgl
   rspec
   rspec-sidekiq
@@ -305,6 +326,7 @@ DEPENDENCIES
   sidekiq-batch!
   simplecov
   simplecov-lcov
+  sinatra
   solr_cursorstream
   standard
   thor

--- a/bin/api_config.ru
+++ b/bin/api_config.ru
@@ -1,0 +1,2 @@
+require "api/holdings_api"
+run HoldingsAPI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,20 @@ services:
     restart: always
     healthcheck:
       <<: *healthcheck-defaults
-      test: ["CMD", "redis-cli","ping"]
+      test: ["CMD", "redis-cli", "ping"]
+
+  api:
+    <<: *holdings-container-defaults
+    restart: always
+    volumes:
+      - .:/usr/src/app
+      - gem_cache:/gems
+    command: bundle exec puma -p 4567 bin/api_config.ru
+    ports:
+      - 4567:4567
+    healthcheck:
+      <<: *healthcheck-defaults
+      test: [ "CMD", "wget", "--quiet", "--tries=1", "-O", "/dev/null", "localhost:4567/v1/ping" ]
 
 volumes:
   gem_cache:

--- a/lib/api/holdings_api.rb
+++ b/lib/api/holdings_api.rb
@@ -1,0 +1,76 @@
+require "cluster"
+require "clusterable/ht_item"
+require "services"
+require "sinatra"
+
+class HoldingsAPI < Sinatra::Base
+  set :show_exceptions, ENV["show_sinatra_exceptions"] || false
+  no_matching_data_error = {"application_error" => "no matching data"}.to_json
+
+  get "/v1/ping" do
+    "pong"
+  end
+
+  # Answers the question: can organization access ht_id?
+  get "/v1/item_access" do
+    # ArgumentError if missing organization / ht_id.
+    validate_params(params, ["organization", "ht_id"])
+
+    organization = params["organization"]
+    ht_id = params["ht_id"]
+
+    ht_item = Clusterable::HtItem.find(item_id: ht_id)
+    cluster = ht_item.cluster
+
+    return_doc = {
+      "copy_count" => cluster.copy_counts[organization],
+      "format" => cluster.format,
+      "n_enum" => ht_item.n_enum,
+      "ocns" => ht_item.ocns.sort
+    }
+    return_doc.to_json
+  end
+
+  # Answers the question: which organization have holdings that match ht_id?
+  get "/v1/item_held_by" do
+    # ArgumentError if missing ht_id.
+    validate_params(params, ["ht_id"])
+    ht_id = params["ht_id"]
+
+    ht_item = Clusterable::HtItem.find(item_id: ht_id)
+    cluster = ht_item.cluster
+
+    return_doc = {
+      "organizations" => cluster.organizations_in_cluster
+    }
+    return_doc.to_json
+  end
+
+  def validate_params(params, to_validate)
+    argument_errors = []
+    to_validate.each do |param_name|
+      if !params.key?(param_name) || params[param_name].empty?
+        argument_errors << "missing param: #{param_name}"
+      end
+    end
+    if argument_errors.any?
+      raise ArgumentError, argument_errors.join("; ")
+    end
+  end
+
+  error ArgumentError do
+    status 404
+    {"application_error" => env["sinatra.error"].message}.to_json
+  end
+
+  error Sequel::NoMatchingRow do
+    status 404
+    no_matching_data_error
+  end
+
+  error do
+    Services.logger.error env["sinatra.error"].message
+    status 404
+    "Error"
+  end
+end

--- a/spec/api/holdings_api_spec.rb
+++ b/spec/api/holdings_api_spec.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require "rack/test"
+require "api/holdings_api"
+
+APP = Rack::Builder.parse_file("bin/api_config.ru")
+
+RSpec.describe "HoldingsApi" do
+  include Rack::Test::Methods
+  include_context "with tables for holdings"
+
+  let(:app) { APP }
+  let(:base_url) { "http://localhost:4567" }
+  # ht_item 1 is an spm with a single ocn
+  let(:item_id_1) { "test.123" }
+  let(:ocn) { 123 }
+  let(:htitem_1) { build(:ht_item, :spm, item_id: item_id_1, ocns: [ocn], billing_entity: "umich") }
+
+  # ht_item 2 is an mpm
+  let(:item_id_2) { "test.123456" }
+  let(:ocn2) { [123, 456] }
+  let(:htitem_2) { build(:ht_item, :mpm, item_id: item_id_2, ocns: ocn2, enum_chron: "v.1-5 (1901-1905)") }
+
+  # ht_item 3 is an spm with 3 ocns
+  let(:item_id_3) { "test.123456789" }
+  let(:ocns) { [123, 456, 789] }
+  let(:htitem_3) { build(:ht_item, :spm, item_id: item_id_3, ocns: ocns) }
+
+  let(:slashy_ht_item_id) { "aeu.ark:/13960/t04x6jk58" }
+  let(:slashy_ht_item) { build(:ht_item, :spm, item_id: slashy_ht_item_id, ocns: [ocn]) }
+
+  def make_call(call)
+    get "#{base_url}/#{call}"
+  end
+
+  def url_template(page, **kwargs)
+    params = []
+    kwargs.each do |k, v|
+      params << "#{k}=#{v}"
+    end
+    "#{page}?" + params.join("&")
+  end
+
+  def v1(url)
+    "v1/" + url
+  end
+
+  def parse_body(call)
+    make_call(call)
+    # Useful debug that includes call and response:
+    # puts "#{call} ==> #{last_response.body}"
+    JSON.parse(last_response.body)
+  end
+
+  describe "/ping" do
+    it "ping-pongs" do
+      make_call(v1("ping"))
+      expect(last_response.body).to eq "pong"
+      expect(last_response.status).to eq 200
+    end
+  end
+
+  describe "invalid route" do
+    it "responds with a 404" do
+      make_call("invalid/route")
+      expect(last_response.status).to eq 404
+    end
+  end
+
+  describe "missing arguments -> #404 & application_error message" do
+    it "missing organization" do
+      load_test_data(htitem_1)
+      response = parse_body(v1(url_template("item_access", ht_id: item_id_1)))
+      expect(response["application_error"]).to eq "missing param: organization"
+      expect(last_response.status).to eq 404
+    end
+    it "missing ht_id" do
+      load_test_data(htitem_1)
+      response = parse_body(v1(url_template("item_access", organization: "umich")))
+      expect(response["application_error"]).to eq "missing param: ht_id"
+      expect(last_response.status).to eq 404
+    end
+    it "missing both" do
+      load_test_data(htitem_1)
+      response = parse_body(v1(url_template("item_access")))
+      expect(response["application_error"]).to eq "missing param: organization; missing param: ht_id"
+      expect(last_response.status).to eq 404
+    end
+  end
+
+  describe "/item_access" do
+    it "returns an error message if there is no matching htitem" do
+      response = parse_body(v1(url_template("item_access", ht_id: item_id_1, organization: "umich")))
+      expect(response["application_error"]).to eq "no matching data"
+      expect(last_response.status).to eq 404
+    end
+    it "returns 0 if no holdings" do
+      load_test_data(htitem_1)
+      response = parse_body(v1(url_template("item_access", ht_id: item_id_1, organization: "umich")))
+      expect(response["ocns"]).to eq [ocn]
+      expect(response["copy_count"]).to eq 0
+    end
+    it "handles ht_items with slashes" do
+      load_test_data(slashy_ht_item)
+      call = v1(url_template("item_access", ht_id: slashy_ht_item_id, organization: "umich"))
+      response = parse_body(call)
+      expect(response["copy_count"]).to eq 0
+    end
+    it "simplest positive case with 1 item, 1 ocn, 1 org, 1 holding" do
+      load_test_data(
+        htitem_1,
+        build(:holding, organization: "umich", ocn: ocn)
+      )
+      response = parse_body(v1(url_template("item_access", ht_id: item_id_1, organization: "umich")))
+      expect(response["ocns"]).to eq [ocn]
+      expect(response["copy_count"]).to eq 1
+    end
+    it "positive case with 1 item, 1 ocn, 1 org, 3 holdings" do
+      load_test_data(
+        htitem_1,
+        build(:holding, organization: "umich", ocn: ocn),
+        build(:holding, organization: "umich", ocn: ocn),
+        build(:holding, organization: "umich", ocn: ocn)
+      )
+      response = parse_body(v1(url_template("item_access", ht_id: item_id_1, organization: "umich")))
+      expect(response["ocns"]).to eq [ocn]
+      expect(response["copy_count"]).to eq 3
+    end
+    it "positive case with 1 item, 1 ocn, 2 orgs, 3 holdings (split umich 1, smu 2)" do
+      load_test_data(
+        htitem_1,
+        build(:holding, organization: "umich", ocn: ocn),
+        build(:holding, organization: "smu", ocn: ocn),
+        build(:holding, organization: "smu", ocn: ocn)
+      )
+      # umich, 1 holding
+      response = parse_body(v1(url_template("item_access", ht_id: item_id_1, organization: "umich")))
+      expect(response["ocns"]).to eq [ocn]
+      expect(response["copy_count"]).to eq 1
+      # smu, 2 holdings
+      response = parse_body(v1(url_template("item_access", ht_id: item_id_1, organization: "smu")))
+      expect(response["ocns"]).to eq [ocn]
+      expect(response["copy_count"]).to eq 2
+    end
+    it "concatenates the ocns to make a lock_id" do
+      load_test_data(
+        htitem_3,
+        build(:holding, organization: "umich", ocn: ocn)
+      )
+      response = parse_body(v1(url_template("item_access", ht_id: item_id_3, organization: "smu")))
+      expect(response["ocns"]).to eq [123, 456, 789]
+    end
+    it "gets the counts for holdings with ocns matching the item" do
+      load_test_data(
+        htitem_3,
+        build(:holding, organization: "umich", ocn: 123),
+        build(:holding, organization: "umich", ocn: 456),
+        build(:holding, organization: "umich", ocn: 789),
+        build(:holding, organization: "umich", ocn: 999999999, local_id: "not matching")
+      )
+      response = parse_body(v1(url_template("item_access", ht_id: item_id_3, organization: "umich")))
+      expect(response["copy_count"]).to eq 3
+    end
+    it "returns an empty n_enum for spm" do
+      load_test_data(htitem_1)
+      response = parse_body(v1(url_template("item_access", ht_id: item_id_1, organization: "umich")))
+      expect(response["n_enum"]).to eq ""
+    end
+    it "returns non-empty n_enum for mpm" do
+      load_test_data(htitem_2)
+      response = parse_body(v1(url_template("item_access", ht_id: item_id_2, organization: "umich")))
+      expect(response["n_enum"]).to eq "1-5"
+    end
+    it "returns format:spm for an item in a spm cluster" do
+      load_test_data(htitem_1)
+      response = parse_body(v1(url_template("item_access", ht_id: item_id_1, organization: "umich")))
+      expect(response["format"]).to eq "spm"
+    end
+    it "returns format:mpm for an item in a mpm cluster" do
+      load_test_data(htitem_2)
+      response = parse_body(v1(url_template("item_access", ht_id: item_id_2, organization: "umich")))
+      expect(response["format"]).to eq "mpm"
+    end
+  end
+
+  describe "v1/item_held_by" do
+    it "returns an application error if the ht_id does not match an ht_item" do
+      response = parse_body(v1(url_template("item_held_by", ht_id: item_id_1, organization: "umich")))
+      expect(response["application_error"]).to eq "no matching data"
+    end
+    it "returns an array with the submitter if no organization has reported holdings matching ht_item" do
+      load_test_data(htitem_1)
+      response = parse_body(v1(url_template("item_held_by", ht_id: item_id_1, organization: "umich")))
+      expect(response["organizations"]).to eq ["umich"]
+    end
+    it "returns an array with the submitter if only submitter has reported holdings matching ht_item" do
+      load_test_data(htitem_1, build(:holding, organization: "umich", ocn: 123))
+      response = parse_body(v1(url_template("item_held_by", ht_id: item_id_1, organization: "umich")))
+      expect(response["organizations"]).to eq ["umich"]
+    end
+    it "returns an array with all organizations with holdings matching ht_item" do
+      load_test_data(
+        htitem_1,
+        build(:holding, organization: "umich", ocn: ocn),
+        build(:holding, organization: "smu", ocn: ocn)
+      )
+      response = parse_body(v1(url_template("item_held_by", ht_id: item_id_1, organization: "umich")))
+      expect(response["organizations"].sort).to eq ["smu", "umich"]
+    end
+  end
+end


### PR DESCRIPTION
See https://hathitrust.atlassian.net/browse/DEV-1590

## Context

In a rare move away from "using the database as API", here's a Sinatra API that can be used to answer holdings questions (such as "how many holdings matching the volume `ht_id:foo` has `organization:bar` reported?")

## Routes

### item_access

Querying `v1/item_access?ht_id=foo&organization=bar` should return:

```ruby
{                                      
  "copy_count" => cluster.copy_counts[organization],
  "format" => cluster.format,                       
  "n_enum" => ht_item.n_enum,                       
  "ocns" => ht_item.ocns.sort                       
}.to_json                                  
```

It should return a `#404` if any of the arguments are missing, if the route is wrong, or if the `ht_id` does not match a `ht_item`.

`copy_count` defaults to 0, even if the given organization does not exists.

### item_held_by

Querying  `v1/item_held_by?ht_id=foo` should return:

```ruby
{                                      
  "organizations" => cluster.organizations_in_cluster
}.to_json
```

`organizations` should never be empty, if the item exists, since all items have at least a `billing_entity` organization (the org that submitted the item). 

## Testing

Run tests: `bundle exec rspec spec/api/etas_api_spec.rb`