### PR TITLE
Use correct logic for getting new record count

### DIFF
--- a/lib/loader/holding_loader.rb
+++ b/lib/loader/holding_loader.rb
@@ -93,12 +93,13 @@ module Loader
         mono_multi_serial: options["mono_multi_serial"]
       )
 
-      # Count only newly loaded records (delete_flag=0); must run before delete_marked! clears the old ones.
-      new_count = Clusterable::Holding.table
+      # Count newly loaded records by subtracting old (delete_flag=1) from total;
+      # must run before delete_marked! clears the old ones.
+      total_count = Clusterable::Holding.table
         .where(organization: options["organization"],
-          mono_multi_serial: options["mono_multi_serial"],
-          delete_flag: 0)
+          mono_multi_serial: options["mono_multi_serial"])
         .count
+      new_count = total_count - pre_load_backup.marked_count
 
       Utils::SlackNotifier.post(
         "Holdings load complete for *#{options["organization"]}* " \

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -285,7 +285,9 @@ RSpec.describe "phctl integration" do
 
         expect(
           a_request(:post, webhook_url)
-            .with(body: a_string_including("umich").and(a_string_including("mon")))
+            .with(body: a_string_including("umich")
+              .and(a_string_including("mon"))
+              .and(a_string_including("6 records loaded")))
         ).to have_been_made
       end
     end


### PR DESCRIPTION
In #425, the logic to get the count for new records was not correct. It assumed that new records have the `delete_flag` set to 0, but the field is not included when writing holdings, so in the DB they are NULL.

The PR fixes the new count by subtracting the number of old records from the total.

Updated a test to verify that it will return 6 records (instead of 0 records in #425).