### PR TITLE
Fix duplicate Slack notifications from overlap report workflow

### DIFF
--- a/lib/workflows/estimate.rb
+++ b/lib/workflows/estimate.rb
@@ -136,6 +136,9 @@ module Workflows
       end
 
       def run(output_filename = report_file(ocn_file))
+        if Dir.glob(File.join(working_directory, "*.estimate.json")).empty?
+          raise "No estimate files found in #{working_directory}"
+        end
         Services.logger.info "Target Cost: #{cost_report.target_cost}"
         Services.logger.info "Cost per volume: #{cost_report.cost_per_volume}"
 
@@ -151,7 +154,6 @@ module Workflows
             "#{num_items_ic} (#{pct_items_ic.round(1)}%) are in copyright."
           ].join("\n")
         end
-
       end
 
       def notify

--- a/lib/workflows/estimate.rb
+++ b/lib/workflows/estimate.rb
@@ -152,6 +152,9 @@ module Workflows
           ].join("\n")
         end
 
+      end
+
+      def notify
         Utils::SlackNotifier.post(
           "Estimate complete for *#{File.basename(ocn_file)}* — " \
           "#{num_ocns_matched}/#{total_ocns} OCNs matched, " \

--- a/lib/workflows/map_reduce.rb
+++ b/lib/workflows/map_reduce.rb
@@ -26,14 +26,21 @@ module Workflows
       def on_success(_status, options)
         reducer = MapReduce.to_class(options["component_class"])
         reducer_params = Jobs.symbolize(options["params"])
-        reducer.new(**reducer_params).run
+        instance = reducer.new(**reducer_params)
+        instance.run
 
         if options["cleanup"]
           wd = options["params"]["working_directory"]
           if wd && File.directory?(wd)
-            FileUtils.remove_entry(wd)
+            begin
+              FileUtils.remove_entry(wd)
+            rescue SystemCallError => e
+              Services.logger.warn("Could not remove working directory #{wd}: #{e.message}")
+            end
           end
         end
+
+        instance.notify if instance.respond_to?(:notify)
       end
     end
 

--- a/lib/workflows/overlap_report.rb
+++ b/lib/workflows/overlap_report.rb
@@ -148,6 +148,9 @@ module Workflows
       end
 
       def run
+        if Dir.glob(File.join(working_directory, "*.overlap.tsv")).empty?
+          raise "No overlap report files found in #{working_directory}"
+        end
         gzip_report
         FileUtils.cp(report_gz_path, persistent_report_path)
         system(*rclone_move(report_gz_path, organization))

--- a/lib/workflows/overlap_report.rb
+++ b/lib/workflows/overlap_report.rb
@@ -151,6 +151,9 @@ module Workflows
         gzip_report
         FileUtils.cp(report_gz_path, persistent_report_path)
         system(*rclone_move(report_gz_path, organization))
+      end
+
+      def notify
         Utils::SlackNotifier.post("Overlap report complete for *#{organization}* — #{report_filename}")
       end
 

--- a/spec/workflows/estimate_spec.rb
+++ b/spec/workflows/estimate_spec.rb
@@ -81,7 +81,9 @@ RSpec.describe Workflows::Estimate do
             .and(a_string_including("2/4 OCNs matched"))
             .and(a_string_including("1 IC items"))
             .and(a_string_including("$5.00")))
-          described_class.new(working_directory: ENV["TEST_TMP"], ocn_file: ocn_file).run
+          writer = described_class.new(working_directory: ENV["TEST_TMP"], ocn_file: ocn_file)
+          writer.run
+          writer.notify
           expect(stub).to have_been_requested.once
         end
       end

--- a/spec/workflows/estimate_spec.rb
+++ b/spec/workflows/estimate_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe Workflows::Estimate do
       end
     end
 
+    it "raises when no estimate files exist in working directory" do
+      Dir.mktmpdir do |tmpdir|
+        writer = described_class.new(working_directory: tmpdir, ocn_file: "/nonexistent/ocnfile.txt")
+        expect { writer.run }.to raise_error(RuntimeError, /No estimate files found/)
+      end
+    end
+
     context "with sample data" do
       # the file name is used to construct the output file, but it shouldn't be
       # read in this step

--- a/spec/workflows/map_reduce_spec.rb
+++ b/spec/workflows/map_reduce_spec.rb
@@ -48,6 +48,10 @@ class TestReducer
       f.puts(output)
     end
   end
+
+  def notify
+    FileUtils.touch("#{ENV["TEST_TMP"]}/mapreduce_notified")
+  end
 end
 
 RSpec.describe Workflows::MapReduce do
