### PR TITLE
ETT-1150: Consistently compute overlap for MPMs

### DIFF
--- a/lib/api/holdings_api.rb
+++ b/lib/api/holdings_api.rb
@@ -53,16 +53,18 @@ class HoldingsAPI < Sinatra::Base
     ht_item = Clusterable::HtItem.find(item_id: item_id)
     cluster = ht_item.cluster
 
-    organizations = case constraint
+    overlaps = Overlap::ClusterOverlap.new(cluster).for_item(ht_item)
+
+    relevant_overlaps = case constraint
     when nil
-      cluster.organizations_in_cluster
+      overlaps
     when "brlm"
-      cluster.access_counts.select { |org, count| count > 0 }.keys.sort
+      overlaps.select { |o| o.access_count > 0 }
     else
       raise ArgumentError, "Invalid constraint."
     end
 
-    return_doc = {"organizations" => organizations}
+    return_doc = {"organizations" => relevant_overlaps.map(&:org)}
     return_doc.to_json
   end
 

--- a/lib/overlap/cluster_overlap.rb
+++ b/lib/overlap/cluster_overlap.rb
@@ -19,14 +19,20 @@ module Overlap
     end
 
     def each
-      return enum_for(:each) unless block_given?
+      return enum_for(__method__) unless block_given?
 
       @cluster.ht_items.each do |ht_item|
-        @orgs.each do |org|
-          overlap = self.class.overlap_record(org, ht_item)
-          if overlap.copy_count.nonzero?
-            yield overlap
-          end
+        for_item(ht_item) { |overlap| yield overlap }
+      end
+    end
+
+    def for_item(ht_item)
+      return enum_for(__method__, ht_item) unless block_given?
+
+      @orgs.each do |org|
+        overlap = self.class.overlap_record(org, ht_item)
+        if overlap.copy_count.nonzero?
+          yield overlap
         end
       end
     end

--- a/lib/overlap/ht_item_overlap.rb
+++ b/lib/overlap/ht_item_overlap.rb
@@ -17,16 +17,7 @@ module Overlap
 
     # Find all organization with holdings that match the given ht_item
     def organizations_with_holdings
-      if @cluster.format != "mpm"
-        # all orgs with a holding hold every spm or ser in cluster
-        (@cluster.org_enums.keys + [@ht_item.billing_entity]).uniq
-      else
-
-        # ht_items match on enum and holdings without enum
-        (@cluster.holding_enum_orgs[""] +
-         @cluster.holding_enum_orgs[@ht_item.n_enum] +
-         @cluster.organizations_with_holdings_but_no_matches + [@ht_item.billing_entity]).uniq
-      end
+      ClusterOverlap.new(@cluster).for_item(@ht_item).map(&:org)
     end
 
     # Find all *members* with holdings that match the given ht_item

--- a/lib/overlap/multi_part_overlap.rb
+++ b/lib/overlap/multi_part_overlap.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "overlap/overlap"
 
 module Overlap
@@ -29,12 +27,28 @@ module Overlap
 
     def matching_holdings
       @matching_holdings ||= @cluster.holdings_by_org[@org]
-        &.select { |h| h.n_enum == @ht_item.n_enum || h.n_enum.nil? || h.n_enum == "" }
+        &.select do |h|
+          matching_enum?(h) || empty_enum?(h) || no_matches_for_holding_org?(h)
+        end
       @matching_holdings ||= []
     end
 
     def matching_count
       matching_holdings.count
+    end
+
+    private
+
+    def matching_enum?(holding)
+      holding.n_enum == @ht_item.n_enum
+    end
+
+    def empty_enum?(holding)
+      holding.n_enum.nil? || holding.n_enum == ""
+    end
+
+    def no_matches_for_holding_org?(holding)
+      @cluster.organizations_with_holdings_but_no_matches.include?(holding.organization)
     end
   end
 end

--- a/spec/api/holdings_api_spec.rb
+++ b/spec/api/holdings_api_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe HoldingsAPI do
   let(:ocn2) { [123, 456] }
   let(:enum_chron) { "v.1-5 (1901-1905)" }
   let(:n_enum) { "1-5" }
