### PR TITLE
set up vscode dev container with ruby-lsp, debugger, port forwarding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,49 +2,30 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
 {
 	"name": "holdings-backend - dev",
-
-	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
-	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
 	"dockerComposeFile": [
 		"../docker-compose.yml",
 		"docker-compose.yml"
 	],
-
-	// The 'service' property is the name of the service for the container that VS Code should
-	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
 	"service": "dev",
-
-	// The optional 'workspaceFolder' property is the path VS Code should open by default when
-	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
-	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Uncomment the next line if you want start specific services in your Docker Compose config.
-	// "runServices": [],
-
-	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// Match WORKDIR in the Dockerfile so ruby-lsp file URIs and debugger paths align
+	"workspaceFolder": "/usr/src/app",
+	// Forward API and Sidekiq web ports to the host (allows browser access to localhost)
+	"forwardPorts": [
+		4567,
+		9292
+	],
+	// Ensure gems are installed into the gem_cache volume on first container creation
+	"postCreateCommand": "bundle install",
+	// Uncomment to keep containers running after VS Code shuts down.
 	// "shutdownAction": "none",
-
-	// Uncomment the next line to run commands after the container is created.
-	// "postCreateCommand": "cat /etc/os-release",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
 	"customizations": {
 		"vscode": {
-						"extensions": [
-							"ms-azuretools.vscode-docker",
-							"Shopify.ruby-lsp"
-						]
+			"extensions": [
+				"ms-azuretools.vscode-docker",
+				"Shopify.ruby-lsp"
+			]
 		}
-}
-
-	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "devcontainer"
+	}
+	// Uncomment to connect as a non-root user. See: https://aka.ms/dev-containers-non-root
+	// "remoteUser": "holdings"
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {
@@ -12,15 +9,15 @@
     },
     {
       "type": "ruby_lsp",
-      "name": "Debug test",
+      "name": "Debug current spec",
       "request": "launch",
-      "program": "ruby -Itest ${relativeFile}"
-    },
-    {
-      "type": "ruby_lsp",
-      "name": "Debug rspec test",
-      "request": "launch",
-      "program": "rspec ${relativeFile}"
+      "program": "rspec ${relativeFile}",
+      "env": {
+        "DATABASE_ENV": "test",
+        "MARIADB_HOLDINGS_RW_DATABASE": "holdings_test",
+        "MARIADB_HT_RO_DATABASE": "holdings_test",
+        "MARIADB_HATHIFILES_RW_DATABASE": "holdings_test"
+      }
     },
     {
       "type": "ruby_lsp",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "rubyLsp.rubyVersionManager": {
+    "identifier": "none"
+  },
+  "rubyLsp.formatter": "auto",
+  "[ruby]": {
+    "editor.defaultFormatter": "Shopify.ruby-lsp",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true
+  },
+  "files.associations": {
+    "*.ru": "ruby"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -54,3 +54,11 @@ concordance, and running various reports.
 Setting the `DEBUG` environment variable will log more information in reporting about individual data elements as they are processed.
 
 Setting `LOG_SQL` will log each statement run against the database.
+
+## IDE debugging (VS Code)
+
+Requires the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
+
+Open the `holdings-backend/` directory in VS Code. Use the Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) and run `Dev Containers: Reopen in Container`. The dev container installs gems automatically and starts ruby-lsp.
+
+To debug a spec, open the file, set a breakpoint, and run `Debug current spec` from the Run and Debug panel. You can also add `debugger` anywhere in application code to pause there when a spec calls into it.


### PR DESCRIPTION
Sets up vscode devcontainer integration. That way we get syntax support, go to definition, and a working debugger by reopening in the container.

The main issue was that `workspaceFolder` pointed to `/workspaces/holdings-backend` while the container's `WORKDIR` is `/usr/src/app`.

I also added `postCreateCommand: bundle install` and a new `settings.json` telling ruby-lsp to use system Ruby and `standard` as the formatter.

The debug config needs `DATABASE_ENV=test` and the test DB vars set, otherwise the debugger exits immediately with a `DATABASE_ENV must be 'test'` error. I also removed the old "Debug test" config which used minitest syntax and never worked here.

I confirmed that port forwarding for the API server and Sidekiq web UI works in vscode when using dev containers.