### PR TITLE
Add slack notification on successful holdings load

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,7 @@ shared_print_report_path: <%= ENV["SHARED_PRINT_REPORT_PATH"] %>
 shared_print_update_report_path: <%= ENV["SHARED_PRINT_UPDATE_REPORT_PATH"] %>
 target_cost: <%= ENV["TARGET_COST"] %>
 working_path: <%= ENV["WORKING_PATH"] %>
+slack_webhook_url: <%= ENV["SLACK_WEBHOOK_URL"] %>
 solr_data_source:
   milemarker_batch_size: 50000
   solr_results_per_query: 5000

--- a/lib/loader/holding_loader.rb
+++ b/lib/loader/holding_loader.rb
@@ -3,6 +3,7 @@
 require "loader/loaded_file"
 require "scrub/pre_load_backup"
 require "utils/file_transfer"
+require "utils/slack_notifier"
 
 module Loader
   # Constructs batches of Holdings from incoming file data
@@ -91,6 +92,20 @@ module Loader
         organization: options["organization"],
         mono_multi_serial: options["mono_multi_serial"]
       )
+
+      # Count only newly loaded records (delete_flag=0); must run before delete_marked! clears the old ones.
+      new_count = Services.holdings_db[:holdings]
+        .where(organization: options["organization"],
+               mono_multi_serial: options["mono_multi_serial"],
+               delete_flag: 0)
+        .count
+
+      Utils::SlackNotifier.post(
+        "Holdings load complete for *#{options["organization"]}* " \
+        "(`#{options["mono_multi_serial"]}`) — " \
+        "#{new_count} records loaded, #{pre_load_backup.marked_count} old records removed."
+      )
+
       if pre_load_backup.marked_count > 0
         Services.logger.info "deleting old #{options["mono_multi_serial"]} records for #{options["organization"]}"
         pre_load_backup.delete_marked!

--- a/lib/loader/holding_loader.rb
+++ b/lib/loader/holding_loader.rb
@@ -94,10 +94,10 @@ module Loader
       )
 
       # Count only newly loaded records (delete_flag=0); must run before delete_marked! clears the old ones.
