### PR TITLE
ETT-1480 Add scrub without load

### DIFF
--- a/lib/phctl.rb
+++ b/lib/phctl.rb
@@ -209,6 +209,14 @@ module PHCTL
       Scrub::ScrubRunner.new(org, options).run
     end
 
+    desc "scrub_file ORG FILENAME", "Download and scrub a specific file for ORG from Dropbox without loading"
+    def scrub_file(org, filename)
+      Scrub::ScrubRunner.new(org, options).scrub_file(filename)
+    rescue => err
+      warn err.message
+      exit 1
+    end
+
     # report
     desc "report", "Generate a report"
     subcommand "report", Report

--- a/lib/scrub/scrub_runner.rb
+++ b/lib/scrub/scrub_runner.rb
@@ -66,6 +66,17 @@ module Scrub
       end
     end
 
+    def scrub_file(filename)
+      Dir.mktmpdir do |tmp_dir|
+        remote_file = File.join(remote_dir, filename)
+        file_transfer.download(remote_file, tmp_dir)
+        downloaded_file = File.join(tmp_dir, File.basename(filename))
+        scrubber = Scrub::AutoScrub.new(downloaded_file, force)
+        scrubber.run
+        scrubber.out_files
+      end
+    end
+
     def run_file(member_submitted_file)
       Services.logger.info "Running member_submitted_file #{member_submitted_file}"
       downloaded_file = download_to_work_dir(member_submitted_file)

--- a/spec/scrub/scrub_runner_spec.rb
+++ b/spec/scrub/scrub_runner_spec.rb
@@ -10,6 +10,7 @@ require "scrub/autoscrub"
 require "scrub/pre_load_backup"
 require "scrub/record_counter"
 require "scrub/scrub_runner"
+require "scrub/malformed_header_error"
 require "scrub/type_check_error"
 require "utils/slack_notifier"
 require "spec_helper"
@@ -150,6 +151,27 @@ RSpec.describe Scrub::ScrubRunner do
         load_test_data(build(:holding, organization: org1, mono_multi_serial: "ser"))
         expect { sr.run }.to change { Clusterable::Holding.count }.by(6)
       end
+    end
+  end
+
+  describe "#scrub_file" do
+    it "downloads and scrubs a specific file without loading" do
+      remote_d = DataSources::DirectoryLocator.new(Settings.remote_member_data, org1)
+      remote_d.ensure!
+      FileUtils.cp(fixture_file, remote_d.holdings_current)
+      out_files = nil
+      expect { out_files = sr.scrub_file(fixture_file_name) }.not_to change { Clusterable::Holding.count }
+      expect(out_files).not_to be_empty
+      expect(out_files.all? { |f| File.exist?(f) }).to be true
+      # File should still appear as new since the local cache was not touched
+      expect(sr.check_new_files.map { |f| f["Name"] }).to include(fixture_file_name)
+    end
+
+    it "raises on a malformed file" do
+      remote_d = DataSources::DirectoryLocator.new(Settings.remote_member_data, org1)
+      remote_d.ensure!
+      FileUtils.cp(fixture("umich_mon_full_20220101_headerfail.tsv"), remote_d.holdings_current)
+      expect { sr.scrub_file("umich_mon_full_20220101_headerfail.tsv") }.to raise_error(Scrub::MalFormedHeaderError)
     end
   end
 


### PR DESCRIPTION
Adds `phctl scrub_file ORG FILENAME`, a command to download and scrub a specific holdings file from Dropbox without loading it into the database. Useful for inspecting a file before committing to a full `phctl scrub` run.

The implementation adds `ScrubRunner#scrub_file`, which reuses the existing `download_to_work_dir` and `AutoScrub` machinery but stops after scrubbing, returning the output files.

`--force` was intentionally left off this command. `AutoScrub` accepts the parameter but only logs it, it doesn't change behavior, so exposing it would be misleading.