### PR TITLE
Set format explicitly for ht_items in tests when enumchron is specified

### DIFF
--- a/spec/api/holdings_api_spec.rb
+++ b/spec/api/holdings_api_spec.rb
@@ -209,10 +209,9 @@ RSpec.describe HoldingsAPI do
       expect(response["format"]).to eq "mpm"
     end
 
-    # Brittle test?
     it "correctly identifies mpms as not held when not held" do
-      ht1 = build(:ht_item, enum_chron: "v.1", billing_entity: "umich")
-      ht2 = build(:ht_item, enum_chron: "v.2", ocns: ht1.ocns, billing_entity: "umich")
+      ht1 = build(:ht_item, :mpm, enum_chron: "v.1", billing_entity: "umich")
+      ht2 = build(:ht_item, :mpm, enum_chron: "v.2", ocns: ht1.ocns, billing_entity: "umich")
       holding = build(:holding, enum_chron: "v.1", ocn: ht1.ocns.first, organization: "upenn")
       load_test_data(ht1, ht2, holding)
 

--- a/spec/api/holdings_api_spec.rb
+++ b/spec/api/holdings_api_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe HoldingsAPI do
     it "correctly identifies mpms as not held when not held" do
       ht1 = build(:ht_item, :mpm, enum_chron: "v.1", billing_entity: "umich")
       ht2 = build(:ht_item, :mpm, enum_chron: "v.2", ocns: ht1.ocns, billing_entity: "umich")
-      holding = build(:holding, enum_chron: "v.1", ocn: ht1.ocns.first, organization: "upenn")
+      holding = build(:holding, mono_multi_serial: "mpm", enum_chron: "v.1", ocn: ht1.ocns.first, organization: "upenn")
       load_test_data(ht1, ht2, holding)
 
       # as set up above, upenn's holdings matches on ht1 but not on ht2 (different enumchron)
@@ -223,9 +223,9 @@ RSpec.describe HoldingsAPI do
     end
 
     it "treats an empty holdings enum_chron as a wildcard, matches all" do
-      ht1 = build(:ht_item, enum_chron: "v.1", billing_entity: "umich")
-      ht2 = build(:ht_item, enum_chron: "v.2", ocns: ht1.ocns, billing_entity: "umich")
-      holding = build(:holding, enum_chron: "", ocn: ht1.ocns.first, organization: "upenn")
+      ht1 = build(:ht_item, :mpm, enum_chron: "v.1", billing_entity: "umich")
+      ht2 = build(:ht_item, :mpm, enum_chron: "v.2", ocns: ht1.ocns, billing_entity: "umich")
+      holding = build(:holding, mono_multi_serial: "mpm", enum_chron: "", ocn: ht1.ocns.first, organization: "upenn")
       load_test_data(ht1, ht2, holding)
 
       # as set up above, upenn's holdings (empty enumchron) matches on ht1 both ht2
@@ -417,10 +417,10 @@ RSpec.describe HoldingsAPI do
         load_test_data(
           htitem_2,
           build(:ht_item, :mpm, ocns: ocn2, enum_chron: "6"),
-          build(:holding, organization: "umich", ocn: ocn, enum_chron: "1-5"),
-          build(:holding, organization: "stanford", ocn: ocn, enum_chron: ""),
-          build(:holding, organization: "smu", ocn: ocn, enum_chron: "1922-1927"),
-          build(:holding, organization: "ualberta", ocn: ocn, enum_chron: "6")
+          build(:holding, mono_multi_serial: "mpm", organization: "umich", ocn: ocn, enum_chron: "1-5"),
+          build(:holding, mono_multi_serial: "mpm", organization: "stanford", ocn: ocn, enum_chron: ""),
+          build(:holding, mono_multi_serial: "mpm", organization: "smu", ocn: ocn, enum_chron: "1922-1927"),
+          build(:holding, mono_multi_serial: "mpm", organization: "ualberta", ocn: ocn, enum_chron: "6")
         )
         response = parse_response("item_held_by", item_id: item_id_2)
 
