### PR TITLE
ETT-183: mapto_instid

### DIFF
--- a/spec/fixtures/organizations.rb
+++ b/spec/fixtures/organizations.rb
@@ -5,8 +5,9 @@
 # true.
 
 def mock_organizations
-  mock = lambda do |inst, country, weight, sym, status = true|
+  mock = lambda do |inst, country, weight, sym, status = true, mapto_inst = inst|
     DataSources::HTOrganization.new(
+      mapto_inst_id: mapto_inst,
       inst_id: inst,
       country_code: country,
       weight: weight,
@@ -19,8 +20,8 @@ def mock_organizations
     "upenn" => mock.call("upenn", "us", 1.0, "PAU"),
     "umich" => mock.call("umich", "us", 1.0, "EYM"),
     "smu" => mock.call("smu", "us", 1.0, "ISM"),
-    "stanford" => mock.call("stanford", "us", 1.0, "STF"),
-    "ualberta" => mock.call("ualberta", "ca", 1.0, "UAB"),
+    "stanford" => mock.call("stanford", "us", 1.0, "STF", true, "stanford_mapped"),
+    "ualberta" => mock.call("ualberta", "ca", 1.0, "UAB", true, "stanford_mapped"),
     "utexas" => mock.call("utexas", "us", 3.0, "IXA"),
     "hathitrust" => mock.call("hathitrust", "us", 0.0, ""),
     "uct" => mock.call("uct", "za", 0.0, "OI@", false)


### PR DESCRIPTION
When we query for the value in mapto_instid (here, "stanford_mapped"), we should get the holdings for stanford.

We could have some additional tests, e.g:

* we should get the copy count we expect when there are multiple institutions with the same mapto_inst_id