### PR TITLE
Add Slack notifications for scrub rejection

### DIFF
--- a/lib/scrub/scrub_runner.rb
+++ b/lib/scrub/scrub_runner.rb
@@ -95,6 +95,7 @@ module Scrub
       Services.scrub_logger.error err.message
 
       # MalformedFileError message already contains the filename and diff details; other errors need err.class for triage.
+      # TODO: Consider adding err.class to MalformedFileError's Slack message for consistency with other error types.
       slack_msg = if err.is_a?(MalformedFileError)
         "Holdings scrub rejected for *#{organization}* — #{err.message}"
       else

--- a/lib/scrub/scrub_runner.rb
+++ b/lib/scrub/scrub_runner.rb
@@ -24,6 +24,7 @@ require "sidekiq_jobs"
 require "sidekiq/batch"
 require "utils/file_transfer"
 require "utils/line_counter"
+require "utils/slack_notifier"
 
 # Example:
 # runner = Scrub::ScrubRunner.new(ORG)
@@ -49,7 +50,16 @@ module Scrub
       Services.logger.info "Running org #{organization}."
       new_files = check_new_files
       Services.logger.info "Found #{new_files.size} new files: #{new_files.join(", ")}."
-      check_new_types(new_files) if type_check
+      if type_check
+        begin
+          check_new_types(new_files)
+        rescue Scrub::TypeCheckError => err
+          Utils::SlackNotifier.post(
+            "Holdings scrub rejected for *#{organization}* — #{err.message}"
+          )
+          raise
+        end
+      end
 
       new_files.each do |new_file|
         run_file(new_file)
@@ -83,6 +93,15 @@ module Scrub
       Services.logger.error err
       Services.scrub_logger.error "Unexpected error. Please contact HathiTrust."
       Services.scrub_logger.error err.message
+
+      # MalformedFileError message already contains the filename and diff details; other errors need err.class for triage.
+      slack_msg = if err.is_a?(MalformedFileError)
+        "Holdings scrub rejected for *#{organization}* — #{err.message}"
+      else
+        "Holdings scrub failed for *#{organization}* — " \
+        "`#{member_submitted_file["Name"]}` (#{err.class}): #{err.message}"
+      end
+      Utils::SlackNotifier.post(slack_msg)
 
       # Do things Loader::HoldingLoader::Cleanup normally does
       FileUtils.rm(downloaded_file)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -290,6 +290,34 @@ RSpec.describe "phctl integration" do
               .and(a_string_including("6 records loaded")))
         ).to have_been_made
       end
+
+      it "posts a Slack notification when a file is rejected by the diff check" do
+        remote_d = "#{ENV["TEST_TMP"]}/remote_member_data/umich-hathitrust-member-data/print holdings/#{Time.new.year}/"
+        FileUtils.mkdir_p(remote_d)
+        FileUtils.cp("spec/fixtures/umich_mon_full_20220101.tsv", remote_d)
+
+        loaded_d = "#{ENV["TEST_TMP"]}/scrub_data/umich/loaded"
+        FileUtils.mkdir_p(loaded_d)
+        File.open(File.join(loaded_d, "umich_mon_1.ndj"), "w") { |f| 20.times { |i| f.puts i } }
+
+        stub_request(:post, webhook_url)
+          .with(body: a_string_including("umich")
+            .and(a_string_including("rejected"))
+            .and(a_string_including("Diff too big"))
+            .and(a_string_including("umich_mon_full_20220101.tsv"))
+            .and(a_string_including("Line diff too great")))
+          .to_return(status: 200)
+        phctl(*%w[scrub umich])
+
+        expect(
+          a_request(:post, webhook_url)
+            .with(body: a_string_including("umich")
+              .and(a_string_including("rejected"))
+              .and(a_string_including("Diff too big"))
+              .and(a_string_including("umich_mon_full_20220101.tsv"))
+              .and(a_string_including("Line diff too great")))
+        ).to have_been_made.once
+      end
     end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -269,26 +269,20 @@ RSpec.describe "phctl integration" do
     end
 
     context "Slack notification" do
-      let(:webhook_url) { "https://hooks.slack.com/services/TEST/WEBHOOK" }
-      # Direct Settings assignment works here because SlackNotifier.post reads
-      # Settings.slack_webhook_url at call time (keyword default), not at load time.
-      before { Settings.slack_webhook_url = webhook_url }
-      after { Settings.slack_webhook_url = nil }
+      include_context "with mocked slack API endpoint"
 
       it "posts a Slack notification on successful load" do
         remote_d = "#{ENV["TEST_TMP"]}/remote_member_data/umich-hathitrust-member-data/print holdings/#{Time.new.year}/"
         FileUtils.mkdir_p(remote_d)
         FileUtils.cp("spec/fixtures/umich_mon_full_20220101.tsv", remote_d)
-        stub_request(:post, webhook_url).to_return(status: 200)
+
+        stub = stub_slack_webhook(a_string_including("umich")
+          .and(a_string_including("mon"))
+          .and(a_string_including("6 records loaded")))
 
         phctl(*%w[scrub umich --force_holding_loader_cleanup_test --force])
 