-  let(:htitem_2) { build(:ht_item, :mpm, item_id: item_id_2, ocns: ocn2, enum_chron: enum_chron) }
+  let(:htitem_2) { build(:ht_item, :mpm, item_id: item_id_2, ocns: ocn2, enum_chron: enum_chron, billing_entity: "upenn") }
 
   # ht_item 3 is an spm with 3 ocns
   let(:item_id_3) { "test.123456789" }
@@ -114,7 +114,7 @@ RSpec.describe HoldingsAPI do
     it "returns 0 if no holdings (and not depositor)" do
       load_test_data(htitem_1)
       response = parse_response("item_access", item_id: item_id_1, organization: "upenn")
-      expect(response["ocns"]).to eq [ocn]
+      expect(response["ocns"]).to contain_exactly(ocn)
       expect(response["copy_count"]).to eq 0
     end
 
@@ -130,7 +130,7 @@ RSpec.describe HoldingsAPI do
         build(:holding, organization: "umich", ocn: ocn)
       )
       response = parse_response("item_access", item_id: item_id_1, organization: "umich")
-      expect(response["ocns"]).to eq [ocn]
+      expect(response["ocns"]).to contain_exactly(ocn)
       expect(response["copy_count"]).to eq 1
     end
 
@@ -142,7 +142,7 @@ RSpec.describe HoldingsAPI do
         build(:holding, organization: "umich", ocn: ocn)
       )
       response = parse_response("item_access", item_id: item_id_1, organization: "umich")
-      expect(response["ocns"]).to eq [ocn]
+      expect(response["ocns"]).to contain_exactly(ocn)
       expect(response["copy_count"]).to eq 3
     end
 
@@ -155,11 +155,11 @@ RSpec.describe HoldingsAPI do
       )
       # umich, 1 holding
       response = parse_response("item_access", item_id: item_id_1, organization: "umich")
-      expect(response["ocns"]).to eq [ocn]
+      expect(response["ocns"]).to contain_exactly(ocn)
       expect(response["copy_count"]).to eq 1
       # smu, 2 holdings
       response = parse_response("item_access", item_id: item_id_1, organization: "smu")
-      expect(response["ocns"]).to eq [ocn]
+      expect(response["ocns"]).to contain_exactly(ocn)
       expect(response["copy_count"]).to eq 2
     end
 
@@ -169,7 +169,7 @@ RSpec.describe HoldingsAPI do
         build(:holding, organization: "umich", ocn: ocn)
       )
       response = parse_response("item_access", item_id: item_id_3, organization: "smu")
-      expect(response["ocns"]).to eq [123, 456, 789]
+      expect(response["ocns"]).to contain_exactly(123, 456, 789)
     end
 
     it "gets the counts for holdings with ocns matching the item" do
@@ -337,31 +337,55 @@ RSpec.describe HoldingsAPI do
   end
 
   describe "v1/item_held_by" do
-    it "returns an application error if the item_id does not match an ht_item" do
-      response = parse_response("item_held_by", item_id: item_id_1)
-      expect(response["application_error"]).to eq "no matching data"
+    context "spm" do
+      it "returns an application error if the item_id does not match an ht_item" do
+        response = parse_response("item_held_by", item_id: item_id_1)
+        expect(response["application_error"]).to eq "no matching data"
+      end
+
+      it "returns an array with the submitter if no organization has reported holdings matching ht_item" do
+        load_test_data(htitem_1)
+        response = parse_response("item_held_by", item_id: item_id_1)
+        expect(response["organizations"]).to contain_exactly("umich")
+      end
+
+      it "returns an array with the submitter if only submitter has reported holdings matching ht_item" do
+        load_test_data(htitem_1, build(:holding, organization: "umich", ocn: 123))
+        response = parse_response("item_held_by", item_id: item_id_1)
+        expect(response["organizations"]).to contain_exactly("umich")
+      end
+
+      it "returns an array with all organizations with holdings matching ht_item" do
+        load_test_data(
+          htitem_1,
+          build(:holding, organization: "umich", ocn: ocn),
+          build(:holding, organization: "smu", ocn: ocn)
+        )
+        response = parse_response("item_held_by", item_id: item_id_1)
+        expect(response["organizations"]).to contain_exactly("smu", "umich")
+      end
     end
 