@@ -448,7 +448,7 @@ RSpec.describe HoldingsAPI do
       ocn = 123
       ht1 = build(:ht_item, enum_chron: "v.1", bib_fmt: "BK", ocns: [ocn], billing_entity: "umich")
       ht2 = build(:ht_item, ht_bib_key: ht1.ht_bib_key, enum_chron: "v.2", bib_fmt: "BK", ocns: [ocn], billing_entity: "umich")
-      holding = build(:holding, enum_chron: "v.1", ocn: ocn, organization: "upenn")
+      holding = build(:holding, mono_multi_serial: "mpm", enum_chron: "v.1", ocn: ocn, organization: "upenn")
       load_test_data(ht1, ht2, holding)
 
       # solr record in the format traject should send it to us

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -144,9 +144,9 @@ RSpec.describe Cluster do
   end
 
   describe "Precomputed fields" do
-    let(:h1) { build(:holding, ocn: ocn1, enum_chron: "1", organization: "umich") }
-    let(:h2) { build(:holding, ocn: ocn1, enum_chron: "2", organization: "umich") }
-    let(:ht1) { build(:ht_item, ocns: [ocn1], enum_chron: "3", collection_code: "MIU") }
+    let(:h1) { build(:holding, mono_multi_serial: "mpm", ocn: ocn1, enum_chron: "1", organization: "umich") }
+    let(:h2) { build(:holding, mono_multi_serial: "mpm", ocn: ocn1, enum_chron: "2", organization: "umich") }
+    let(:ht1) { build(:ht_item, :mpm, ocns: [ocn1], enum_chron: "3", collection_code: "MIU") }
     let(:cluster) { Cluster.new(ocns: [ocn1]) }
 
     before(:each) do
@@ -183,22 +183,22 @@ RSpec.describe Cluster do
 
     describe "#organizations_with_holdings_but_no_matches" do
       it "is a list of orgs in the cluster that don't match anything" do
-        create(:holding, ocn: ocn1, enum_chron: "4", organization: "ualberta")
+        create(:holding, mono_multi_serial: "mpm", ocn: ocn1, enum_chron: "4", organization: "ualberta")
         expect(cluster.organizations_with_holdings_but_no_matches).to include("ualberta")
       end
 
       it "does not include orgs that do have a match" do
-        matching_holding = create(:holding, ocn: ocn1, enum_chron: "3")
+        matching_holding = create(:holding, mono_multi_serial: "mpm", ocn: ocn1, enum_chron: "3")
         expect(cluster.organizations_with_holdings_but_no_matches).not_to \
           include(matching_holding.organization)
       end
 
       it "DOES NOT include orgs that only have a billing entity match" do
-        ht2 = build(:ht_item, ocns: [ocn1], enum_chron: "5", collection_code: "AEU")
+        ht2 = build(:ht_item, :mpm, ocns: [ocn1], enum_chron: "5", collection_code: "AEU")
         insert_htitem(ht2)
         expect(cluster.organizations_with_holdings_but_no_matches).not_to include("ualberta")
         # but does if they have a non-matching holding
-        create(:holding, ocn: ocn1, enum_chron: "6", organization: "ualberta")
+        create(:holding, mono_multi_serial: "mpm", ocn: ocn1, enum_chron: "6", organization: "ualberta")
         cluster.invalidate_cache
         expect(cluster.organizations_with_holdings_but_no_matches).to include("ualberta")
       end

--- a/spec/clusterable/ht_item_spec.rb
+++ b/spec/clusterable/ht_item_spec.rb
@@ -83,14 +83,14 @@ RSpec.describe Clusterable::HtItem do
   end
 
   it "normalizes enum_chron" do
-    htitem = build(:ht_item, enum_chron: "v.1 Jul 1999")
+    htitem = build(:ht_item, :ser, enum_chron: "v.1 Jul 1999")
     expect(htitem.enum_chron).to eq("v.1 Jul 1999")
     expect(htitem.n_enum).to eq("1")
     expect(htitem.n_chron).to eq("Jul 1999")
   end
 
   it "gives empty string if given an empty enum_chron" do
