### PR TITLE
ETT-1447 phctl report costreport should accept ht item count & ht ite…

### DIFF
--- a/lib/phctl.rb
+++ b/lib/phctl.rb
@@ -82,11 +82,13 @@ module PHCTL
   end
 
   class Report < JobCommand
-    desc "costreport (--organization ORG) (--target_cost COST) (--frequency-table /path/to/table.json) (--working-directory /path/to/frequency/tables)", "Run a cost report given existing frequency tables. One of --frequency-table or --working-directory must be provided."
+    desc "costreport (--organization ORG) (--target_cost COST) (--frequency-table /path/to/table.json) (--working-directory /path/to/frequency/tables) (--ht-item-count NUM) (--ht-item-pd-count NUM)", "Run a cost report given existing frequency tables. One of --frequency-table or --working-directory must be provided."
     option :organization, type: :string, default: nil
     option :target_cost, type: :numeric, default: nil
     option :frequency_table, type: :string, default: nil, desc: "The full path to a .json frequency table to use for the report."
     option :working_directory, type: :string, default: nil, desc: "A directory containing .json frequency tables to sum for this cost report."
+    option :ht_item_count, type: :numeric, default: nil
+    option :ht_item_pd_count, type: :numeric, default: nil
     def costreport
       run_common_job(Reports::CostReport, options)
     end

--- a/spec/phctl_spec.rb
+++ b/spec/phctl_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe "PHCTL::PHCTL", type: :sidekiq_fake do
         .to eq(["Reports::CostReport",
           {"frequency_table" => "/path/to/freqtable.json"}])
     end
+
+    it "accepts item and pd counts" do
+      PHCTL::PHCTL.start(["report", "costreport", "--ht_item_count", "2", "--ht_item_pd_count", "1"])
+
+      expect(Jobs::Common.jobs[0]["args"])
+        .to eq(["Reports::CostReport",
+          {"ht_item_count" => 2, "ht_item_pd_count" => 1}])
+    end
   end
 
   xdescribe "running inline" do


### PR DESCRIPTION
…m pd count

- Add `--ht_item_count` and `--ht_pd_item_count` parameters to `phctl report costreport`
- Add test for proper conversion to Integer and inclusion in params
- The ticket notes that writing this information to the frequency table file would be preferable; however, I am a bit leery of introducing a new version of the freqtable file format if not needed. Hence this simplistic solution.