### PR TITLE
Add slack notification for overlap reports

### DIFF
--- a/lib/workflows/overlap_report.rb
+++ b/lib/workflows/overlap_report.rb
@@ -4,6 +4,7 @@ require "services"
 require "overlap/cluster_overlap"
 require "overlap/report_record"
 require "overlap/report_record_matching_members_count"
+require "utils/slack_notifier"
 require "workflows/solr"
 
 module Workflows
@@ -150,6 +151,7 @@ module Workflows
         gzip_report
         FileUtils.cp(report_gz_path, persistent_report_path)
         system(*rclone_move(report_gz_path, organization))
+        Utils::SlackNotifier.post("Overlap report complete for *#{organization}* — #{report_filename}")
       end
 
       def header

--- a/spec/workflows/overlap_report_spec.rb
+++ b/spec/workflows/overlap_report_spec.rb
@@ -69,6 +69,19 @@ RSpec.describe Workflows::OverlapReport do
 
       expect(open_gz_report("smu").to_a).to eq([writer.header + "\n"])
     end
+
+    context "Slack notification" do
+      include_context "with mocked slack API endpoint"
+
+      it "posts a notification when the report is complete" do
+        writer = writer_for_org("umich")
+        stub = stub_slack_webhook(a_string_including("Overlap report complete")
+          .and(a_string_including("umich"))
+          .and(a_string_including(writer.report_filename)))
+        writer.run
+        expect(stub).to have_been_requested.once
+      end
+    end
   end
 
   describe "integration test with Workflow::MapReduce" do


### PR DESCRIPTION
Posts a Slack notification when the overlap report finishes.

Example message: `Overlap report complete for *umich* — overlap_umich_2026-05-07.tsv.gz`