-    htitem = build(:ht_item, enum_chron: "")
+    htitem = build(:ht_item, :mpm, enum_chron: "")
     expect(htitem.enum_chron).to eq("")
     expect(htitem.n_enum).to eq("")
     expect(htitem.n_chron).to eq("")

--- a/spec/frequency_table_spec.rb
+++ b/spec/frequency_table_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe FrequencyTable do
         end
         let(:spm_holding) do
           build(:holding,
+            mono_multi_serial: "spm",
             enum_chron: "",
             organization: spm.billing_entity,
             ocn: spm.ocns.first)
@@ -167,7 +168,7 @@ RSpec.describe FrequencyTable do
       end
 
       context "with MPM holding without enum chron" do
-        let(:mpm_wo_ec) { build(:holding, ocn: mpm.ocns.first, organization: "umich") }
+        let(:mpm_wo_ec) { build(:holding, mono_multi_serial: "mpm", ocn: mpm.ocns.first, organization: "umich") }
 
         it "assigns mpm shares to empty enum chron holdings" do
           load_test_data(mpm, mpm_wo_ec)
@@ -179,6 +180,7 @@ RSpec.describe FrequencyTable do
       context "with MPM holding with the wrong enum_chron" do
         let(:mpm_wrong_ec) do
           build(:holding,
+            mono_multi_serial: "mpm",
             ocn: mpm.ocns.first,
             organization: "umich",
             enum_chron: "2",
@@ -214,6 +216,7 @@ RSpec.describe FrequencyTable do
         end
         let(:holding_serial) do
           build(:holding,
+            mono_multi_serial: "ser",
             ocn: ht_serial.ocns.first,
             organization: "smu")
         end

--- a/spec/overlap/cluster_overlap_spec.rb
+++ b/spec/overlap/cluster_overlap_spec.rb
@@ -6,7 +6,7 @@ require "overlap/cluster_overlap"
 RSpec.describe Overlap::ClusterOverlap do
   include_context "with tables for holdings"
 
-  let(:spm) { build(:ht_item, enum_chron: "", billing_entity: "upenn") }
+  let(:spm) { build(:ht_item, :spm, enum_chron: "", billing_entity: "upenn") }
   let(:ocns) { spm.ocns }
   let(:cluster) { Cluster.for_ocns(ocns) }
   let(:holding) { build(:holding, ocn: ocns.first, organization: "umich") }

--- a/spec/overlap/multi_part_overlap_spec.rb
+++ b/spec/overlap/multi_part_overlap_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Overlap::MultiPartOverlap do
 
   let(:holding_with_enumchron) do
     build(:holding,
+      mono_multi_serial: "mpm",
       ocn: ocns.first,
       organization: "umich",
       enum_chron: "1")
@@ -42,6 +43,7 @@ RSpec.describe Overlap::MultiPartOverlap do
 
   let(:holding_lost_missing) do
     build(:holding,
+      mono_multi_serial: "mpm",
       ocn: ocns.first,
       organization: holding_with_enumchron.organization,
       enum_chron: "1",
@@ -50,6 +52,7 @@ RSpec.describe Overlap::MultiPartOverlap do
 
   let(:holding_brittle_withdrawn) do
     build(:holding,
+      mono_multi_serial: "mpm",
       ocn: ocns.first,
       organization: holding_with_enumchron.organization,
       enum_chron: "1",
@@ -70,14 +73,14 @@ RSpec.describe Overlap::MultiPartOverlap do
     end
 
     it "finds holdings with no enum" do
-      holding_without_enumchron = create(:holding, ocn: c.ocns.first, enum_chron: "", n_enum: "")
+      holding_without_enumchron = create(:holding, mono_multi_serial: "mpm", ocn: c.ocns.first, enum_chron: "", n_enum: "")
       overlap = described_class.new(holding_without_enumchron.organization, htitem_with_enumchron)
       expect(overlap.matching_holdings).to be_a(Enumerable)
       expect(overlap.matching_holdings.count).to eq(1)
     end
 
     it "finds holdings with nil enum" do
-      holding_nil_enumchron = create(:holding, ocn: c.ocns.first, enum_chron: "", n_enum: nil)
+      holding_nil_enumchron = create(:holding, mono_multi_serial: "mpm", ocn: c.ocns.first, enum_chron: "", n_enum: nil)
       overlap = described_class.new(holding_nil_enumchron.organization, htitem_with_enumchron)
       expect(overlap.matching_holdings).to be_a(Enumerable)
       expect(overlap.matching_holdings.count).to eq(1)
@@ -110,8 +113,8 @@ RSpec.describe Overlap::MultiPartOverlap do
       # differently from the institution reported holdings, so we assume they
       # hold them all.
 
-      create(:holding, organization: "smu", ocn: c.ocns.first, enum_chron: "1863")
-      create(:holding, organization: "smu", ocn: c.ocns.first, enum_chron: "1865")
+      create(:holding, mono_multi_serial: "mpm", organization: "smu", ocn: c.ocns.first, enum_chron: "1863")
+      create(:holding, mono_multi_serial: "mpm", organization: "smu", ocn: c.ocns.first, enum_chron: "1865")
 
       overlap = described_class.new("smu", htitem_with_enumchron)
       expect(overlap.matching_holdings.count).to eq(2)
@@ -122,8 +125,8 @@ RSpec.describe Overlap::MultiPartOverlap do
       # smu reports v.3 and v.5
       # we ask: does smu hold 1? it should not.
 
-      create(:holding, organization: "smu", ocn: c.ocns.first, enum_chron: "v.3")
-      create(:holding, organization: "smu", ocn: c.ocns.first, enum_chron: "v.5")
+      create(:holding, mono_multi_serial: "mpm", organization: "smu", ocn: c.ocns.first, enum_chron: "v.3")
+      create(:holding, mono_multi_serial: "mpm", organization: "smu", ocn: c.ocns.first, enum_chron: "v.5")
 
       overlap = described_class.new("smu", htitem_with_enumchron)
 
@@ -157,7 +160,7 @@ RSpec.describe Overlap::MultiPartOverlap do
     end
 
     it "returns 1 copy if org has a non-matching holding" do
-      nmh = create(:holding, ocn: htitem_with_enumchron.ocns.first, n_enum: "not matched")
+      nmh = create(:holding, mono_multi_serial: "mpm", ocn: htitem_with_enumchron.ocns.first, n_enum: "not matched")
       mpo = described_class.new(nmh.organization, htitem_with_enumchron)
       expect(mpo.copy_count).to be(1)
     end
@@ -187,7 +190,9 @@ RSpec.describe Overlap::MultiPartOverlap do
     end
 
     it "returns false if the member has a non-matching holding" do
-      nmh = create(:holding, organization: "upenn",
+      nmh = create(:holding,
+        mono_multi_serial: "mpm",
+        organization: "upenn",
         ocn: htitem_with_enumchron.ocns.first,
         n_enum: "not matched")
       mpo = described_class.new(nmh.organization, htitem_with_enumchron)

--- a/spec/overlap/single_part_overlap_spec.rb
+++ b/spec/overlap/single_part_overlap_spec.rb
@@ -13,14 +13,15 @@ RSpec.describe Overlap::SinglePartOverlap do
       ocns: ht.ocns,
       collection_code: "MIU")
   end
-  let(:h) { build(:holding, ocn: ht.ocns.first, organization: "umich", status: "LM") }
+  let(:h) { build(:holding, mono_multi_serial: "spm", ocn: ht.ocns.first, organization: "umich", status: "LM") }
   let(:h2) do
     build(:holding,
+      mono_multi_serial: "spm",
       ocn: c.ocns.first,
       organization: "umich",
       condition: "BRT")
   end
-  let(:h3) { build(:holding, ocn: ht.ocns.first, organization: "smu") }
+  let(:h3) { build(:holding, mono_multi_serial: "spm", ocn: ht.ocns.first, organization: "smu") }
 
   before(:each) do
     load_test_data(ht, h, h2, h3)

--- a/spec/reports/cost_report_spec.rb
+++ b/spec/reports/cost_report_spec.rb
@@ -273,17 +273,17 @@ RSpec.describe Reports::CostReport do
         rights: pd
       )
     end
-    let(:holding_serial1) { build(:holding, ocn: ht_serial.ocns.first, organization: "umich") }
-    let(:holding_serial2) { build(:holding, ocn: ht_serial.ocns.first, organization: "utexas") }
+    let(:holding_serial1) { build(:holding, mono_multi_serial: "ser", ocn: ht_serial.ocns.first, organization: "umich") }
+    let(:holding_serial2) { build(:holding, mono_multi_serial: "ser", ocn: ht_serial.ocns.first, organization: "utexas") }
     let(:serial) { build(:serial, ocns: ht_serial.ocns, record_id: ht_serial.ht_bib_key) }
     let(:holding_mpm) do
-      build(:holding, ocn: ht_mpm1.ocns.first, organization: "smu", enum_chron: "", n_enum: "")
+      build(:holding, mono_multi_serial: "mpm", ocn: ht_mpm1.ocns.first, organization: "smu", enum_chron: "", n_enum: "")
     end
     let(:texas_mpm) do
-      build(:holding, ocn: ht_mpm1.ocns.first, organization: "utexas", enum_chron: "1", n_enum: "1")
+      build(:holding, mono_multi_serial: "mpm", ocn: ht_mpm1.ocns.first, organization: "utexas", enum_chron: "1", n_enum: "1")
     end
     let(:umich_mpm) do
-      build(:holding, ocn: ht_mpm1.ocns.first, organization: "umich", enum_chron: "", n_enum: "")
+      build(:holding, mono_multi_serial: "mpm", ocn: ht_mpm1.ocns.first, organization: "umich", enum_chron: "", n_enum: "")
     end
 
     before(:each) do

--- a/spec/workflows/deposit_holdings_analysis_spec.rb
+++ b/spec/workflows/deposit_holdings_analysis_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe Workflows::DepositHoldingsAnalysis do
         let(:ht_item) { build(:ht_item, :mpm, enum_chron: "V.1") }
 
         it "returns status held if depositing institution reports holding a copy with the same enumchron" do
-          load_test_data(ht_item, holding_for(ht_item, enum_chron: "V.1"))
+          load_test_data(ht_item, holding_for(ht_item, mono_multi_serial: "mpm", enum_chron: "V.1"))
 
           expect(analyzer.analyze(ht_item)).to eq(:held)
         end
 
         it "returns status held if depositing institution reports holding only copies with no enumchrons" do
-          load_test_data(ht_item, holding_for(ht_item))
+          load_test_data(ht_item, holding_for(ht_item, mono_multi_serial: "mpm"))
 
           expect(analyzer.analyze(ht_item)).to eq(:held)
         end
@@ -54,8 +54,7 @@ RSpec.describe Workflows::DepositHoldingsAnalysis do
           # if none of the enums match
 
           # TODO: may want to specifically analyze this case separately
-          load_test_data(ht_item, holding_for(ht_item, enum_chron: "volume
-99"))
+          load_test_data(ht_item, holding_for(ht_item, mono_multi_serial: "mpm", enum_chron: "volume 99"))
 
           expect(analyzer.analyze(ht_item)).to eq(:held)
         end
@@ -63,7 +62,7 @@ RSpec.describe Workflows::DepositHoldingsAnalysis do
         it "returns status not held if depositing institution reports holding a copy with enumchron that matches a different item" do
           load_test_data(ht_item,
             build(:ht_item, :mpm, ocns: ht_item.ocns, enum_chron: "v.3"),
-            holding_for(ht_item, enum_chron: "v.3"))
+            holding_for(ht_item, mono_multi_serial: "mpm", enum_chron: "v.3"))
 
           expect(analyzer.analyze(ht_item)).to eq(:not_held)
         end
@@ -86,7 +85,7 @@ RSpec.describe Workflows::DepositHoldingsAnalysis do
         end
 
         it "returns status held if depositing institution reports holding a title" do
-          load_test_data(ht_item, holding_for(ht_item))
+          load_test_data(ht_item, holding_for(ht_item, mono_multi_serial: "spm"))
 
           expect(analyzer.analyze(ht_item)).to eq(:held)
         end
@@ -98,7 +97,7 @@ RSpec.describe Workflows::DepositHoldingsAnalysis do
         end
 
         it "returns status withdrawn if depositing institution only reports holding as withdrawn" do
-          holding = holding_for(ht_item, status: "WD")
+          holding = holding_for(ht_item, mono_multi_serial: "spm", status: "WD")
           load_test_data(ht_item, holding)
 
           expect(analyzer.analyze(ht_item)).to eq(:withdrawn)
@@ -106,15 +105,15 @@ RSpec.describe Workflows::DepositHoldingsAnalysis do
 
         it "returns status held if depositing institution reports holding a withdrawn and a currently-held copy" do
           load_test_data(ht_item,
-            holding_for(ht_item, status: "WD"),
-            holding_for(ht_item, status: "CH"))
+            holding_for(ht_item, mono_multi_serial: "spm", status: "WD"),
+            holding_for(ht_item, mono_multi_serial: "spm", status: "CH"))
 
           expect(analyzer.analyze(ht_item)).to eq(:held)
         end
 
         it "returns status lost_missing if depositing institution only reports holding a lost or missing copy" do
           load_test_data(ht_item,
-            holding_for(ht_item, status: "LM"))
+            holding_for(ht_item, mono_multi_serial: "spm", status: "LM"))
 
           expect(analyzer.analyze(ht_item)).to eq(:lost_missing)
         end
@@ -124,8 +123,8 @@ RSpec.describe Workflows::DepositHoldingsAnalysis do
           # withdrawn copies?
 
           load_test_data(ht_item,
-            holding_for(ht_item, status: "LM"),
-            holding_for(ht_item, status: "WD"))
+            holding_for(ht_item, mono_multi_serial: "spm", status: "LM"),
+            holding_for(ht_item, mono_multi_serial: "spm", status: "WD"))
 
           expect(analyzer.analyze(ht_item)).to eq(:lost_missing)
         end