-        expect(
-          a_request(:post, webhook_url)
-            .with(body: a_string_including("umich")
-              .and(a_string_including("mon"))
-              .and(a_string_including("6 records loaded")))
-        ).to have_been_made
+        expect(stub).to have_been_requested.once
       end
 
       it "posts a Slack notification when a file is rejected by the diff check" do
@@ -300,23 +294,14 @@ RSpec.describe "phctl integration" do
         FileUtils.mkdir_p(loaded_d)
         File.open(File.join(loaded_d, "umich_mon_1.ndj"), "w") { |f| 20.times { |i| f.puts i } }
 
-        stub_request(:post, webhook_url)
-          .with(body: a_string_including("umich")
-            .and(a_string_including("rejected"))
-            .and(a_string_including("Diff too big"))
-            .and(a_string_including("umich_mon_full_20220101.tsv"))
-            .and(a_string_including("Line diff too great")))
-          .to_return(status: 200)
+        stub = stub_slack_webhook(a_string_including("umich")
+          .and(a_string_including("rejected"))
+          .and(a_string_including("Diff too big"))
+          .and(a_string_including("umich_mon_full_20220101.tsv"))
+          .and(a_string_including("Line diff too great")))
         phctl(*%w[scrub umich])
 
-        expect(
-          a_request(:post, webhook_url)
-            .with(body: a_string_including("umich")
-              .and(a_string_including("rejected"))
-              .and(a_string_including("Diff too big"))
-              .and(a_string_including("umich_mon_full_20220101.tsv"))
-              .and(a_string_including("Line diff too great")))
-        ).to have_been_made.once
+        expect(stub).to have_been_requested.once
       end
     end
   end

--- a/spec/scrub/scrub_runner_spec.rb
+++ b/spec/scrub/scrub_runner_spec.rb
@@ -16,6 +16,7 @@ require "spec_helper"
 
 RSpec.describe Scrub::ScrubRunner do
   include_context "with tables for holdings"
+  include_context "with mocked slack API endpoint"
 
   let(:org1) { "umich" }
   # Only set force_holding_loader_cleanup_test to true in testing.
@@ -112,13 +113,9 @@ RSpec.describe Scrub::ScrubRunner do
       FileUtils.cp(fixture_file, remote_d.holdings_current)
       load_test_data(build(:holding, organization: org1, mono_multi_serial: "mix"))
 
-      webhook_url = "https://hooks.slack.com/services/TEST/WEBHOOK"
-      allow(Settings).to receive(:slack_webhook_url).and_return(webhook_url)
-      stub = stub_request(:post, webhook_url)
-        .with(body: a_string_including("umich")
-          .and(a_string_including("rejected"))
-          .and(a_string_including("mismatch")))
-        .to_return(status: 200)
+      stub = stub_slack_webhook(a_string_including("umich")
+        .and(a_string_including("rejected"))
+        .and(a_string_including("mismatch")))
 
       expect { sr.run }.to raise_error(Scrub::TypeCheckError)
       expect(stub).to have_been_requested.once
@@ -214,13 +211,9 @@ RSpec.describe Scrub::ScrubRunner do
         1.upto(20) { |i| file.puts i }
       end
 
-      webhook_url = "https://hooks.slack.com/services/TEST/WEBHOOK"
-      allow(Settings).to receive(:slack_webhook_url).and_return(webhook_url)
-      stub = stub_request(:post, webhook_url)
-        .with(body: a_string_including("rejected")
-          .and(a_string_including("umich"))
-          .and(a_string_including("Diff too big")))
-        .to_return(status: 200)
+      stub = stub_slack_webhook(a_string_including("rejected")
+        .and(a_string_including("umich"))
+        .and(a_string_including("Diff too big")))
 
       sr.run_file(remote_file)
       expect(stub).to have_been_requested.once
@@ -234,14 +227,10 @@ RSpec.describe Scrub::ScrubRunner do
 
       allow_any_instance_of(Scrub::RecordCounter).to receive(:acceptable_diff?).and_raise(RuntimeError, "disk full")
 
-      webhook_url = "https://hooks.slack.com/services/TEST/WEBHOOK"
-      allow(Settings).to receive(:slack_webhook_url).and_return(webhook_url)
-      stub = stub_request(:post, webhook_url)
-        .with(body: a_string_including("failed")
-          .and(a_string_including("umich"))
-          .and(a_string_including("RuntimeError"))
-          .and(a_string_including("disk full")))
-        .to_return(status: 200)
+      stub = stub_slack_webhook(a_string_including("failed")
+        .and(a_string_including("umich"))
+        .and(a_string_including("RuntimeError"))
+        .and(a_string_including("disk full")))
 
       sr.run_file(remote_file)
       expect(stub).to have_been_requested.once

--- a/spec/scrub/scrub_runner_spec.rb
+++ b/spec/scrub/scrub_runner_spec.rb
@@ -11,6 +11,7 @@ require "scrub/pre_load_backup"
 require "scrub/record_counter"
 require "scrub/scrub_runner"
 require "scrub/type_check_error"
