### PR TITLE
ETT-1488 Add slack notification for sidekiq failures

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -22,9 +22,7 @@ end
 Sidekiq.configure_server do |config|
   config.redis = Services.redis_config
 
-  config.server_middleware do |chain|
-    chain.add Utils::SidekiqFailureNotifier::Middleware
-  end
+  config.error_handlers << Utils::SidekiqFailureNotifier.method(:on_error)
 
   config.death_handlers << lambda { |job, exception|
     Utils::SlackNotifier.post(

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,6 @@
 require "sidekiq"
 require "services"
+require "utils/sidekiq_failure_notifier"
 
 # Add anything here you need for sidekiq initialization
 
@@ -20,6 +21,17 @@ end
 
 Sidekiq.configure_server do |config|
   config.redis = Services.redis_config
+
+  config.server_middleware do |chain|
+    chain.add Utils::SidekiqFailureNotifier::Middleware
+  end
+
+  config.death_handlers << lambda { |job, exception|
+    Utils::SlackNotifier.post(
+      Utils::SidekiqFailureNotifier.death_message(job, exception),
+      url: Utils::SidekiqFailureNotifier.alerts_url
+    )
+  }
 end
 
 Sidekiq.configure_client do |config|

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,6 +18,7 @@ shared_print_update_report_path: <%= ENV["SHARED_PRINT_UPDATE_REPORT_PATH"] %>
 target_cost: <%= ENV["TARGET_COST"] %>
 working_path: <%= ENV["WORKING_PATH"] %>
 slack_webhook_url: <%= ENV["SLACK_WEBHOOK_URL"] %>
+slack_alerts_webhook_url: <%= ENV["SLACK_ALERTS_WEBHOOK_URL"] %>
 solr_data_source:
   milemarker_batch_size: 50000
   solr_results_per_query: 5000

--- a/lib/utils/sidekiq_failure_notifier.rb
+++ b/lib/utils/sidekiq_failure_notifier.rb
@@ -4,7 +4,7 @@ require "utils/slack_notifier"
 
 module Utils
   module SidekiqFailureNotifier
-    # retry_count is nil on 1st attempt, 0 on 2nd, 1 on 3rd — notify on 3rd failure
+    # retry_count is nil on 1st attempt, 0 on 2nd, 1 on 3rd — notify on 3rd+ failure
     NOTIFY_AT_RETRY_COUNT = 1
 
     def self.alerts_url
@@ -23,18 +23,13 @@ module Utils
         "Error: #{exception.class}: #{exception.message}"
     end
 
-    class Middleware
-      def call(_worker, job, _queue)
-        yield
-      rescue => e
-        if job["retry_count"] == NOTIFY_AT_RETRY_COUNT
-          Utils::SlackNotifier.post(
-            SidekiqFailureNotifier.failure_message(job, e),
-            url: SidekiqFailureNotifier.alerts_url
-          )
-        end
-        raise
-      end
+    def self.on_error(exception, ctx, _config = nil)
+      job = ctx[:job]
+      return unless job && job["retry_count"].to_i >= NOTIFY_AT_RETRY_COUNT
+      Utils::SlackNotifier.post(
+        failure_message(job, exception),
+        url: alerts_url
+      )
     end
   end
 end

--- a/lib/utils/sidekiq_failure_notifier.rb
+++ b/lib/utils/sidekiq_failure_notifier.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "utils/slack_notifier"
+
+module Utils
+  module SidekiqFailureNotifier
+    # retry_count is nil on 1st attempt, 0 on 2nd, 1 on 3rd — notify on 3rd failure
+    NOTIFY_AT_RETRY_COUNT = 1
+
+    def self.alerts_url
+      Settings.slack_alerts_webhook_url
+    end
+
+    def self.failure_message(job, exception)
+      "Sidekiq job failed (will retry): #{job["class"]}\n" \
+        "Args: #{job["args"].inspect}\n" \
+        "Error: #{exception.class}: #{exception.message}"
+    end
+
+    def self.death_message(job, exception)
+      "Sidekiq job failed (no more retries): #{job["class"]}\n" \
+        "Args: #{job["args"].inspect}\n" \
+        "Error: #{exception.class}: #{exception.message}"
+    end
+
+    class Middleware
+      def call(_worker, job, _queue)
+        yield
+      rescue => e
+        if job["retry_count"] == NOTIFY_AT_RETRY_COUNT
+          Utils::SlackNotifier.post(
+            SidekiqFailureNotifier.failure_message(job, e),
+            url: SidekiqFailureNotifier.alerts_url
+          )
+        end
+        raise
+      end
+    end
+  end
+end

--- a/spec/support/mock_slack_webhook.rb
+++ b/spec/support/mock_slack_webhook.rb
@@ -17,3 +17,21 @@ RSpec.shared_context "with mocked slack API endpoint" do
     Settings.slack_webhook_url = old_webhook_url
   end
 end
+
+RSpec.shared_context "with mocked slack alerts endpoint" do
+  let(:alerts_webhook_url) { "https://hooks.slack.invalid/services/TEST/ALERTS_WEBHOOK" }
+
+  def stub_slack_alerts_webhook(body)
+    stub_request(:post, alerts_webhook_url)
+      .with(body: body)
+      .to_return(status: 200)
+  end
+
+  around(:each) do |example|
+    old_alerts_webhook_url = Settings.slack_alerts_webhook_url
+    Settings.slack_alerts_webhook_url = alerts_webhook_url
+    stub_request(:post, alerts_webhook_url).to_return(status: 200)
+    example.run
+    Settings.slack_alerts_webhook_url = old_alerts_webhook_url
+  end
+end

--- a/spec/utils/sidekiq_failure_notifier_spec.rb
+++ b/spec/utils/sidekiq_failure_notifier_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Utils::SidekiqFailureNotifier do
   let(:error) { RuntimeError.new("disk full") }
 
   describe "NOTIFY_AT_RETRY_COUNT" do
-    it "is 1 (triggers on the 3rd failure)" do
+    it "is 1 (triggers on the 3rd failure and beyond)" do
       expect(described_class::NOTIFY_AT_RETRY_COUNT).to eq 1
     end
   end
@@ -38,45 +38,35 @@ RSpec.describe Utils::SidekiqFailureNotifier do
     end
   end
 
-  describe "Middleware" do
-    subject(:middleware) { described_class::Middleware.new }
-
-    def run_middleware(job, &blk)
-      middleware.call(nil, job, "default", &blk)
-    rescue RuntimeError
-      # expected re-raise
-    end
-
-    it "always re-raises the exception" do
-      job = {"class" => "Jobs::Common", "retry_count" => 1}
-      expect {
-        middleware.call(nil, job, "default") { raise error }
-      }.to raise_error(RuntimeError, "disk full")
+  describe ".on_error" do
+    def run_handler(job)
+      described_class.on_error(error, {job: job})
     end
 
     it "does not post to Slack on 1st attempt (retry_count nil)" do
-      run_middleware({"class" => "Jobs::Common", "retry_count" => nil}) { raise error }
+      run_handler({"class" => "Jobs::Common", "retry_count" => nil})
       expect(a_request(:post, alerts_webhook_url)).not_to have_been_made
     end
 
     it "does not post to Slack on 2nd attempt (retry_count 0)" do
-      run_middleware({"class" => "Jobs::Common", "retry_count" => 0}) { raise error }
+      run_handler({"class" => "Jobs::Common", "retry_count" => 0})
       expect(a_request(:post, alerts_webhook_url)).not_to have_been_made
     end
 
-    it "posts to Slack exactly once on 3rd attempt (retry_count 1)" do
+    it "posts to Slack on 3rd attempt (retry_count 1)" do
       stub = stub_request(:post, alerts_webhook_url).to_return(status: 200)
-      run_middleware({"class" => "Jobs::Common", "retry_count" => 1}) { raise error }
+      run_handler({"class" => "Jobs::Common", "retry_count" => 1})
       expect(stub).to have_been_requested.once
     end
 
-    it "does not post to Slack on subsequent retries (retry_count 2+)" do
-      run_middleware({"class" => "Jobs::Common", "retry_count" => 2}) { raise error }
-      expect(a_request(:post, alerts_webhook_url)).not_to have_been_made
+    it "posts to Slack on subsequent retries (retry_count 2+)" do
+      stub = stub_request(:post, alerts_webhook_url).to_return(status: 200)
+      run_handler({"class" => "Jobs::Common", "retry_count" => 2})
+      expect(stub).to have_been_requested.once
     end
 
-    it "does not post to Slack when the job succeeds" do
-      middleware.call(nil, {"class" => "Jobs::Common", "retry_count" => 1}, "default") { nil }
+    it "does not post to Slack when ctx has no job" do
+      described_class.on_error(error, {})
       expect(a_request(:post, alerts_webhook_url)).not_to have_been_made
     end
 
@@ -89,7 +79,7 @@ RSpec.describe Utils::SidekiqFailureNotifier do
       end
 
       it "makes no HTTP request" do
-        run_middleware({"class" => "Jobs::Common", "retry_count" => 1}) { raise error }
+        run_handler({"class" => "Jobs::Common", "retry_count" => 1})
         expect(a_request(:any, //)).not_to have_been_made
       end
     end

--- a/spec/utils/sidekiq_failure_notifier_spec.rb
+++ b/spec/utils/sidekiq_failure_notifier_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "utils/sidekiq_failure_notifier"
+require "spec_helper"
+
+RSpec.describe Utils::SidekiqFailureNotifier do
+  include_context "with mocked slack alerts endpoint"
+
+  let(:error) { RuntimeError.new("disk full") }
+
+  describe "NOTIFY_AT_RETRY_COUNT" do
+    it "is 1 (triggers on the 3rd failure)" do
+      expect(described_class::NOTIFY_AT_RETRY_COUNT).to eq 1
+    end
+  end
+
+  describe ".failure_message" do
+    it "includes will retry notice, job class, args, error class, and message" do
+      job = {"class" => "Jobs::Load::Holdings", "args" => ["/data/umich.ndj"], "retry_count" => 1}
+      msg = described_class.failure_message(job, error)
+      expect(msg).to include("Sidekiq job failed (will retry)")
+      expect(msg).to include("Jobs::Load::Holdings")
+      expect(msg).to include("/data/umich.ndj")
+      expect(msg).to include("RuntimeError")
+      expect(msg).to include("disk full")
+    end
+  end
+
+  describe ".death_message" do
+    it "includes no more retries notice, job class, args, error class, and message" do
+      job = {"class" => "Jobs::Load::Holdings", "args" => ["/data/umich.ndj"], "retry_count" => 24}
+      msg = described_class.death_message(job, error)
+      expect(msg).to include("Sidekiq job failed (no more retries)")
+      expect(msg).to include("Jobs::Load::Holdings")
+      expect(msg).to include("/data/umich.ndj")
+      expect(msg).to include("RuntimeError")
+      expect(msg).to include("disk full")
+    end
+  end
+
+  describe "Middleware" do
+    subject(:middleware) { described_class::Middleware.new }
+
+    def run_middleware(job, &blk)
+      middleware.call(nil, job, "default", &blk)
+    rescue RuntimeError
+      # expected re-raise
+    end
+
+    it "always re-raises the exception" do
+      job = {"class" => "Jobs::Common", "retry_count" => 1}
+      expect {
+        middleware.call(nil, job, "default") { raise error }
+      }.to raise_error(RuntimeError, "disk full")
+    end
+
+    it "does not post to Slack on 1st attempt (retry_count nil)" do
+      run_middleware({"class" => "Jobs::Common", "retry_count" => nil}) { raise error }
+      expect(a_request(:post, alerts_webhook_url)).not_to have_been_made
+    end
+
+    it "does not post to Slack on 2nd attempt (retry_count 0)" do
+      run_middleware({"class" => "Jobs::Common", "retry_count" => 0}) { raise error }
+      expect(a_request(:post, alerts_webhook_url)).not_to have_been_made
+    end
+
+    it "posts to Slack exactly once on 3rd attempt (retry_count 1)" do
+      stub = stub_request(:post, alerts_webhook_url).to_return(status: 200)
+      run_middleware({"class" => "Jobs::Common", "retry_count" => 1}) { raise error }
+      expect(stub).to have_been_requested.once
+    end
+
+    it "does not post to Slack on subsequent retries (retry_count 2+)" do
+      run_middleware({"class" => "Jobs::Common", "retry_count" => 2}) { raise error }
+      expect(a_request(:post, alerts_webhook_url)).not_to have_been_made
+    end
+
+    it "does not post to Slack when the job succeeds" do
+      middleware.call(nil, {"class" => "Jobs::Common", "retry_count" => 1}, "default") { nil }
+      expect(a_request(:post, alerts_webhook_url)).not_to have_been_made
+    end
+
+    context "when slack_alerts_webhook_url is nil" do
+      around do |example|
+        old = Settings.slack_alerts_webhook_url
+        Settings.slack_alerts_webhook_url = nil
+        example.run
+        Settings.slack_alerts_webhook_url = old
+      end
+
+      it "makes no HTTP request" do
+        run_middleware({"class" => "Jobs::Common", "retry_count" => 1}) { raise error }
+        expect(a_request(:any, //)).not_to have_been_made
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds Slack alerts to a separate channel when Sidekiq jobs fail, posting on the 3rd failure and every subsequent retry and again when the job exhausts all retries, with job args included so there's enough context to investigate. The threshold is `NOTIFY_AT_RETRY_COUNT` in `SidekiqFailureNotifier` and `SLACK_ALERTS_WEBHOOK_URL` needs to be set.

Example alert:
```
Sidekiq job failed (will retry): Jobs::Load::Holdings
Args: ["/umich_2024-01-15-120000.ndj"]
Error: Mysql2::Error: Lost connection to MySQL server during query
```