### PR TITLE
DEV-1640: check ocn counts as part of scrub and reject file if diff is too great

### DIFF
--- a/config/environments/test.yml
+++ b/config/environments/test.yml
@@ -20,6 +20,7 @@ scrub_base_path: <%= ENV["TEST_TMP"] %>/scrub_data
 scrub_chunk_count: 4
 scrub_chunk_work_dir: <%= ENV["TEST_TMP"] %>
 scrub_line_count_diff_max: 0.05
+scrub_ocn_diff_max: 0.10
 shared_print_report_path: <%= ENV["TEST_TMP"] %>/shared_print_reports
 shared_print_update_report_path: <%= ENV["TEST_TMP"] %>/shared_print_update_report
 sp_newly_ingested_report_path: <%= ENV["TEST_TMP"] %>/sp_newly_ingested_report

--- a/lib/scrub/autoscrub.rb
+++ b/lib/scrub/autoscrub.rb
@@ -19,8 +19,9 @@ module Scrub
     # by another ruby class.
     attr_reader :output_struct, :out_files, :logger_path, :item_type
 
-    def initialize(path)
+    def initialize(path, force = false)
       @path = path
+      @force = force
 
       # @member_id and @item_type are used in the path to scrub_logger, but we
       # also need somewhere to log to before we know @member_id and @item_type
@@ -48,7 +49,7 @@ module Scrub
       @encoding = Utils::Encoding.new(@path)
       convert_to_utf8 unless @encoding.ascii_or_utf8?
 
-      Services.scrub_logger.info("Started scrubbing #{@path}")
+      Services.scrub_logger.info("Started scrubbing #{@path}, --force=#{@force}")
       write_to do |out_file|
         @member_holding_file.parse do |holding|
           out_file.puts(holding.to_json)

--- a/lib/scrub/record_counter.rb
+++ b/lib/scrub/record_counter.rb
@@ -4,14 +4,19 @@ require "utils/line_counter"
 
 module Scrub
   class RecordCounter
-    attr_reader :organization, :item_type, :struct
+    attr_reader :organization, :item_type, :struct, :message
     def initialize(organization, item_type)
       @organization = organization
       @item_type = item_type
       @struct = Scrub::ScrubOutputStructure.new(organization)
       @rx = /^#{@organization}_#{@item_type}_.+\.ndj$/
+      @message = []
+
       if Settings.scrub_line_count_diff_max.nil?
         raise ArgumentError, "Missing Settings.scrub_line_count_diff_max"
+      end
+      if Settings.scrub_ocn_diff_max.nil?
+        raise ArgumentError, "Missing Settings.scrub_ocn_diff_max"
       end
     end
 
@@ -26,7 +31,28 @@ module Scrub
         true
       else
         # Check if the percent diff is less than the diff_max
-        diff < Settings.scrub_line_count_diff_max
+        line_diff_ok = line_diff < Settings.scrub_line_count_diff_max
+        ocn_diff_ok = ocn_diff < Settings.scrub_ocn_diff_max
+
+        unless line_diff_ok
+          @message << [
+            "Line diff too great.",
+            "Most recently loaded file (#{File.basename(last_loaded)}) line count: #{count_loaded}.",
+            "The current file (#{File.basename(last_ready)}) line count: #{count_ready}.",
+            "Line count diff: #{line_diff * 100}% (max allowed #{Settings.scrub_line_count_diff_max * 100}%)."
+          ].join(" ")
+        end
+
+        unless ocn_diff_ok
+          @message << [
+            "Distinct OCN diff too great.",
+            "Most recently loaded file (#{File.basename(last_loaded)}) ocn count: #{count_loaded_ocns}.",
+            "The current file (#{File.basename(last_ready)}) OCN count: #{count_ready_ocns}.",
+            "Distinct OCN diff: #{ocn_diff * 100}% (max allowed #{Settings.scrub_ocn_diff_max * 100}%)."
+          ].join(" ")
+        end
+
+        line_diff_ok && ocn_diff_ok
       end
     end
 
@@ -46,8 +72,20 @@ module Scrub
       @count_ready ||= count(last_ready)
     end
 
-    def diff
-      @diff ||= ((count_ready - count_loaded) / count_loaded.to_f).abs
+    def count_loaded_ocns
+      @count_loaded_ocns ||= count_distinct_ocns(last_loaded)
+    end
+
+    def count_ready_ocns
+      @count_ready_ocns ||= count_distinct_ocns(last_ready)
+    end
+
+    def line_diff
+      @line_diff ||= ((count_ready - count_loaded) / count_loaded.to_f).abs
+    end
+
+    def ocn_diff
+      @ocn_diff ||= ((count_ready_ocns - count_loaded_ocns) / count_loaded_ocns.to_f).abs
     end
 
     private