@@ -167,6 +171,33 @@ RSpec.describe Workflows::MapReduce do
     it "cleans up when cost report completes" do
       workflow.run
       expect(File.exist?(@tmpdir)).to be false
+    end
+
+    context "notify behavior" do
+      before { FileUtils.rm_f("#{ENV["TEST_TMP"]}/mapreduce_notified") }
+
+      it "calls notify after the workflow completes" do
+        workflow.run
+        expect(File.exist?("#{ENV["TEST_TMP"]}/mapreduce_notified")).to be true
+      end
+
+      it "calls notify and does not raise when cleanup fails" do
+        rescue_wd = Dir.mktmpdir("test-rescue")
+        allow(FileUtils).to receive(:remove_entry).and_call_original
+        allow(FileUtils).to receive(:remove_entry).with(rescue_wd).and_raise(Errno::ENOTEMPTY)
+
+        expect {
+          Workflows::MapReduce::Callback.new.on_success(:success, {
+            "component_class" => "TestReducer",
+            "params" => {"working_directory" => rescue_wd},
+            "cleanup" => true
+          })
+        }.not_to raise_error
+
+        expect(File.exist?("#{ENV["TEST_TMP"]}/mapreduce_notified")).to be true
+      ensure
+        FileUtils.rm_rf(rescue_wd)
+      end
     end
   end
 end

--- a/spec/workflows/overlap_report_spec.rb
+++ b/spec/workflows/overlap_report_spec.rb
@@ -11,6 +11,17 @@ RSpec.describe Workflows::OverlapReport do
       described_class.new(organization: org, working_directory: ENV["TEST_TMP"])
     end
 
+    before(:each) do
+      FileUtils.touch(File.join(ENV["TEST_TMP"], "records_00000.overlap.tsv"))
+    end
+
+    it "raises when no overlap files exist in working directory" do
+      Dir.mktmpdir do |tmpdir|
+        writer = described_class.new(organization: "umich", working_directory: tmpdir)
+        expect { writer.run }.to raise_error(RuntimeError, /No overlap report files found/)
+      end
+    end
+
     describe "#initialize" do
       it "makes directories if they don't exist" do
         expect(File).not_to exist(Settings.overlap_reports_path)

--- a/spec/workflows/overlap_report_spec.rb
+++ b/spec/workflows/overlap_report_spec.rb
@@ -73,12 +73,19 @@ RSpec.describe Workflows::OverlapReport do
     context "Slack notification" do
       include_context "with mocked slack API endpoint"
 
+      it "does not post to Slack during run" do
+        stub = stub_slack_webhook(anything)
+        writer_for_org("umich").run
+        expect(stub).not_to have_been_requested
+      end
+
       it "posts a notification when the report is complete" do
         writer = writer_for_org("umich")
         stub = stub_slack_webhook(a_string_including("Overlap report complete")
           .and(a_string_including("umich"))
           .and(a_string_including(writer.report_filename)))
         writer.run
+        writer.notify
         expect(stub).to have_been_requested.once
       end
     end
@@ -150,6 +157,17 @@ RSpec.describe Workflows::OverlapReport do
         expected_rec = ["2", h2.local_id, h2.mono_multi_serial,
           "", "", "", "", ""].join("\t") + "\n"
         expect(recs).to include(expected_rec)
+      end
+
+      context "Slack notification" do
+        include_context "with mocked slack API endpoint"
+
+        it "posts a notification after the full workflow completes" do
+          stub = stub_slack_webhook(a_string_including("Overlap report complete")
+            .and(a_string_including(h.organization)))
+          workflow_for_org(h.organization).run
+          expect(stub).to have_been_requested.once
+        end
       end
 
       context "using ReportRecord::MatchingMembersCount" do


### PR DESCRIPTION
We got two duplicate "Overlap report complete" Slack messages last week. Traced it to the `on_success` batch callback: `Writer#run` posts to Slack, then cleanup tries `FileUtils.remove_entry` on the working directory, which raised `ENOTEMPTY` from a filesystem race. Sidekiq retried the whole callback, `run` fired again, resulting in the second Slack message.

There are two fixes here with some help from AI.
* First, rescue `SystemCallError` around the cleanup so a race can't crash the callback and trigger a retry.
* Second, moved the Slack post out of `Writer#run` into a `notify` method that the callback calls after cleanup, so the ordering is correct going forward even if cleanup has issues.

Also applied the same split to `Estimate::Writer` since it had the identical pattern and the same risk.

Added tests for the rescue path, that `notify` is called from the callback, that `run` alone doesn't post to Slack, and also added a test that runs the full pipeline in test mode and asserts that exactly one Slack message is sent at the end.