+require "utils/slack_notifier"
 require "spec_helper"
 
 RSpec.describe Scrub::ScrubRunner do
@@ -105,6 +106,24 @@ RSpec.describe Scrub::ScrubRunner do
       expect { sr.run }.to raise_error(Scrub::TypeCheckError, /There is a mismatch in item types./)
     end
 
+    it "posts a Slack notification on type check rejection" do
+      remote_d = DataSources::DirectoryLocator.new(Settings.remote_member_data, org1)
+      remote_d.ensure!
+      FileUtils.cp(fixture_file, remote_d.holdings_current)
+      load_test_data(build(:holding, organization: org1, mono_multi_serial: "mix"))
+
+      webhook_url = "https://hooks.slack.com/services/TEST/WEBHOOK"
+      allow(Settings).to receive(:slack_webhook_url).and_return(webhook_url)
+      stub = stub_request(:post, webhook_url)
+        .with(body: a_string_including("umich")
+          .and(a_string_including("rejected"))
+          .and(a_string_including("mismatch")))
+        .to_return(status: 200)
+
+      expect { sr.run }.to raise_error(Scrub::TypeCheckError)
+      expect(stub).to have_been_requested.once
+    end
+
     context "with type_check false" do
       # might use this flag if data was partially loaded, or we need to do
       # something manually
@@ -182,6 +201,50 @@ RSpec.describe Scrub::ScrubRunner do
       sr.run_file(remote_file)
       expect(File.exist?(preloader.backup_path)).to be true
       expect(Utils::LineCounter.new(preloader.backup_path).count_lines).to eq 6
+    end
+
+    it "posts a 'rejected' Slack notification on diff limit rejection" do
+      remote_d = DataSources::DirectoryLocator.new(Settings.remote_member_data, org1)
+      remote_d.ensure!
+      FileUtils.cp(fixture_file, remote_d.holdings_current)
+      remote_file = sr.check_new_files.first
+
+      FileUtils.mkdir_p("#{ENV["TEST_TMP"]}/scrub_data/#{org1}/loaded/")
+      File.open("#{ENV["TEST_TMP"]}/scrub_data/#{org1}/loaded/umich_mon_1.ndj", "w") do |file|
+        1.upto(20) { |i| file.puts i }
+      end
+
+      webhook_url = "https://hooks.slack.com/services/TEST/WEBHOOK"
+      allow(Settings).to receive(:slack_webhook_url).and_return(webhook_url)
+      stub = stub_request(:post, webhook_url)
+        .with(body: a_string_including("rejected")
+          .and(a_string_including("umich"))
+          .and(a_string_including("Diff too big")))
+        .to_return(status: 200)
+
+      sr.run_file(remote_file)
+      expect(stub).to have_been_requested.once
+    end
+
+    it "posts a 'failed' Slack notification with error class on unexpected error" do
+      remote_d = DataSources::DirectoryLocator.new(Settings.remote_member_data, org1)
+      remote_d.ensure!
+      FileUtils.cp(fixture_file, remote_d.holdings_current)
+      remote_file = sr.check_new_files.first
+
+      allow_any_instance_of(Scrub::RecordCounter).to receive(:acceptable_diff?).and_raise(RuntimeError, "disk full")
+
+      webhook_url = "https://hooks.slack.com/services/TEST/WEBHOOK"
+      allow(Settings).to receive(:slack_webhook_url).and_return(webhook_url)
+      stub = stub_request(:post, webhook_url)
+        .with(body: a_string_including("failed")
+          .and(a_string_including("umich"))
+          .and(a_string_including("RuntimeError"))
+          .and(a_string_including("disk full")))
+        .to_return(status: 200)
+
+      sr.run_file(remote_file)
+      expect(stub).to have_been_requested.once
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,7 @@ require "fixtures/organizations"
 require_relative "support/cluster_fixture_data"
 require_relative "support/holdings_tables"
 require_relative "support/mock_solr_response"
+require_relative "support/mock_slack_webhook"
 
 SimpleCov::Formatter::LcovFormatter.config do |c|
   c.report_with_single_file = true

--- a/spec/support/mock_slack_webhook.rb
+++ b/spec/support/mock_slack_webhook.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with mocked slack API endpoint" do
+  let(:webhook_url) { "https://hooks.slack.invalid/services/TEST/WEBHOOK" }
+
+  def stub_slack_webhook(body)
+    stub_request(:post, webhook_url)
+      .with(body: body)
+      .to_return(status: 200)
+  end
+
+  around(:each) do |example|
+    old_webhook_url = Settings.slack_webhook_url
+    Settings.slack_webhook_url = webhook_url
+    stub_request(:post, webhook_url).to_return(status: 200)
+    example.run
+    Settings.slack_webhook_url = old_webhook_url
+  end
+end


### PR DESCRIPTION
Follow-up for #425.

Adds failure/rejection notifications:
* `run_file` branches on error type. `MalformedFileError` gets rejected, everything else gets failed.
* `run` wraps `check_new_types` and notifies on `TypeCheckError` before re-raising.

For diff rejections, `err.message` already has filename, percentages, and line counts, so I didn't add a filename prefix.