### PR TITLE
ETT-434: Don't query holdings for OCN > column max

### DIFF
--- a/lib/clusterable/holding.rb
+++ b/lib/clusterable/holding.rb
@@ -102,12 +102,14 @@ module Clusterable
       dataset.order(:uuid).paged_each(strategy: :filter, &block)
     end
 
-    # ocn column in holdings is defined as int(11)
-    # max ocn is currently 10 digits
-    MAX_OCN_COLUMN_LENGTH = 11
-
     def self.cleaned_stringified_ocns(ocns)
-      ocns.map(&:to_s).reject { |ocn| ocn.length > MAX_OCN_COLUMN_LENGTH }
+      # currently defined as int
+      @table_max_ocn ||= Services.holdings_db.schema("holdings").to_h[:ocn][:max_value]
+
+      ocns
+        .map(&:to_i)
+        .reject { |ocn| ocn > @table_max_ocn }
+        .map(&:to_s)
     end
 
     def self.all

--- a/spec/clusterable/holding_spec.rb
+++ b/spec/clusterable/holding_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Clusterable::Holding do
       expect(described_class.cleaned_stringified_ocns(["123", 456])).to contain_exactly("123", "456")
     end
 
-    it "rejects ocns > 2**31 - 1" do
-      expect(described_class.cleaned_stringified_ocns([123, 2147483648])).to contain_exactly("123")
+    it "rejects ocns > 2**31 - 1 (2147483647)" do
+      expect(described_class.cleaned_stringified_ocns([123, 2147483647, 2147483648])).to contain_exactly("123", "2147483647")
     end
   end
 

--- a/spec/clusterable/holding_spec.rb
+++ b/spec/clusterable/holding_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe Clusterable::Holding do
     expect(holding.n_enum_chron).to eq("")
   end
 
+  describe "#cleaned_stringified_ocns" do
+    it "converts to string" do
+      expect(described_class.cleaned_stringified_ocns([123])).to contain_exactly("123")
+    end
+
+    it "accepts a mix of strings and ints" do
+      expect(described_class.cleaned_stringified_ocns(["123", 456])).to contain_exactly("123", "456")
+    end
+
+    it "rejects ocns > 2**31 - 1" do
+      expect(described_class.cleaned_stringified_ocns([123, 2147483648])).to contain_exactly("123")
+    end
+  end
+
   describe "#batch_add" do
     include_context "with tables for holdings"
 


### PR DESCRIPTION
Symptom:

Determining organizations that hold certain catalog records appear to always cause timeouts when querying the holdings API.

Example records:

https://catalog.hathitrust.org/Record/010642468.marc
https://catalog.hathitrust.org/Record/102308325.marc

Note both have (alleged) OCLC numbers > 2**31 - 1 (2147483647), which is the maximum value for a (default) unsigned integer column mariadb -- for example 6370428317 and 2263684902 respectively, appearing in the 035 field in the MARC record.

When loading holdings, we limit OCLC numbers to the attested current max OCLC number from OCLC, as returned by https://www.oclc.org/apps/oclc/wwg (and queried here in `lib/scrub/max_ocn.rb`).

However, there are some records we get that have these bad OCLC numbers in them.

It appears that due to an issue in MariaDB's query optimizer, if we do a query like:

```sql
select * from holdings where ocn in ('2263684902','263684902')
```

then MariaDB will do inexplicably do a full table scan rather than using the index. (Maybe this is fixed in newer versions of MariaDB; our current version is quite old.)

The fix here is to limit querying for OCNs that are within range for the column type.

(Obviously, the maximum OCLC number could someday exceed 2**31 - 1, in which case we could change the column type, and continue on without even needing to update this.)


