### PR TITLE
ETT-1487 Add slack notification for cost reports

### DIFF
--- a/lib/reports/cost_report.rb
+++ b/lib/reports/cost_report.rb
@@ -3,6 +3,7 @@
 require "overlap/ht_item_overlap"
 require "frequency_table"
 require "services"
+require "utils/slack_notifier"
 
 # In Aug 2023 we decided that items with rights:icus should behave as if
 # they were access:allow (PD, everybody pay), instead of the traditional
@@ -52,6 +53,14 @@ module Reports
       ymd = Time.new.strftime("%F")
       dump_frequency_table("frequency_#{ymd}.json")
       logger.info "Done"
+
+      Utils::SlackNotifier.post(
+        "Cost report complete — " \
+        "*#{ht_item_count}* volumes, " \
+        "target cost *$#{sprintf("%0.2f", target_cost)}*, " \
+        "cost per volume *$#{sprintf("%0.4f", cost_per_volume)}*, " \
+        "written to *#{File.basename(output_filename)}*."
+      )
     end
 
     def initialize(organization: nil,

--- a/spec/reports/cost_report_spec.rb
+++ b/spec/reports/cost_report_spec.rb
@@ -2,6 +2,8 @@
 
 require "spec_helper"
 require "reports/cost_report"
+require "utils/slack_notifier"
+require "timecop"
 require "data_sources/ht_organizations"
 require "frequency_table"
 
@@ -120,6 +122,27 @@ RSpec.describe Reports::CostReport do
 
       # only one item loaded from upenn -- upenn pays for everything
       expect(cr.total_cost_for_member("upenn")).to eq Settings.target_cost
+    end
+
+    describe "#run slack notification" do
+      include_context "with mocked slack API endpoint"
+
+      it "posts a slack notification when the cost report completes" do
+        ft = FrequencyTable.new
+        load_test_data(spm)
+        ft.add_ht_item(spm)
+        # 1 volume, target cost $10 => cost per volume $10.0000
+        cr = described_class.new(target_cost: 10, precomputed_frequency_table: ft)
+
+        Timecop.freeze(Time.new(2025, 1, 15)) do
+          stub = stub_slack_webhook(
+            a_string_including("Cost report complete — *1* volumes, target cost *$10.00*, cost per volume *$10.0000*, written to *costreport_20250115.tsv*")
+          )
+
+          cr.run
+          expect(stub).to have_been_requested.once
+        end
+      end
     end
 
     it "can use a frequency table file" do


### PR DESCRIPTION
Posts a Slack notification when the cost report finishes.

Example notification: `Cost report complete — *1* volumes, target cost *$10.00*, cost per volume *$10.0000*, written to *costreport_20250115.tsv*.`