### PR TITLE
ETT-1336 Holdings: scrub should ignore Dropbox subdirectories when lo…

### DIFF
--- a/lib/scrub/scrub_runner.rb
+++ b/lib/scrub/scrub_runner.rb
@@ -173,6 +173,8 @@ module Scrub
       remote_files.each do |f|
         # Possibly filtering other files here.
         next if f["Name"].end_with?(".log")
+        # Ignore subdirectories. We may stash e.g., XML originals in a subdirectory
+        next if f["IsDir"]
         if old_files.select { |oldf| f["Name"] == oldf["Name"] }.empty?
           new_files << f
         end

--- a/spec/scrub/scrub_runner_spec.rb
+++ b/spec/scrub/scrub_runner_spec.rb
@@ -85,6 +85,20 @@ RSpec.describe Scrub::ScrubRunner do
       FileUtils.touch(File.join(remote_d.holdings_current, "b.tsv"))
       expect(sr.check_new_files.first["Name"]).to eq "b.tsv"
     end
+
+    it "ignores subdirectories in the remote current-year holdings directory" do
+      remote_d = DataSources::DirectoryLocator.new(Settings.remote_member_data, org1)
+      remote_d.ensure!
+      # Create subdirectory in the current year's holdings directory.
+      ignore_dir = File.join(remote_d.holdings_current, "xml")
+      FileUtils.mkdir_p(ignore_dir)
+      # It's invisible to ScrubRunner
+      expect(
+        sr.check_new_files.select { |file| file["Name"] == "xml" }
+      ).to be_empty
+      # Clean up
+      FileUtils.rm_rf(ignore_dir)
+    end
   end
 
   describe "#run" do


### PR DESCRIPTION
…oking for TSV files

As mentioned in the originating ticket, we would like to stash originals (like XML that has been converted to TSV) in the yearly (e.g., `/2026`) directory that `ScrubRunner` searches for the latest batch of holdings files. Alas, `ScrubRunner` knows to skip `.log` files but not directories. Hence this additional check.

The result, log files and directories are invisible to scrub runner when it's scanning for current holdings files.

Commenting out the added scrub_runner.rb line 177 will cause the test to fail.