-    it "returns an array with the submitter if no organization has reported holdings matching ht_item" do
-      load_test_data(htitem_1)
-      response = parse_response("item_held_by", item_id: item_id_1)
-      expect(response["organizations"]).to eq ["umich"]
-    end
+    context "mpm" do
+      it "reports only those organizations that match the mpm" do
+        load_test_data(
+          htitem_2,
+          build(:holding, organization: "umich", ocn: ocn, enum_chron: "1-5"),
+          build(:holding, organization: "stanford", ocn: ocn, enum_chron: ""),
+          build(:holding, organization: "smu", ocn: ocn, enum_chron: "99")
+        )
+        response = parse_response("item_held_by", item_id: item_id_2)
 
-    it "returns an array with the submitter if only submitter has reported holdings matching ht_item" do
-      load_test_data(htitem_1, build(:holding, organization: "umich", ocn: 123))
-      response = parse_response("item_held_by", item_id: item_id_1)
-      expect(response["organizations"]).to eq ["umich"]
-    end
-
-    it "returns an array with all organizations with holdings matching ht_item" do
-      load_test_data(
-        htitem_1,
-        build(:holding, organization: "umich", ocn: ocn),
-        build(:holding, organization: "smu", ocn: ocn)
-      )
-      response = parse_response("item_held_by", item_id: item_id_1)
-      expect(response["organizations"].sort).to eq ["smu", "umich"]
+        # should include
+        #  * umich (because enumchron matches),
+        #  * upenn (because they deposited the item)
+        #  * stanford (because none of their holdings had enumchron matches, so we consider that all do)
+        #
+        # should NOT include
+        #  * smu (because their enumchron doesn't match)
+        #  * anybody else
+        expect(response["organizations"]).to contain_exactly("stanford", "umich", "upenn")
+      end
     end
   end
 
@@ -401,21 +425,21 @@ RSpec.describe HoldingsAPI do
     it "reports nothing if there are no holdings" do
       load_test_data(htitem_1)
       response = parse_response("item_held_by", item_id: item_id_1, constraint: "brlm")
-      expect(response["organizations"]).to eq []
+      expect(response["organizations"]).to be_empty
     end
 
     it "reports nothing if all holdings are status:CH & condition:''" do
       load_test_data(htitem_1)
       load_test_data(build(:holding, organization: "a", ocn: htitem_1.ocns.first, status: "CH", condition: ""))
       response = parse_response("item_held_by", item_id: item_id_1, constraint: "brlm")
-      expect(response["organizations"]).to eq []
+      expect(response["organizations"]).to be_empty
     end
 
     it "reports nothing if all holdings are status:WD & condition:''" do
       load_test_data(htitem_1)
       load_test_data(build(:holding, organization: "a", ocn: htitem_1.ocns.first, status: "WD", condition: ""))
       response = parse_response("item_held_by", item_id: item_id_1, constraint: "brlm")
-      expect(response["organizations"]).to eq []
+      expect(response["organizations"]).to be_empty
     end
 
     it "reports the organizations with LM holdings" do
@@ -423,7 +447,7 @@ RSpec.describe HoldingsAPI do
       load_test_data(build(:holding, organization: "a", ocn: htitem_1.ocns.first, status: "LM", condition: ""))
       load_test_data(build(:holding, organization: "b", ocn: htitem_1.ocns.first, status: nil, condition: ""))
       response = parse_response("item_held_by", item_id: item_id_1, constraint: "brlm")
-      expect(response["organizations"]).to eq ["a"]
+      expect(response["organizations"]).to contain_exactly("a")
     end
 
     it "reports the organizations with BRT holdings" do
@@ -431,7 +455,7 @@ RSpec.describe HoldingsAPI do
       load_test_data(build(:holding, organization: "a", ocn: htitem_1.ocns.first, status: nil, condition: "BRT"))
       load_test_data(build(:holding, organization: "b", ocn: htitem_1.ocns.first, status: nil, condition: ""))
       response = parse_response("item_held_by", item_id: item_id_1, constraint: "brlm")