@@ -58,6 +96,27 @@ module Scrub
       else
         Utils::LineCounter.new(path).count_lines
       end
+    end
+
+    def count_distinct_ocns(path)
+      if path.nil?
+        return 0
+      end
+
+      ocns = Set.new
+      # Expecting file to be a .ndj, so we want to parse each line as JSON.
+      File.open(path) do |f|
+        f.each_line do |line|
+          holding_hash = JSON.parse(line)
+          next unless holding_hash.is_a? Hash
+          next unless holding_hash.key?("ocn")
+          ocns << holding_hash["ocn"]
+        rescue JSON::ParserError
+          warn "#{path} contains non-JSON"
+        end
+      end
+
+      ocns.size
     end
 
     def last_file(path)

--- a/spec/fixtures/umich_mon_full_20220101_ocndiff1.tsv
+++ b/spec/fixtures/umich_mon_full_20220101_ocndiff1.tsv
@@ -1,0 +1,7 @@
+oclc	local_id	status	condition
+3	i3	WD	
+1	i1	CH	
+4	i4	CH	BRT
+5	i5	LM	BRT
+2	i2	LM	
+6	i6	WD	BRT

--- a/spec/fixtures/umich_mon_full_20220102_ocndiff2.tsv
+++ b/spec/fixtures/umich_mon_full_20220102_ocndiff2.tsv
@@ -1,0 +1,14 @@
+oclc	local_id	status	condition
+30	i3	WD	
+10	i1	CH	
+40	i4	CH	BRT
+50	i5	LM	BRT
+20	i2	LM	
+60	i6	CH	
+61	i6	CH	
+62	i6	CH	
+63	i6	CH	
+64	i6	CH	
+65	i6	CH	
+66	i6	CH	
+67	i6	CH	

--- a/spec/scrub/record_counter_spec.rb
+++ b/spec/scrub/record_counter_spec.rb
@@ -4,6 +4,8 @@ require "spec_helper"
 require "scrub/record_counter"
 
 RSpec.describe Scrub::RecordCounter do
+  include_context "with tables for holdings"
+
   let(:org) { "umich" }
   let(:item_type) { "spm" }
   let(:rc) { described_class.new(org, item_type) }
@@ -15,14 +17,26 @@ RSpec.describe Scrub::RecordCounter do
   }
   let(:hundo) { 100 }
   let(:small_diff) { (Settings.scrub_line_count_diff_max * 100) - 1 }
-  def put_x_lines_in_file(x, file)
+
+  # Write a testfile with a certain number of { "ocn": i } ndjs.
+  def testfile(lines:, file:)
     File.open(file, "w") do |f|
-      1.upto(x) do |i|
-        f.puts(i)
+      1.upto(lines) do |i|
+        f.puts({"ocn" => i}.to_json)
       end
     end
   end
-  context "#initialize" do
+
+  # Write a testfile with array as basis for { "ocn": x } ndjs.
+  def array_to_testfile(array:, file:)
+    File.open(file, "w") do |f|
+      array.each do |i|
+        f.puts({"ocn" => i}.to_json)
+      end
+    end
+  end
+
+  describe "#initialize" do
     it "requires required args" do
       expect { described_class.new }.to raise_error ArgumentError
     end
@@ -33,49 +47,173 @@ RSpec.describe Scrub::RecordCounter do
       Settings.scrub_line_count_diff_max = org_setting
     end
   end
-  context "#count_loaded & #count_ready" do
-    it "count_loaded empty == 0" do
-      expect(rc.count_loaded).to eq 0
+
+  context "count methods" do
+    describe "#count_loaded & #count_ready" do
+      it "count_loaded empty == 0" do
+        expect(rc.count_loaded).to eq 0
+      end
+      it "count_loaded 1 == 1" do
+        testfile(lines: 1, file: loaded_file)
+        expect(rc.count_loaded).to eq 1
+      end
+      it "count_ready empty == 0" do
+        expect(rc.count_ready).to eq 0
+      end
+      it "count_ready 1 == 1" do
+        testfile(lines: 1, file: ready_file)
+        expect(rc.count_ready).to eq 1
+      end
+      it "counts each duplicate line" do
+        duplicate_count = 5
+        array_to_testfile(array: [1] * duplicate_count, file: ready_file)
+        expect(rc.count_ready).to eq duplicate_count
+      end
+      it "dedupes ocns" do
+        ocn_count = 5
+        # make 3 copies of each ocn from 1..5
+        array_to_testfile(array: (1..ocn_count).to_a * 3, file: ready_file)
+        # expect 5, not 15
+        expect(rc.count_ready_ocns).to eq ocn_count
+      end
     end
