### PR TITLE
 DEV-1639: abort `Scrub::ScrubRunner` if it detects a type mismatch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,4 +337,4 @@ DEPENDENCIES
   zinzout
 
 BUNDLED WITH
-   2.6.2
+   2.6.8

--- a/lib/scrub/member_holding_file.rb
+++ b/lib/scrub/member_holding_file.rb
@@ -17,7 +17,7 @@ module Scrub
   class MemberHoldingFile
     attr_reader :error_count
     # private perhaps?
-    attr_reader :col_map, :member_id, :filename, :filepath
+    attr_reader :col_map, :member_id, :filename, :filepath, :item_type
 
     SPEC_RX = {
       # A single regex for file name pass/fail.

--- a/lib/scrub/type_check_error.rb
+++ b/lib/scrub/type_check_error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Scrub
+  class TypeCheckError < StandardError
+    # When something goes wrong in Scrub::TypeChecker
+  end
+end

--- a/lib/scrub/type_checker.rb
+++ b/lib/scrub/type_checker.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "scrub/type_check_error"
+
+module Scrub
+  class TypeChecker
+    attr_reader :organization, :new_types, :old_types
+
+    def initialize(organization:, new_types: [], old_types: [])
+      @organization = organization
+      @new_types = new_types
+      @old_types = old_types.any? ? old_types : get_old_types
+    end
+
+    def validate
+      # If there are no old types, we'll allow loading any new type(s).
+      return if old_types.empty?
+
+      diff_types = new_types - old_types
+      return if diff_types.empty?
+
+      raise Scrub::TypeCheckError, [
+        "There is a mismatch in item types.",
+        "Previously loaded types: #{old_types.join(", ")}.",
+        "Types being loaded now: #{new_types.join(", ")}.",
+        "The diff is: #{diff_types.join(", ")}.",
+        "This *can* be loaded but requires manual intervention."
+      ].join(" ")
+    end
+
+    private
+
+    def get_old_types
+      Services.holdings_db[:holdings]
+        .where(organization: organization)
+        .select(:mono_multi_serial)
+        .distinct
+        .to_a
+        .map { |hash| hash[:mono_multi_serial] }
+    end
+  end
+end

--- a/spec/scrub/type_checker_spec.rb
+++ b/spec/scrub/type_checker_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "scrub/type_checker"
+require "scrub/type_check_error"
+require "spec_helper"
+
+RSpec.describe Scrub::TypeChecker do
+  include_context "with tables for holdings"
+  let(:org) { "umich" }
+
+  def make(new:, old: [])
+    described_class.new(organization: org, new_types: new, old_types: old)
+  end
+
+  def validate(new:, old: [])
+    make(new: new, old: old).validate
+  end
+
+  describe "#initialize" do
+    it "initializes OK" do
+      expect { make(new: ["spm"], old: ["spm"]) }.not_to raise_error
+    end
+    it "requires required fields" do
+      expect { described_class.new }.to raise_error ArgumentError
+    end
+    it "sets new_types and old_types as given" do
+      type_checker = make(new: ["spm"], old: ["spm", "mpm"])
+      expect(type_checker.new_types).to match_array ["spm"]
+      expect(type_checker.old_types).to match_array ["spm", "mpm"]
+    end
+    it "sets old_types to empty if none given and none in db" do
+      type_checker = make(new: ["spm"])
+      expect(type_checker.old_types).to match_array []
+    end
+    it "sets old_types to whatever distinct types are in the database for org" do
+      types_in_db = ["spm", "mpm", "ser"]
+      types_in_db.each do |type|
+        load_test_data(build(:holding, organization: org, mono_multi_serial: type))
+      end
+      type_checker = make(new: ["spm"])
+      expect(type_checker.old_types).to match_array types_in_db
+    end
+  end
+
+  describe "#validate" do
+    it "validates OK when new == old" do
+      type_checker = make(new: ["spm"], old: ["spm"])
+      expect { type_checker.validate }.not_to raise_error
+    end
+    it "validates OK when old is empty" do
+      new = ["spm"]
+      old = []
+      type_checker = make(new: new, old: old)
+      expect { type_checker.validate }.not_to raise_error
+    end
+    it "validates OK when new is a subset of old" do
+      new = ["spm"]
+      old = ["spm", "mpm", "ser"]
+      type_checker = make(new: new, old: old)
+      expect { type_checker.validate }.not_to raise_error
+    end
+    it "generates a message when validation fails" do
+      type_checker = make(new: ["mix", "ser"], old: ["spm", "mpm", "ser"])
+
+      expect { type_checker.validate }.to raise_error(Scrub::TypeCheckError, /There is a mismatch in item types\..+The diff is: mix\./)
+    end
+    it "refuses if we have mpm, spm, and ser loaded and member submits mon and ser or mix" do
+      old = ["spm", "mpm", "ser"]
+      expect { validate(new: ["mon"], old: old) }.to raise_error(Scrub::TypeCheckError)
+      expect { validate(new: ["mon", "ser"], old: old) }.to raise_error(Scrub::TypeCheckError)
+      expect { validate(new: ["mix"], old: old) }.to raise_error(Scrub::TypeCheckError)
+    end
+    it "refuses if we have mon and ser loaded and member submits mix or mpm/spm/ser" do
+      old = ["mon", "ser"]
+      expect { validate(new: ["mix"], old: old) }.to raise_error(Scrub::TypeCheckError)
+      expect { validate(new: ["mpm"], old: old) }.to raise_error(Scrub::TypeCheckError)
+    end
+    it "refuses if we have mix loaded and member submits mon/ser or mpm/spm/ser" do
+      old = ["mix"]
+      expect { validate(new: ["mon", "ser"], old: old) }.to raise_error(Scrub::TypeCheckError)
+      expect { validate(new: ["mpm", "spm", "ser"], old: old) }.to raise_error(Scrub::TypeCheckError)
+    end
+  end
+end


### PR DESCRIPTION
DEV-1639

This PR adds a new class, `Scrub::TypeChecker`, which checks the `mono_multi_serial` (a.k.a. `item_type`) of files-about-to-be-scrubbed against the holdings already loaded by the same member, and aborts if the types-about-to-be-scrubbed are not a subset of the types already loaded.

It's plugged into `Scrub::ScrubRunner.run`, in order to catch the type mismatch as early as possible. There are no changes needed to `phctl` or sidekiq jobs.

If the `TypeChecker` aborts the `ScrubRunner`, a human will need to intervene... we don't have a good automatic solution.