-      expect(response["organizations"]).to eq ["a"]
+      expect(response["organizations"]).to contain_exactly("a")
     end
 
     it "reports the organizations with BRT+LM holdings" do
@@ -439,7 +463,7 @@ RSpec.describe HoldingsAPI do
       load_test_data(build(:holding, organization: "a", ocn: htitem_1.ocns.first, status: "LM", condition: "BRT"))
       load_test_data(build(:holding, organization: "b", ocn: htitem_1.ocns.first, status: nil, condition: ""))
       response = parse_response("item_held_by", item_id: item_id_1, constraint: "brlm")
-      expect(response["organizations"]).to eq ["a"]
+      expect(response["organizations"]).to contain_exactly("a")
     end
 
     it "reports all the relevant organizations" do
@@ -449,7 +473,7 @@ RSpec.describe HoldingsAPI do
       load_test_data(build(:holding, organization: "c", ocn: htitem_1.ocns.first, status: "LM", condition: "BRT"))
       load_test_data(build(:holding, organization: "d", ocn: htitem_1.ocns.first, status: "CH", condition: "BRT"))
       response = parse_response("item_held_by", item_id: item_id_1, constraint: "brlm")
-      expect(response["organizations"]).to eq ["a", "b", "c", "d"]
+      expect(response["organizations"]).to contain_exactly("a", "b", "c", "d")
     end
   end
 end

--- a/spec/overlap/ht_item_overlap_spec.rb
+++ b/spec/overlap/ht_item_overlap_spec.rb
@@ -51,6 +51,8 @@ RSpec.describe Overlap::HtItemOverlap do
     describe "#organizations_with_holdings" do
       it "only returns the contributor" do
         ocnless_spm = build(:ht_item, :spm, ocns: [], collection_code: "PU")
+        load_test_data(ocnless_spm)
+
         overlap = described_class.new(ocnless_spm)
         expect(overlap.organizations_with_holdings).to eq(["upenn"])
       end

--- a/spec/workflows/deposit_holdings_analysis_spec.rb
+++ b/spec/workflows/deposit_holdings_analysis_spec.rb
@@ -49,8 +49,21 @@ RSpec.describe Workflows::DepositHoldingsAnalysis do
           expect(analyzer.analyze(ht_item)).to eq(:held)
         end
 
-        it "returns status not held if depositing institution reports holding only copies with different enumchrons" do
-          load_test_data(ht_item, holding_for(ht_item, enum_chron: "volume 99"))
+        it "returns status held if depositing institution reports holding only copies with different enumchrons" do
+          # see multi_part_overlap_spec.rb - case of finding all org holdings
+          # if none of the enums match
+
+          # TODO: may want to specifically analyze this case separately
+          load_test_data(ht_item, holding_for(ht_item, enum_chron: "volume
+99"))
+
+          expect(analyzer.analyze(ht_item)).to eq(:held)
+        end
+
+        it "returns status not held if depositing institution reports holding a copy with enumchron that matches a different item" do
+          load_test_data(ht_item,
+            build(:ht_item, :mpm, ocns: ht_item.ocns, enum_chron: "v.3"),
+            holding_for(ht_item, enum_chron: "v.3"))
 
           expect(analyzer.analyze(ht_item)).to eq(:not_held)
         end


### PR DESCRIPTION
This fixes a bug in the holdings API (where info on `item_held_by` for multiparts was completely wrong) and makes overlap computation for multiparts consistent between the cost report, holdings API, and overlap reports. See notes in the individual commits & inline.

One potential pitfall is that this involves significantly more object creation than the existing method in `HtItemOverlap`. However, it _shouldn't_ involve additional database queries, which is typically the bulk of the time for any operation involving holdings; I think we are already doing a pretty good job of memoizing things in `Cluster` to prevent duplicate computations.

If we see that cost reports, catalog indexing, etc get significantly slower though we can try to do some additional profiling/optimization which could involve changing things that currently use `HtItemOverlap` to instead use `ClusterOverlap` directly, and/or additional caching of `Cluster`s.