-    it "count_loaded 1 == 1" do
-      put_x_lines_in_file(1, loaded_file)
-      expect(rc.count_loaded).to eq 1
-    end
-    it "count_ready empty == 0" do
-      expect(rc.count_ready).to eq 0
-    end
-    it "count_ready 1 == 1" do
-      put_x_lines_in_file(1, ready_file)
-      expect(rc.count_ready).to eq 1
+
+    describe "#count_loaded_ocns & #count_ready_ocns" do
+      it "count_loaded_ocns empty == 0" do
+        expect(rc.count_loaded_ocns).to eq 0
+      end
+      it "count_loaded_ocns 1 == 1" do
+        ocn_count = 3
+        testfile(lines: ocn_count, file: loaded_file)
+        expect(rc.count_loaded_ocns).to eq ocn_count
+      end
+      it "count_ready_ocns empty == 0" do
+        expect(rc.count_ready_ocns).to eq 0
+      end
+      it "count_ready_ocns 1 == 1" do
+        ocn_count = 3
+        testfile(lines: ocn_count, file: ready_file)
+        expect(rc.count_ready_ocns).to eq ocn_count
+      end
     end
   end
-  context "#acceptable_diff?" do
-    it "is not acceptable if there are no files to load" do
-      expect(rc.acceptable_diff?).to be false
+
+  context "diff methods" do
+    describe "line_diff" do
+      it "reports the line difference as an absolute percentage" do
+        testfile(lines: 1, file: ready_file)
+        testfile(lines: 2, file: loaded_file)
+        expect(rc.line_diff).to eq 0.5
+        # percentage is absolute, i.e. we don't get -0.5 if we flip the counts
+        testfile(lines: 2, file: ready_file)
+        testfile(lines: 1, file: loaded_file)
+        expect(rc.line_diff).to eq 0.5
+      end
     end
-    it "is acceptable if there are files to load and nothing was loaded before" do
-      put_x_lines_in_file(hundo, ready_file)
-      expect(rc.acceptable_diff?).to be true
+
+    describe "ocn_diff" do
+      it "reports the ocn difference as an absolute percentage" do
+        testfile(lines: 1, file: ready_file)
+        testfile(lines: 2, file: loaded_file)
+        expect(rc.ocn_diff).to eq 0.5
+        # percentage is absolute, i.e. we don't get -0.5 if we flip the counts
+        testfile(lines: 2, file: ready_file)
+        testfile(lines: 1, file: loaded_file)
+        expect(rc.ocn_diff).to eq 0.5
+      end
     end
-    it "is acceptable if the line counts are the same" do
-      put_x_lines_in_file(hundo, ready_file)
-      put_x_lines_in_file(hundo, loaded_file)
-      expect(rc.acceptable_diff?).to be true
+
+    describe "#acceptable_diff?" do
+      it "is not acceptable if there are no files to load" do
+        expect(rc.acceptable_diff?).to be false
+      end
+      it "is acceptable if there are files to load and nothing was loaded before" do
+        testfile(lines: hundo, file: ready_file)
+        expect(rc.acceptable_diff?).to be true
+      end
+      it "is acceptable if the line counts are the same" do
+        testfile(lines: hundo, file: ready_file)
+        testfile(lines: hundo, file: loaded_file)
+        expect(rc.acceptable_diff?).to be true
+      end
+      it "is acceptable if the line counts are same-ish" do
+        testfile(lines: hundo, file: ready_file)
+        testfile(lines: hundo - small_diff, file: loaded_file)
+        expect(rc.acceptable_diff?).to be true
+      end
+      it "is not acceptable if the diff is greater than Settings.scrub_line_count_diff_max" do
+        testfile(lines: hundo, file: ready_file)
+        testfile(lines: hundo / small_diff, file: loaded_file)
+        expect(rc.acceptable_diff?).to be false
+      end
+      it "is not acceptable if the diff is greater than scrub_line_count_diff_max, reversed" do
+        testfile(lines: hundo / small_diff, file: ready_file)
+        testfile(lines: hundo, file: loaded_file)
+        expect(rc.acceptable_diff?).to be false
+      end
+      it "is unacceptable if either line_diff or ocn_diff are unacceptable" do
+        array_to_testfile(array: (1..100).to_a, file: loaded_file) # file w/ 100 distinct ocns
+        array_to_testfile(array: [1] * 100, file: ready_file) # file w/ 100 identical ocns
+        expect(rc.acceptable_diff?).to be false
+        expect(rc.line_diff).to eq 0.0
+        expect(rc.ocn_diff).to eq 0.99
+        expect(rc.message).to include(match(/Distinct OCN diff too great/))
+      end
     end
