### PR TITLE
Dependency updates for June 2026

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.4 AS base
+FROM ruby:4.0 AS base
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
   nodejs rclone uchardet sqlite3
@@ -10,7 +10,7 @@ ENV RUBYLIB /usr/src/app/lib
 RUN gem install bundler
 
 FROM base AS dev
-RUN apt-get install -yqq --no-install-recommends less entr mariadb-client
+RUN apt-get install -yqq --no-install-recommends less entr mariadb-client libmariadb-dev
 
 FROM base AS prod
 LABEL org.opencontainers.image.source https://github.com/hathitrust/holdings-backend

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,10 @@ GIT
 
 GIT
   remote: https://github.com/hathitrust/hathifiles_database.git
-  revision: aee8dc197927a464f2c2c7c609f52abe33ab9103
+  revision: 5e957ef3e1f04c9aa5e74662a9ffeaa43b9cfc55
   branch: main
   specs:
-    hathifiles_database (0.5.6)
+    hathifiles_database (0.5.7)
       date_named_file
       dotenv
       ettin
@@ -23,17 +23,17 @@ GIT
 
 GIT
   remote: https://github.com/hathitrust/push_metrics.git
-  revision: 3cba728a95eb936fed5f06da028c88d06bb23996
+  revision: 197dacfa9da68059012809cb6108691da7b605f6
   branch: main
   specs:
-    push_metrics (0.10.0)
+    push_metrics (0.10.1)
       milemarker (~> 1.0)
       prometheus-client (~> 4.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2.1)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -50,7 +50,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     canister (0.9.2)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -75,15 +75,15 @@ GEM
     erb (6.0.4)
     ettin (1.3.0)
       deep_merge
-    factory_bot (6.5.6)
+    factory_bot (6.6.0)
       activesupport (>= 6.1.0)
-    faker (3.6.0)
+    faker (3.8.0)
       i18n (>= 1.8.11, < 2)
     faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
@@ -97,18 +97,18 @@ GEM
       rake (~> 13.0)
       zeitwerk (~> 2.6)
     hashdiff (1.2.1)
-    http-2 (1.1.2)
-    httpx (1.7.2)
-      http-2 (>= 1.0.0)
+    http-2 (1.1.3)
+    httpx (1.7.8)
+      http-2 (>= 1.1.3)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    irb (1.17.0)
+    irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.19.5)
+    json (2.19.7)
     language_server-protocol (3.17.0.5)
     library_stdnums (1.6.0)
     lint_roller (1.1.0)
@@ -119,11 +119,10 @@ GEM
     method_source (1.1.0)
     milemarker (1.0.2)
       logger
-    minitest (6.0.2)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    mustermann (3.0.4)
-      ruby2_keywords (~> 0.0.1)
+    mustermann (3.1.1)
     mysql2 (0.5.7)
       bigdecimal
     net-http (0.9.1)
@@ -131,12 +130,14 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.19.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
     pairing_heap (3.1.0)
-    parallel (1.27.0)
-    parser (3.3.10.2)
+    parallel (1.28.0)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     pastel (0.8.0)
@@ -155,7 +156,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (7.2.0)
+    puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -171,7 +172,7 @@ GEM
     rackup (2.3.1)
       rack (>= 3)
     rainbow (3.1.1)
-    rake (13.3.1)
+    rake (13.4.2)
     rbs (4.0.2)
       logger
       prism (>= 1.6.0)
@@ -180,13 +181,13 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
-    redis-client (0.26.4)
+    redis-client (0.29.0)
       connection_pool
-    regexp_parser (2.11.3)
+    regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
     rexml (3.4.4)
-    rgl (0.6.6)
+    rgl (0.6.7)
       pairing_heap (>= 0.3, < 4.0)
       rexml (~> 3.2, >= 3.2.4)
       stream (~> 0.5.3)
@@ -219,7 +220,7 @@ GEM
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.0)
+    rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-performance (1.26.1)
@@ -230,22 +231,21 @@ GEM
       language_server-protocol (~> 3.17.0)
       prism (>= 1.2, < 2.0)
       rbs (>= 3, < 5)
-    ruby-lsp-rspec (0.1.28)
+    ruby-lsp-rspec (0.1.29)
       ruby-lsp (~> 0.26.0)
-    ruby-prof (2.0.3)
+    ruby-prof (2.0.4)
       base64
       ostruct
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     securerandom (0.4.1)
-    sequel (5.102.0)
+    sequel (5.104.0)
       bigdecimal
-    sidekiq (8.1.1)
+    sidekiq (8.1.6)
       connection_pool (>= 3.0.0)
       json (>= 2.16.0)
       logger (>= 1.7.0)
       rack (>= 3.2.0)
-      redis-client (>= 0.26.0)
+      redis-client (>= 0.29.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -265,8 +265,9 @@ GEM
       faraday-retry
       httpx
       milemarker
-    sqlite3 (2.9.1-aarch64-linux-gnu)
-    sqlite3 (2.9.1-x86_64-linux-gnu)
+    sqlite3 (2.9.4-aarch64-linux-gnu)
+    sqlite3 (2.9.4-arm64-darwin)
+    sqlite3 (2.9.4-x86_64-linux-gnu)
     standard (1.54.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -279,12 +280,12 @@ GEM
     standard-performance (1.9.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.26.0)
-    stream (0.5.5)
+    stream (0.5.6)
     stringio (3.2.0)
     thor (1.5.0)
     tilt (2.7.0)
-    timecop (0.9.10)
-    trilogy (2.10.0)
+    timecop (0.9.11)
+    trilogy (2.12.5)
       bigdecimal
     tsort (0.2.0)
     tty-color (0.6.0)
@@ -303,17 +304,19 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     uri (1.1.1)
-    webmock (3.26.1)
+    webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     wisper (2.0.1)
-    yard (0.9.42)
-    zeitwerk (2.7.5)
-    zinzout (0.1.1)
+    yard (0.9.44)
+    zeitwerk (2.8.2)
+    zinzout (0.1.3)
+      ostruct
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES
@@ -357,4 +360,4 @@ DEPENDENCIES
   zinzout
 
 BUNDLED WITH
-   2.7.2
+  4.0.12

--- a/lib/scrub/scrub_output_structure.rb
+++ b/lib/scrub/scrub_output_structure.rb
@@ -2,7 +2,6 @@
 
 require "fileutils"
 require "json"
-require "pathname"
 require "services"
 
 module Scrub


### PR DESCRIPTION
- Bump Dockerfile Ruby to 4.0
- `bundle update --bundler`
- Add `libmariadb-dev` so that `mysql2` (a hathifiles-database dependency) can build
- `bundle update`