@@ -137,7 +136,7 @@ RSpec.describe Workflows::DepositHoldingsAnalysis do
         # ualberta doesn't report holding; stanford does
 
         let(:ht_item) { build(:ht_item, :spm, rights: "ic", billing_entity: "ualberta") }
-        let(:holding) { holding_for(ht_item, status: "CH", organization: "stanford") }
+        let(:holding) { holding_for(ht_item, mono_multi_serial: "spm", status: "CH", organization: "stanford") }
 
         before(:each) { load_test_data(ht_item, holding) }
 
@@ -177,8 +176,8 @@ RSpec.describe Workflows::DepositHoldingsAnalysis do
     end
 
     it "includes data for held and not-held in-copyright and icus items" do
-      current_holding = build(:holding, organization: "umich", ocn: "2779601", enum_chron: "v.1")
-      withdrawn_holding = build(:holding, organization: "umich", ocn: "2779601", enum_chron: "v.2", status: "WD")
+      current_holding = build(:holding, mono_multi_serial: "mpm", organization: "umich", ocn: "2779601", enum_chron: "v.1")
+      withdrawn_holding = build(:holding, mono_multi_serial: "mpm", organization: "umich", ocn: "2779601", enum_chron: "v.2", status: "WD")
 
       load_test_data(current_holding, withdrawn_holding)
 


### PR DESCRIPTION
This caused brittle tests, i.e. tests could fail if the format was randomly selected as 'SE' rather than 'BK', enumchron was provided, and we were relying on mpm matching behavior.

This attempts to set format explicitly for all ht_items and holdings when enumchron is specified.

Although it may not be specifically relevant or necessary for all tests, it should make it less confusing to debug issues if the data we load is more reflective of the way it would be in the actual system - i.e. when a holding has enumchron it has format mpm, and when an ht_item has enumchron it's reflected as mpm or ser.

I'm especially not sure about setting for holdings as well as ht_items because there isn't any behavior in the system for matching (so far as I'm aware) that relies on the format given for the holding. However, it is the way the data should be coming in, and should make it less confusing to debug if there are issues in the tests.