-      new_count = Services.holdings_db[:holdings]
+      new_count = Clusterable::Holding.table
         .where(organization: options["organization"],
-               mono_multi_serial: options["mono_multi_serial"],
-               delete_flag: 0)
+          mono_multi_serial: options["mono_multi_serial"],
+          delete_flag: 0)
         .count
 
       Utils::SlackNotifier.post(

--- a/lib/utils/slack_notifier.rb
+++ b/lib/utils/slack_notifier.rb
@@ -5,11 +5,11 @@ require "services"
 
 module Utils
   module SlackNotifier
-    def self.post(message)
-      webhook_url = Settings.slack_webhook_url
-      return unless webhook_url
+    # url kwarg allows injection in tests; defaults to Settings for production use
+    def self.post(message, url: Settings.slack_webhook_url)
+      return unless url
 
-      Faraday.post(webhook_url, {text: message}.to_json, "Content-Type" => "application/json")
+      Faraday.post(url, {text: message}.to_json, "Content-Type" => "application/json")
     rescue => e
       Services.logger.error "SlackNotifier failed: #{e.message}"
     end

--- a/lib/utils/slack_notifier.rb
+++ b/lib/utils/slack_notifier.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "faraday"
+require "services"
+
+module Utils
+  module SlackNotifier
+    def self.post(message)
+      webhook_url = Settings.slack_webhook_url
+      return unless webhook_url
+
+      Faraday.post(webhook_url, {text: message}.to_json, "Content-Type" => "application/json")
+    rescue => e
+      Services.logger.error "SlackNotifier failed: #{e.message}"
+    end
+  end
+end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -251,6 +251,8 @@ RSpec.describe "phctl integration" do
   end
 
   describe "Scrub" do
+    after { Settings.slack_webhook_url = nil }
+
     it "'scrub x' loads records and produces output for org x" do
       # Needs a bit of setup.
       local_d = "#{ENV["TEST_TMP"]}/local_member_data/umich-hathitrust-member-data/print holdings/#{Time.new.year}/"
@@ -266,6 +268,24 @@ RSpec.describe "phctl integration" do
       expect { phctl(*%w[scrub umich --force_holding_loader_cleanup_test --force]) }.to change { Clusterable::Holding.table.count }.by(6)
       expect(File.exist?(logfile)).to be true
       expect(File.exist?(local_d)).to be true
+    end
+
+    it "posts a Slack notification on successful load" do
+      remote_d = "#{ENV["TEST_TMP"]}/remote_member_data/umich-hathitrust-member-data/print holdings/#{Time.new.year}/"
+      FileUtils.mkdir_p(remote_d)
+      FileUtils.cp("spec/fixtures/umich_mon_full_20220101.tsv", remote_d)
+
+      webhook_url = "https://hooks.slack.com/services/TEST/WEBHOOK"
+      Settings.slack_webhook_url = webhook_url
+      slack_stub = stub_request(:post, webhook_url).to_return(status: 200)
+
+      phctl(*%w[scrub umich --force_holding_loader_cleanup_test --force])
+
+      expect(slack_stub).to have_been_requested
+      expect(
+        a_request(:post, webhook_url)
+          .with(body: a_string_including("umich").and(a_string_including("mon")))
+      ).to have_been_made
     end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -251,8 +251,6 @@ RSpec.describe "phctl integration" do
   end
 
   describe "Scrub" do
-    after { Settings.slack_webhook_url = nil }
-
     it "'scrub x' loads records and produces output for org x" do
       # Needs a bit of setup.
       local_d = "#{ENV["TEST_TMP"]}/local_member_data/umich-hathitrust-member-data/print holdings/#{Time.new.year}/"
@@ -270,22 +268,26 @@ RSpec.describe "phctl integration" do
       expect(File.exist?(local_d)).to be true
     end
 
-    it "posts a Slack notification on successful load" do
-      remote_d = "#{ENV["TEST_TMP"]}/remote_member_data/umich-hathitrust-member-data/print holdings/#{Time.new.year}/"
-      FileUtils.mkdir_p(remote_d)
-      FileUtils.cp("spec/fixtures/umich_mon_full_20220101.tsv", remote_d)
+    context "Slack notification" do
+      let(:webhook_url) { "https://hooks.slack.com/services/TEST/WEBHOOK" }
+      # Direct Settings assignment works here because SlackNotifier.post reads
+      # Settings.slack_webhook_url at call time (keyword default), not at load time.
+      before { Settings.slack_webhook_url = webhook_url }
+      after { Settings.slack_webhook_url = nil }
 
-      webhook_url = "https://hooks.slack.com/services/TEST/WEBHOOK"
-      Settings.slack_webhook_url = webhook_url
-      slack_stub = stub_request(:post, webhook_url).to_return(status: 200)
+      it "posts a Slack notification on successful load" do
+        remote_d = "#{ENV["TEST_TMP"]}/remote_member_data/umich-hathitrust-member-data/print holdings/#{Time.new.year}/"
+        FileUtils.mkdir_p(remote_d)
+        FileUtils.cp("spec/fixtures/umich_mon_full_20220101.tsv", remote_d)
+        stub_request(:post, webhook_url).to_return(status: 200)
 
-      phctl(*%w[scrub umich --force_holding_loader_cleanup_test --force])
+        phctl(*%w[scrub umich --force_holding_loader_cleanup_test --force])
 
-      expect(slack_stub).to have_been_requested
-      expect(
-        a_request(:post, webhook_url)
-          .with(body: a_string_including("umich").and(a_string_including("mon")))
-      ).to have_been_made
+        expect(
+          a_request(:post, webhook_url)
+            .with(body: a_string_including("umich").and(a_string_including("mon")))
+        ).to have_been_made
+      end
     end
   end
 end

--- a/spec/utils/slack_notifier_spec.rb
+++ b/spec/utils/slack_notifier_spec.rb
@@ -11,9 +11,6 @@ RSpec.describe Utils::SlackNotifier do
 
   describe ".post" do
     context "when slack_webhook_url is configured" do
-      before { Settings.slack_webhook_url = webhook_url }
-      after  { Settings.slack_webhook_url = nil }
-
       it "POSTs the message as JSON to the webhook URL" do
         stub = stub_request(:post, webhook_url)
           .with(
@@ -22,31 +19,27 @@ RSpec.describe Utils::SlackNotifier do
           )
           .to_return(status: 200)
 
-        described_class.post(message)
+        # url kwarg bypasses Settings/ENV; see SlackNotifier.post signature
+        described_class.post(message, url: webhook_url)
 
         expect(stub).to have_been_requested
       end
     end
 
     context "when slack_webhook_url is nil" do
-      before { Settings.slack_webhook_url = nil }
-
       it "makes no HTTP request" do
-        described_class.post(message)
+        described_class.post(message, url: nil)
 
         expect(a_request(:any, //)).not_to have_been_made
       end
     end
 
     context "when a network error occurs" do
-      before { Settings.slack_webhook_url = webhook_url }
-      after  { Settings.slack_webhook_url = nil }
-
       it "logs the error and does not raise" do
         stub_request(:post, webhook_url).to_raise(Faraday::ConnectionFailed.new("connection refused"))
 
         expect(Services.logger).to receive(:error).with(a_string_matching(/SlackNotifier/))
-        expect { described_class.post(message) }.not_to raise_error
+        expect { described_class.post(message, url: webhook_url) }.not_to raise_error
       end
     end
   end

--- a/spec/utils/slack_notifier_spec.rb
+++ b/spec/utils/slack_notifier_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "utils/slack_notifier"
+require "spec_helper"
+
+# Unit tests for the unconfigured (no webhook URL) and network failure cases —
+# cheaper here than wiring them through the full scrub pipeline in the integration spec.
+RSpec.describe Utils::SlackNotifier do
+  let(:webhook_url) { "https://hooks.slack.com/services/TEST/WEBHOOK/URL" }
+  let(:message) { "Holdings load complete for *umich* (`mon`) — 6 records loaded, 0 old records removed." }
+
+  describe ".post" do
+    context "when slack_webhook_url is configured" do
+      before { Settings.slack_webhook_url = webhook_url }
+      after  { Settings.slack_webhook_url = nil }
+
+      it "POSTs the message as JSON to the webhook URL" do
+        stub = stub_request(:post, webhook_url)
+          .with(
+            body: {text: message}.to_json,
+            headers: {"Content-Type" => "application/json"}
+          )
+          .to_return(status: 200)
+
+        described_class.post(message)
+
+        expect(stub).to have_been_requested
+      end
+    end
+
+    context "when slack_webhook_url is nil" do
+      before { Settings.slack_webhook_url = nil }
+
+      it "makes no HTTP request" do
+        described_class.post(message)
+
+        expect(a_request(:any, //)).not_to have_been_made
+      end
+    end
+
+    context "when a network error occurs" do
+      before { Settings.slack_webhook_url = webhook_url }
+      after  { Settings.slack_webhook_url = nil }
+
+      it "logs the error and does not raise" do
+        stub_request(:post, webhook_url).to_raise(Faraday::ConnectionFailed.new("connection refused"))
+
+        expect(Services.logger).to receive(:error).with(a_string_matching(/SlackNotifier/))
+        expect { described_class.post(message) }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Posts a slack message via incoming webhook when a holdings load completes successfully.

Message format: `Holdings load complete for org (type) - x records loaded, y old records removed`

If the slack webhook url is not set, it will do nothing.

I added an integration test for the success case, and unit tests for the unconfigured (no webhook URL) and network failure cases, since that's cheaper than wiring them through the full scrub pipeline in the integration spec.