### PR TITLE
ETT-302 clean up "work" directory after workflows complete

### DIFF
--- a/lib/phctl.rb
+++ b/lib/phctl.rb
@@ -105,6 +105,7 @@ module PHCTL
   class Workflow < JobCommand
     class_option :records_per_job, type: :numeric, default: Settings.mapreduce.records_per_job
     class_option :test_mode, type: :boolean, default: false
+    class_option :cleanup, type: :boolean, default: true, desc: "remove intermediate files in work directory on completion"
 
     no_commands do
       def component(...)
@@ -123,6 +124,7 @@ module PHCTL
       def base_params
         {
           records_per_job: options[:records_per_job],
+          cleanup: options[:cleanup],
           test_mode: options[:test_mode]
         }
       end

--- a/lib/workflows/map_reduce.rb
+++ b/lib/workflows/map_reduce.rb
@@ -28,9 +28,12 @@ module Workflows
         reducer_params = Jobs.symbolize(options["params"])
         reducer.new(**reducer_params).run
 
-        # Don't delete intermediate files for now to aid in debugging.
-        # In the future: consider removing by default, but disabling that if a debug flag is present.
-        # FileUtils.remove_entry(options["working_directory"])
+        if options["cleanup"]
+          wd = options["params"]["working_directory"]
+          if wd && File.directory?(wd)
+            FileUtils.remove_entry(wd)
+          end
+        end
       end
     end
 
@@ -40,7 +43,8 @@ module Workflows
       components: {},
       # for testing only; assumes running inline; runs the reduce step
       # immediately
-      test_mode: false
+      test_mode: false,
+      cleanup: true
     )
       if components.keys.to_set != COMPONENT_TYPES
         raise ArgumentError, "Components must be all of #{COMPONENT_TYPES}"
@@ -49,6 +53,7 @@ module Workflows
       @records_per_job = records_per_job
       @inline = false
       @working_directory = working_directory
+      @cleanup = cleanup
       @test_mode = test_mode
 
       yield self if block_given?
@@ -63,7 +68,7 @@ module Workflows
 
     private
 
-    attr_reader :components, :records_per_job, :working_directory, :test_mode
+    attr_reader :cleanup, :components, :records_per_job, :working_directory, :test_mode
 
     COMPONENT_TYPES = [:data_source, :mapper, :reducer].to_set
 
@@ -78,7 +83,8 @@ module Workflows
         component_class: reducer.component_class,
         params: reducer.params.merge(
           working_directory: working_directory
-        )
+        ),
+        cleanup: cleanup
       })
     end
 

--- a/spec/workflows/map_reduce_spec.rb
+++ b/spec/workflows/map_reduce_spec.rb
@@ -73,7 +73,8 @@ RSpec.describe Workflows::MapReduce do
         mapper: WorkflowComponent.new(TestMapper, mapper_params),
         reducer: WorkflowComponent.new(TestReducer)
       },
-      test_mode: true
+      test_mode: true,
+      cleanup: false
     )
   end
 
@@ -148,7 +149,8 @@ RSpec.describe Workflows::MapReduce do
           data_source: WorkflowComponent.new(TestDataSource),
           mapper: WorkflowComponent.new(TestMapper),
           reducer: WorkflowComponent.new(TestReducer)
-        }
+        },
+        cleanup: true # the default
       )
     end
 
@@ -162,9 +164,7 @@ RSpec.describe Workflows::MapReduce do
       expect(File.read(output).strip).to eq(TestDataSource::RECORD_COUNT.to_s)
     end
 
-    # See CostReportWorkflow::Callback -- deleting the intermediate files is currently
-    # not enabled, but we may re-enable that in the future. Re-enable this test at that time.
-    xit "cleans up when cost report completes" do
+    it "cleans up when cost report completes" do
       workflow.run
       expect(File.exist?(@tmpdir)).to be false
     end


### PR DESCRIPTION
- Add `--cleanup` option to `PHCTL::Workflow` defaulting to `true`
- Make sure this option is available to the `Callback`
  - Mostly a matter of uncommenting the old code and accounting for code drift