### PR TITLE
ETT-1485: Add estimate notification

### DIFF
--- a/lib/workflows/estimate.rb
+++ b/lib/workflows/estimate.rb
@@ -151,6 +151,13 @@ module Workflows
             "#{num_items_ic} (#{pct_items_ic.round(1)}%) are in copyright."
           ].join("\n")
         end
+
+        Utils::SlackNotifier.post(
+          "Estimate complete for *#{File.basename(ocn_file)}* — " \
+          "#{num_ocns_matched}/#{total_ocns} OCNs matched, " \
+          "#{num_items_ic} IC items, " \
+          "estimated cost *$#{sprintf("%0.2f", total_estimated_ic_cost)}*."
+        )
       end
 
       def pct_ocns_matched

--- a/spec/workflows/estimate_spec.rb
+++ b/spec/workflows/estimate_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe Workflows::Estimate do
           1 (50.0%) are in copyright.
         EOT
       end
+
+      context "Slack notification" do
+        include_context "with mocked slack API endpoint"
+
+        it "posts a notification with the estimate results" do
+          stub = stub_slack_webhook(a_string_including("Estimate complete")
+            .and(a_string_including("ocnfile.txt"))
+            .and(a_string_including("2/4 OCNs matched"))
+            .and(a_string_including("1 IC items"))
+            .and(a_string_including("$5.00")))
+          described_class.new(working_directory: ENV["TEST_TMP"], ocn_file: ocn_file).run
+          expect(stub).to have_been_requested.once
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Adds a Slack notification at the end of the estimate workflow so we know when a cost estimate finishes.

Example notification: `Estimate complete for *ocn_list.txt* — 1/6 OCNs matched, 0 IC items, estimated cost *$0.00*.`