### PR TITLE
ETT-256: log requests to stdout; don't dump exceptions

### DIFF
--- a/lib/api/holdings_api.rb
+++ b/lib/api/holdings_api.rb
@@ -6,6 +6,9 @@ require "solr_record"
 
 class HoldingsAPI < Sinatra::Base
   set :show_exceptions, ENV["show_sinatra_exceptions"] || false
+  set :logging, true
+  set :dump_errors, false
+
   no_matching_data_error = {"application_error" => "no matching data"}.to_json
 
   get "/v1/ping" do


### PR DESCRIPTION
This enables logging for general requests and suppresses backtraces (which previously were saved even in our `error` handlers)

It might still be nice to have backtraces for "unexpected" errors, but I think it isn't critical, and the error does still get logged (just not the full backtrace)