### PR TITLE
ETT-1476 - get item count when starting costreport workflow

### DIFF
--- a/lib/phctl.rb
+++ b/lib/phctl.rb
@@ -124,17 +124,29 @@ module PHCTL
       end
     end
 
-    desc "costreport --ht-item-count NUM --ht-item-pd-count NUM (--chunk-size SIZE)", "Dump records from solr, split into chunks of chunk-size records, generate frequency tables for each chunk, sum the resulting frequency tables, and generate a cost report based on that table."
+    desc "costreport [--ht-item-count NUM --ht-item-pd-count NUM] (--chunk-size SIZE)", "Dump records from solr, split into chunks of chunk-size records, generate frequency tables for each chunk, sum the resulting frequency tables, and generate a cost report based on that table."
     option :ht_item_count, type: :numeric
     option :ht_item_pd_count, type: :numeric
     def costreport_workflow
+      ht_item_count = options[:ht_item_count]
+      ht_item_pd_count = options[:ht_item_pd_count]
+
+      if !ht_item_count || !ht_item_pd_count
+        Services.logger.info("Getting item counts...")
+
+        ht_item_count = Clusterable::HtItem.count
+        Services.logger.info("Num volumes: #{ht_item_count}")
+        ht_item_pd_count = Clusterable::HtItem.pd_count
+        Services.logger.info("Num pd volumes: #{ht_item_pd_count}")
+      end
+
       components = {
         data_source: component(Workflows::CostReport::DataSource),
         mapper: component(Workflows::CostReport::Analyzer),
         reducer: component(Reports::CostReport,
           {
-            ht_item_count: options[:ht_item_count],
-            ht_item_pd_count: options[:ht_item_pd_count]
+            ht_item_count: ht_item_count,
+            ht_item_pd_count: ht_item_pd_count
           })
       }
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -90,12 +90,26 @@ RSpec.describe "phctl integration" do
     include_context "with complete data for one cluster"
 
     it "cost report workflow produces output" do
-      # item counts match what we have in the mock solr response
-      phctl(*%w[workflow costreport --ht-item-count 16 --ht-item-pd-count 5 --test-mode])
+      # item counts match what we specify
+      phctl(*%w[workflow costreport --ht-item-count 999 --ht-item-pd-count 123 --test-mode])
       year = Time.new.year.to_s
 
       costreport = File.read(Dir.glob("#{ENV["TEST_TMP"]}/cost_reports/#{year}/*").first)
-      expect(costreport).to match(/Num volumes: 16/)
+      expect(costreport).to match(/Num volumes: 999/)
+      expect(costreport).to match(/Num pd volumes: 123/)
+    end
+
+    it "cost report workflow produces output without given item count or pd count" do
+      # we start with one pd item from "with complete data for one cluster"; add some more:
+      8.times { insert_htitem(build(:ht_item, rights: "ic")) }
+      4.times { insert_htitem(build(:ht_item, rights: "pd")) }
+
+      phctl(*%w[workflow costreport --test-mode])
+      year = Time.new.year.to_s
+
+      costreport = File.read(Dir.glob("#{ENV["TEST_TMP"]}/cost_reports/#{year}/*").first)
+      # item counts match what we put in hathifiles table
+      expect(costreport).to match(/Num volumes: 13/)
       expect(costreport).to match(/Num pd volumes: 5/)
     end
 


### PR DESCRIPTION
We added this functionality to specify it on DEV-1569 / commit 472dbdc because at the time holdings was only looking at the development hathifiles database. It is now using the production database, so that need goes away.

However, it still seems useful to have it query for item counts up front (rather than when starting the cost report part) because it reduces the window in which rights updates during the process could cause inconsistencies.