-    it "is acceptable if the line counts are same-ish" do
-      put_x_lines_in_file(hundo, ready_file)
-      put_x_lines_in_file(hundo - small_diff, loaded_file)
-      expect(rc.acceptable_diff?).to be true
+  end
+
+  context "integration test" do
+    require "data_sources/directory_locator"
+    require "scrub/scrub_output_structure"
+    require "scrub/scrub_runner"
+
+    # In sequence:
+    # 1) Try loading 1 small file.
+    # 2) Try loading a significantly larger file  on top of that and get failure.
+    # 3) Try loading it again with --force and get success.
+    let(:loadfile_small) { fixture("umich_mon_full_20220101_ocndiff1.tsv") }
+    let(:small_count) { 6 }
+    let(:loadfile_large) { fixture("umich_mon_full_20220102_ocndiff2.tsv") }
+    let(:large_count) { 13 }
+    let(:local) { DataSources::DirectoryLocator.new(Settings.local_member_data, org) }
+    let(:remote) { DataSources::DirectoryLocator.new(Settings.remote_member_data, org) }
+
+    scrub_options = {"force_holding_loader_cleanup_test" => true}
+    scrub_force_options = scrub_options.merge({"force" => true})
+
+    def get_loaded
+      Clusterable::Holding.for_organization(org)
     end
-    it "is not acceptable if the diff is greater than Settings.scrub_line_count_diff_max" do
-      put_x_lines_in_file(hundo, ready_file)
-      put_x_lines_in_file(hundo / small_diff, loaded_file)
-      expect(rc.acceptable_diff?).to be false
-    end
-    it "is not acceptable if the diff is greater than scrub_line_count_diff_max, reversed" do
-      put_x_lines_in_file(hundo / small_diff, ready_file)
-      put_x_lines_in_file(hundo, loaded_file)
-      expect(rc.acceptable_diff?).to be false
+
+    it "will reject a large diff, unless --force is applied" do
+      local.ensure!
+      remote.ensure!
+
+      # Load a small file, expect a small db count.
+      FileUtils.copy(loadfile_small, remote.holdings_current)
+      scrub_runner = Scrub::ScrubRunner.new(org, scrub_options)
+      scrub_runner.run
+      expect(get_loaded.count).to eq small_count
+
+      # Load a large file on top of that, expect db count to remain small.
+      FileUtils.copy(loadfile_large, remote.holdings_current)
+      scrub_runner = Scrub::ScrubRunner.new(org, scrub_options)
+      scrub_runner.run
+      expect(get_loaded.count).to eq small_count
+      # Check that the scrub log file contains the specific warning we are looking for
+      log_dir_path = Scrub::ScrubOutputStructure.new(org).latest("log").path
+      log_file = Dir.new(log_dir_path).children.first
+      log_file_path = File.join(log_dir_path, log_file)
+      log_file_contents = File.read(log_file_path)
+      expect(log_file_contents).to match(/Line diff too great/)
+      expect(log_file_contents).to match(/Distinct OCN diff too great/)
+      expect(log_file_contents).to match(/This file will not be loaded/)
+
+      # Load large file again with --force and expect db count to be large.
+      FileUtils.copy(loadfile_large, remote.holdings_current)
+      scrub_runner = Scrub::ScrubRunner.new(org, scrub_force_options)
+      scrub_runner.run
+      expect(get_loaded.count).to eq large_count
     end
   end
 end


### PR DESCRIPTION
## Context

`Scrub::RecordCounter` is the class that performs the line-count check between new scrubbed files and old scrubbed files (that have the same `organization` & `mono_multi_serial`) before they are loaded, in order to alert & abort in cases where the absolute change is greater than 5% (or whatever `Settings.scrub_line_count_diff_max` is set to).

This PR adds the ability to compare number of _distinct ocns_ between old & new as well, since that is likely a better predictor of fee change than plain line counts.

For instance: Assume we have already loaded a file with 1000 records of umich spm holdings via `bash phctl.sh scrub ORG`. We should then get alerted & stopped when we next try to load a file with way too few (10) or way too many (100K) holdings. This is the existing functionality.

What is being added in this PR is a similar warning when the number of distinct ocns is way too big or small compared to the most recent set of loaded ocns.

The alert consists of a message of what is wrong, and the file being loaded should be rejected. It should be possible to override and load it anyways by adding `--force` (`bash phctl.sh scrub ORG --force`)