### PR TITLE
Qualify exception classes in concordance processing

### DIFF
--- a/lib/concordance_processing.rb
+++ b/lib/concordance_processing.rb
@@ -24,7 +24,7 @@ class ConcordanceProcessing
       fout.puts [variant, c.canonical_ocn(variant)].join("\t")
       milemarker.increment_and_log_batch_line
       Thread.pass
-    rescue OCNCycleError, MultipleOCNError => e
+    rescue ConcordanceValidation::OCNCycleError, ConcordanceValidation::MultipleOCNError => e
       log.puts e
       log.flush
       next


### PR DESCRIPTION
Adds integration tests that cover this  -- normally I don't really like adding non-happy-path integration tests, but right now these are the only tests that cover ConcordanceProcessing. We could extract these as unit tests in the future, but I think this is the most straightforward for now.