### PR TITLE
ETT-194: get all holdings on a record given items in JSON form

### DIFF
--- a/spec/api/holdings_api_spec.rb
+++ b/spec/api/holdings_api_spec.rb
@@ -239,25 +239,23 @@ RSpec.describe "HoldingsApi" do
 
     it "given a record with ocns and items, returns holdings for all items in the record" do
       ht1 = build(:ht_item, enum_chron: "v.1", billing_entity: "umich")
-      ht2 = build(:ht_item, ht_bib_key: ht1.ht_bib_key, enum_chron: "v.2", 
-                  ocns: ht1.ocns, billing_entity: "umich")
+      ht2 = build(:ht_item, ht_bib_key: ht1.ht_bib_key, enum_chron: "v.2",
+        ocns: ht1.ocns, billing_entity: "umich")
 
       holding = build(:holding, enum_chron: "v.1", ocn: ht1.ocns.first, organization: "upenn")
       load_test_data(ht1, ht2, holding)
 
       # solr record in the format traject should send it to us
-      solr_record_no_holdings = JSON.parse(solr_response_for(ht1,ht2))["response"]["docs"][0].to_json
-      require "debug"
-      debugger
+      solr_record_no_holdings = solr_docs_for(ht1, ht2)[0].to_json
 
-      post v1(url_template("record_held_by")), solr_record_no_holdings, 'Content-Type' => 'application/json'
+      post base_url + "/" + v1(url_template("record_held_by")), solr_record_no_holdings, "CONTENT_TYPE" => "application/json"
 
       response = JSON.parse(last_response.body)
 
-      ht1_response = response.find { |i| i["item_id"] = ht1.item_id }
-      ht2_response = response.find { |i| i["item_id"] = ht2.item_id }
+      ht1_response = response.find { |i| i["item_id"] == ht1.item_id }
+      ht2_response = response.find { |i| i["item_id"] == ht2.item_id }
 
-      expect(ht1_response["organizations"]).to contain_exactly("umich","upenn")
+      expect(ht1_response["organizations"]).to contain_exactly("umich", "upenn")
       expect(ht2_response["organizations"]).to contain_exactly("umich")
     end
   end

--- a/spec/support/mock_solr_response.rb
+++ b/spec/support/mock_solr_response.rb
@@ -10,18 +10,22 @@ RSpec.shared_context "with mocked solr response" do
       "response" => {
         "numFound" => htitems.count,
         "start" => 0,
-        "docs" => htitems.map do |htitem|
+        "docs" => htitems.group_by(&:ht_bib_key).map do |ht_bib_key, htitems|
+          record_ocns = htitems.collect(&:ocns).flatten.uniq.map(&:to_s)
+
           {
-            "id" => htitem.ht_bib_key,
-            "format" => (htitem.bib_fmt == "SE") ? "Serial" : "Book",
-            "oclc" => htitem.ocns.map(&:to_s),
-            "oclc_search" => htitem.ocns.map(&:to_s),
-            "ht_json" => [
-              "htid" => htitem.item_id,
-              "rights" => [htitem.rights, nil],
-              "enumcron" => htitem.enum_chron,
-              "collection_code" => htitem.collection_code.downcase
-            ].to_json
+            "id" => ht_bib_key,
+            "format" => [(htitems.first.bib_fmt == "SE") ? "Serial" : "Book"],
+            "oclc" => record_ocns,
+            "oclc_search" => record_ocns,
+            "ht_json" => htitems.map do |htitem| 
+              { 
+                "htid" => htitem.item_id,
+                "rights" => [htitem.rights, nil],
+                "enumcron" => htitem.enum_chron,
+                "collection_code" => htitem.collection_code.downcase
+              }
+            end.to_json
           }
         end
       }

--- a/spec/support/mock_solr_response.rb
+++ b/spec/support/mock_solr_response.rb
@@ -3,6 +3,28 @@ RSpec.shared_context "with mocked solr response" do
   # on its own record. This also doesn't account for any concordance info.
   # This isn't the complete response solr actually returns, but it
   # should include everything we use.
+  #
+
+  def solr_docs_for(*htitems)
+    htitems.group_by(&:ht_bib_key).map do |ht_bib_key, htitems|
+      record_ocns = htitems.collect(&:ocns).flatten.uniq.map(&:to_s)
+
+      {
+        "id" => ht_bib_key,
+        "format" => [(htitems.first.bib_fmt == "SE") ? "Serial" : "Book"],
+        "oclc" => record_ocns,
+        "oclc_search" => record_ocns,
+        "ht_json" => htitems.map do |htitem|
+          {
+            "htid" => htitem.item_id,
+            "rights" => [htitem.rights, nil],
+            "enumcron" => htitem.enum_chron,
+            "collection_code" => htitem.collection_code.downcase
+          }
+        end.to_json
+      }
+    end
+  end
 
   def solr_response_for(*htitems)
     {
@@ -10,24 +32,7 @@ RSpec.shared_context "with mocked solr response" do
       "response" => {
         "numFound" => htitems.count,
         "start" => 0,
-        "docs" => htitems.group_by(&:ht_bib_key).map do |ht_bib_key, htitems|
-          record_ocns = htitems.collect(&:ocns).flatten.uniq.map(&:to_s)
-
-          {
-            "id" => ht_bib_key,
-            "format" => [(htitems.first.bib_fmt == "SE") ? "Serial" : "Book"],
-            "oclc" => record_ocns,
-            "oclc_search" => record_ocns,
-            "ht_json" => htitems.map do |htitem| 
-              { 
-                "htid" => htitem.item_id,
-                "rights" => [htitem.rights, nil],
-                "enumcron" => htitem.enum_chron,
-                "collection_code" => htitem.collection_code.downcase
-              }
-            end.to_json
-          }
-        end
+        "docs" => solr_docs_for(*htitems)
       }
     }.to_json
   end


### PR DESCRIPTION
This use is quite coupled to its use from catalog indexing (given that it needs a solr record) but IMO that's OK given the desire for performance in catalog indexing, especially the full reindex. That said, given the coupling that already exists to the catalog and that we already are passing around solr records in holdings, I think it makes sense to do here and doesn't introduce any _new_ coupling.

Next step is to take a look at https://github.com/hathitrust/hathitrust_catalog_indexer/blob/main/lib/ht_traject/ht_print_holdings.rb#L13 and see whether we can in fact generate this partial record format there.