### PR TITLE
ETT-1479 Add preflight tooling

### DIFF
--- a/lib/clusterable/holding.rb
+++ b/lib/clusterable/holding.rb
@@ -23,6 +23,16 @@ module Clusterable
       table.count
     end
 
+    def self.count_for_organization(org)
+      table.where(organization: org).count
+    end
+
+    def self.format_counts(org)
+      table.where(organization: org)
+        .group_and_count(:mono_multi_serial)
+        .order(:mono_multi_serial)
+    end
+
     def cluster
       @cluster ||= Cluster.for_ocns([ocn])
     end

--- a/lib/phctl.rb
+++ b/lib/phctl.rb
@@ -1,7 +1,9 @@
 require "thor"
 
 require "alma_holdings"
+require "clusterable/holding"
 require "sidekiq_jobs"
+require "utils/file_transfer"
 require "workflow_component"
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
@@ -193,6 +195,54 @@ module PHCTL
     end
   end
 
+  class Holdings < JobCommand
+    desc "count ORGANIZATION", "Count holdings currently loaded in the database for ORGANIZATION"
+    def count(org)
+      puts Clusterable::Holding.count_for_organization(org)
+    end
+
+    desc "file-count REMOTE_PATH", "Count lines in a remote holdings file via rclone"
+    def file_count(remote_path)
+      puts Utils::FileTransfer.new.cat(remote_path, &:count)
+    end
+
+    desc "file-sample REMOTE_PATH", "Print first N lines of a remote holdings file"
+    option :lines, type: :numeric, default: 50
+    def file_sample(remote_path)
+      Utils::FileTransfer.new.cat(remote_path) do |io|
+        io.each_line.first(options[:lines]).each { |line| print line }
+      end
+    end
+
+    desc "dir-counts REMOTE_DIR", "Count lines in each .tsv file in a remote directory"
+    def dir_counts(remote_dir)
+      ft = Utils::FileTransfer.new
+      tsv_files = ft.lsjson(remote_dir)
+        .reject { |f| f["IsDir"] }
+        .select { |f| f["Name"].end_with?(".tsv") }
+        .sort_by { |f| f["Name"] }
+      total = 0
+      tsv_files.each do |f|
+        count = ft.cat("#{remote_dir}/#{f["Path"]}", &:count)
+        puts "#{f["Name"]}: #{count}"
+        total += count
+      end
+      puts "Total: #{total}"
+    end
+
+    desc "format-counts ORGANIZATION", "Show holdings breakdown by format (mono_multi_serial) for ORGANIZATION"
+    def format_counts(org)
+      rows = Clusterable::Holding.format_counts(org)
+      puts "#{org} holdings by format:"
+      total = 0
+      rows.each do |row|
+        puts "  #{row[:mono_multi_serial]}:  #{row[:count]}"
+        total += row[:count]
+      end
+      puts "Total: #{total}"
+    end
+  end
+
   class PHCTL < Thor
     # Run inline instead of with sidekiq
     class_option :inline, type: :boolean
@@ -254,5 +304,8 @@ module PHCTL
 
     desc "workflow", "Parallelized workflows for generating reports"
     subcommand "workflow", Workflow
+
+    desc "holdings SUBCOMMAND", "Pre-flight inspection of holdings"
+    subcommand "holdings", Holdings
   end
 end

--- a/lib/phctl.rb
+++ b/lib/phctl.rb
@@ -4,6 +4,7 @@ require "alma_holdings"
 require "clusterable/holding"
 require "sidekiq_jobs"
 require "utils/file_transfer"
+require "utils/holdings_preflight"
 require "workflow_component"
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
@@ -196,9 +197,12 @@ module PHCTL
   end
 
   class Holdings < JobCommand
-    desc "count ORGANIZATION", "Count holdings currently loaded in the database for ORGANIZATION"
+    desc "count ORGANIZATION", "Show holdings in the database for ORGANIZATION, broken down by format"
     def count(org)
-      puts Clusterable::Holding.count_for_organization(org)
+      result = Utils::HoldingsPreflight.new.format_counts(org)
+      puts "#{org} holdings by format:"
+      result[:counts].each { |r| puts "  #{r[:format]}:  #{r[:count]}" }
+      puts "Total: #{result[:total]}"
     end
 
     desc "file-count REMOTE_PATH", "Count lines in a remote holdings file via rclone"
@@ -216,30 +220,9 @@ module PHCTL
 
     desc "dir-counts REMOTE_DIR", "Count lines in each .tsv file in a remote directory"
     def dir_counts(remote_dir)
-      ft = Utils::FileTransfer.new
-      tsv_files = ft.lsjson(remote_dir)
-        .reject { |f| f["IsDir"] }
-        .select { |f| f["Name"].end_with?(".tsv") }
-        .sort_by { |f| f["Name"] }
-      total = 0
-      tsv_files.each do |f|
-        count = ft.cat("#{remote_dir}/#{f["Path"]}", &:count)
-        puts "#{f["Name"]}: #{count}"
-        total += count
-      end
-      puts "Total: #{total}"
-    end
-
-    desc "format-counts ORGANIZATION", "Show holdings breakdown by format (mono_multi_serial) for ORGANIZATION"
-    def format_counts(org)
-      rows = Clusterable::Holding.format_counts(org)
-      puts "#{org} holdings by format:"
-      total = 0
-      rows.each do |row|
-        puts "  #{row[:mono_multi_serial]}:  #{row[:count]}"
-        total += row[:count]
-      end
-      puts "Total: #{total}"
+      result = Utils::HoldingsPreflight.new.dir_counts(remote_dir)
+      result[:counts].each { |r| puts "#{r[:name]}: #{r[:count]}" }
+      puts "Total: #{result[:total]}"
     end
   end
 

--- a/lib/utils/file_transfer.rb
+++ b/lib/utils/file_transfer.rb
@@ -47,6 +47,12 @@ module Utils
       raise Utils::FileTransferError, "Could not ls #{remote_dir}... #{err}"
     end
 
+    def cat(remote_path, &block)
+      result = IO.popen(["rclone", "--config", Settings.rclone_config_path, "cat", remote_path], &block)
+      raise Utils::FileTransferError, "rclone cat failed for #{remote_path}" unless $?.success?
+      result
+    end
+
     private
 
     def make_call(sys_call)

--- a/lib/utils/holdings_preflight.rb
+++ b/lib/utils/holdings_preflight.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "clusterable/holding"
+require "utils/file_transfer"
+
+module Utils
+  class HoldingsPreflight
+    def initialize(file_transfer: Utils::FileTransfer.new)
+      @file_transfer = file_transfer
+    end
+
+    def format_counts(org)
+      rows = Clusterable::Holding.format_counts(org)
+      counts = rows.map { |r| {format: r[:mono_multi_serial], count: r[:count]} }
+      {counts: counts, total: counts.sum { |r| r[:count] }}
+    end
+
+    def dir_counts(remote_dir)
+      tsv_files = @file_transfer.lsjson(remote_dir)
+        .reject { |f| f["IsDir"] }
+        .select { |f| f["Name"].end_with?(".tsv") }
+        .sort_by { |f| f["Name"] }
+      counts = tsv_files.map do |f|
+        count = @file_transfer.cat("#{remote_dir}/#{f["Path"]}", &:count)
+        {name: f["Name"], count: count}
+      end
+      {counts: counts, total: counts.sum { |r| r[:count] }}
+    end
+  end
+end

--- a/spec/phctl_spec.rb
+++ b/spec/phctl_spec.rb
@@ -64,10 +64,14 @@ RSpec.describe "PHCTL::PHCTL", type: :sidekiq_fake do
     before { allow(Utils::FileTransfer).to receive(:new).and_return(ft) }
 
     describe "count" do
-      it "prints the holding count for an organization" do
-        allow(Clusterable::Holding).to receive(:count_for_organization).with("umich").and_return(42)
+      it "prints the format breakdown and total for an organization" do
+        rows = [
+          {mono_multi_serial: "spm", count: 1000},
+          {mono_multi_serial: "ser", count: 500}
+        ]
+        allow(Clusterable::Holding).to receive(:format_counts).with("umich").and_return(rows)
         expect { PHCTL::PHCTL.start(["holdings", "count", "umich"]) }
-          .to output("42\n").to_stdout
+          .to output("umich holdings by format:\n  spm:  1000\n  ser:  500\nTotal: 1500\n").to_stdout
       end
     end
 
@@ -113,18 +117,6 @@ RSpec.describe "PHCTL::PHCTL", type: :sidekiq_fake do
         allow(ft).to receive(:lsjson).with("dropbox:some/dir").and_return(files)
         expect { PHCTL::PHCTL.start(["holdings", "dir-counts", "dropbox:some/dir"]) }
           .to output("Total: 0\n").to_stdout
-      end
-    end
-
-    describe "format-counts" do
-      it "prints the format breakdown for an organization" do
-        rows = [
-          {mono_multi_serial: "spm", count: 1000},
-          {mono_multi_serial: "ser", count: 500}
-        ]
-        allow(Clusterable::Holding).to receive(:format_counts).with("umich").and_return(rows)
-        expect { PHCTL::PHCTL.start(["holdings", "format-counts", "umich"]) }
-          .to output("umich holdings by format:\n  spm:  1000\n  ser:  500\nTotal: 1500\n").to_stdout
       end
     end
 

--- a/spec/phctl_spec.rb
+++ b/spec/phctl_spec.rb
@@ -58,6 +58,158 @@ RSpec.describe "PHCTL::PHCTL", type: :sidekiq_fake do
     end
   end
 
+  describe "holdings" do
+    let(:ft) { instance_double(Utils::FileTransfer) }
+
+    before { allow(Utils::FileTransfer).to receive(:new).and_return(ft) }
+
+    describe "count" do
+      it "prints the holding count for an organization" do
+        allow(Clusterable::Holding).to receive(:count_for_organization).with("umich").and_return(42)
+        expect { PHCTL::PHCTL.start(["holdings", "count", "umich"]) }
+          .to output("42\n").to_stdout
+      end
+    end
+
+    describe "file-count" do
+      it "prints the line count of a remote file" do
+        allow(ft).to receive(:cat)
+          .with("dropbox:some/file.tsv")
+          .and_yield(StringIO.new("line1\nline2\nline3\n"))
+        expect { PHCTL::PHCTL.start(["holdings", "file-count", "dropbox:some/file.tsv"]) }
+          .to output("3\n").to_stdout
+      end
+    end
+
+    describe "dir-counts" do
+      it "counts lines in each tsv file, skipping non-tsv files" do
+        files = [
+          {"Name" => "umich_mon_2025.tsv", "Path" => "umich_mon_2025.tsv", "IsDir" => false},
+          {"Name" => "umich_ser_2025.tsv", "Path" => "umich_ser_2025.tsv", "IsDir" => false},
+          {"Name" => "umich_mon_2025.log", "Path" => "umich_mon_2025.log", "IsDir" => false}
+        ]
+        allow(ft).to receive(:lsjson).with("dropbox:some/dir").and_return(files)
+        allow(ft).to receive(:cat).with("dropbox:some/dir/umich_mon_2025.tsv").and_yield(StringIO.new("a\nb\nc\n"))
+        allow(ft).to receive(:cat).with("dropbox:some/dir/umich_ser_2025.tsv").and_yield(StringIO.new("x\ny\n"))
+        expect { PHCTL::PHCTL.start(["holdings", "dir-counts", "dropbox:some/dir"]) }
+          .to output("umich_mon_2025.tsv: 3\numich_ser_2025.tsv: 2\nTotal: 5\n").to_stdout
+      end
+
+      it "skips subdirectory entries" do
+        files = [
+          {"Name" => "umich_mon_2025.tsv", "Path" => "umich_mon_2025.tsv", "IsDir" => false},
+          {"Name" => "archive", "Path" => "archive", "IsDir" => true}
+        ]
+        allow(ft).to receive(:lsjson).with("dropbox:some/dir").and_return(files)
+        allow(ft).to receive(:cat).with("dropbox:some/dir/umich_mon_2025.tsv").and_yield(StringIO.new("a\nb\n"))
+        expect { PHCTL::PHCTL.start(["holdings", "dir-counts", "dropbox:some/dir"]) }
+          .to output("umich_mon_2025.tsv: 2\nTotal: 2\n").to_stdout
+      end
+
+      it "prints only a total when no tsv files are present" do
+        files = [
+          {"Name" => "umich_mon_2025.log", "Path" => "umich_mon_2025.log", "IsDir" => false}
+        ]
+        allow(ft).to receive(:lsjson).with("dropbox:some/dir").and_return(files)
+        expect { PHCTL::PHCTL.start(["holdings", "dir-counts", "dropbox:some/dir"]) }
+          .to output("Total: 0\n").to_stdout
+      end
+    end
+
+    describe "format-counts" do
+      it "prints the format breakdown for an organization" do
+        rows = [
+          {mono_multi_serial: "spm", count: 1000},
+          {mono_multi_serial: "ser", count: 500}
+        ]
+        allow(Clusterable::Holding).to receive(:format_counts).with("umich").and_return(rows)
+        expect { PHCTL::PHCTL.start(["holdings", "format-counts", "umich"]) }
+          .to output("umich holdings by format:\n  spm:  1000\n  ser:  500\nTotal: 1500\n").to_stdout
+      end
+    end
+
+    describe "file-sample" do
+      it "prints the first N lines of a remote file" do
+        content = (1..100).map { |i| "line#{i}\n" }.join
+        allow(ft).to receive(:cat)
+          .with("dropbox:some/file.tsv")
+          .and_yield(StringIO.new(content))
+        expect { PHCTL::PHCTL.start(["holdings", "file-sample", "dropbox:some/file.tsv", "--lines", "3"]) }
+          .to output("line1\nline2\nline3\n").to_stdout
+      end
+    end
+  end
+
+  describe "holdings rclone commands (integration)" do
+    let(:test_dir) { "#{ENV["TEST_TMP"]}/holdings_rclone_test" }
+
+    before do
+      FileUtils.touch Settings.rclone_config_path
+      FileUtils.rm_rf(test_dir)
+      FileUtils.mkdir_p(test_dir)
+    end
+
+    describe "file-count" do
+      it "counts lines in a local file" do
+        File.write("#{test_dir}/umich_mon_2025.tsv", "line1\nline2\nline3\n")
+        expect { PHCTL::PHCTL.start(["holdings", "file-count", "#{test_dir}/umich_mon_2025.tsv"]) }
+          .to output("3\n").to_stdout
+      end
+    end
+
+    describe "file-sample" do
+      it "prints the first N lines" do
+        File.write("#{test_dir}/umich_mon_2025.tsv", (1..100).map { |i| "line#{i}\n" }.join)
+        expect { PHCTL::PHCTL.start(["holdings", "file-sample", "#{test_dir}/umich_mon_2025.tsv", "--lines", "3"]) }
+          .to output("line1\nline2\nline3\n").to_stdout
+      end
+
+      it "prints all lines when file is shorter than --lines" do
+        File.write("#{test_dir}/umich_mon_2025.tsv", "only\ntwo\n")
+        expect { PHCTL::PHCTL.start(["holdings", "file-sample", "#{test_dir}/umich_mon_2025.tsv", "--lines", "50"]) }
+          .to output("only\ntwo\n").to_stdout
+      end
+    end
+
+    describe "dir-counts" do
+      it "counts lines in each tsv file, skipping non-tsv files" do
+        File.write("#{test_dir}/umich_mon_2025.tsv", "a\nb\nc\n")
+        File.write("#{test_dir}/umich_ser_2025.tsv", "x\ny\n")
+        File.write("#{test_dir}/umich_mon_2025.log", "ignored\n")
+        expect { PHCTL::PHCTL.start(["holdings", "dir-counts", test_dir]) }
+          .to output("umich_mon_2025.tsv: 3\numich_ser_2025.tsv: 2\nTotal: 5\n").to_stdout
+      end
+
+      it "skips subdirectory entries" do
+        File.write("#{test_dir}/umich_mon_2025.tsv", "a\nb\n")
+        FileUtils.mkdir_p("#{test_dir}/archive")
+        expect { PHCTL::PHCTL.start(["holdings", "dir-counts", test_dir]) }
+          .to output("umich_mon_2025.tsv: 2\nTotal: 2\n").to_stdout
+      end
+
+      it "prints only a total when no tsv files are present" do
+        File.write("#{test_dir}/umich_mon_2025.log", "ignored\n")
+        expect { PHCTL::PHCTL.start(["holdings", "dir-counts", test_dir]) }
+          .to output("Total: 0\n").to_stdout
+      end
+
+      it "does not count tsv files in nested directories" do
+        File.write("#{test_dir}/umich_mon_2025.tsv", "a\nb\n")
+        FileUtils.mkdir_p("#{test_dir}/subdir")
+        File.write("#{test_dir}/subdir/umich_ser_2025.tsv", "x\ny\nz\n")
+        expect { PHCTL::PHCTL.start(["holdings", "dir-counts", test_dir]) }
+          .to output("umich_mon_2025.tsv: 2\nTotal: 2\n").to_stdout
+      end
+
+      it "outputs files sorted alphabetically" do
+        File.write("#{test_dir}/umich_zzz.tsv", "z\n")
+        File.write("#{test_dir}/umich_aaa.tsv", "a\nb\n")
+        expect { PHCTL::PHCTL.start(["holdings", "dir-counts", test_dir]) }
+          .to output("umich_aaa.tsv: 2\numich_zzz.tsv: 1\nTotal: 3\n").to_stdout
+      end
+    end
+  end
+
   describe "running inline" do
     include_context "with tables for holdings"
 

--- a/spec/utils/file_transfer_spec.rb
+++ b/spec/utils/file_transfer_spec.rb
@@ -95,6 +95,18 @@ RSpec.describe Utils::FileTransfer do
     end
   end
 
+  describe "#cat" do
+    it "streams file content to the block" do
+      File.write(local_file_path, "line1\nline2\nline3\n")
+      result = ft.cat(local_file_path, &:count)
+      expect(result).to eq 3
+    end
+
+    it "raises if the file does not exist" do
+      expect { ft.cat(missing_file, &:count) }.to raise_error Utils::FileTransferError
+    end
+  end
+
   describe "#download" do
     it "puts a file in the expected location" do
       expect(File.exist?("#{local_dir}/#{remote_file_name}")).to be false

--- a/spec/utils/holdings_preflight_spec.rb
+++ b/spec/utils/holdings_preflight_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "utils/holdings_preflight"
+require "spec_helper"
+
+RSpec.describe Utils::HoldingsPreflight do
+  describe "#format_counts" do
+    it "returns per-format counts and a total for an organization" do
+      rows = [
+        {mono_multi_serial: "ser", count: 500},
+        {mono_multi_serial: "spm", count: 1000}
+      ]
+      allow(Clusterable::Holding).to receive(:format_counts).with("umich").and_return(rows)
+
+      result = described_class.new.format_counts("umich")
+
+      expect(result[:counts]).to eq([{format: "ser", count: 500}, {format: "spm", count: 1000}])
+      expect(result[:total]).to eq(1500)
+    end
+
+    it "returns an empty counts array and zero total when the organization has no holdings" do
+      allow(Clusterable::Holding).to receive(:format_counts).with("empty").and_return([])
+
+      result = described_class.new.format_counts("empty")
+
+      expect(result[:counts]).to eq([])
+      expect(result[:total]).to eq(0)
+    end
+  end
+
+  describe "#dir_counts" do
+    let(:ft) { instance_double(Utils::FileTransfer) }
+    subject(:preflight) { described_class.new(file_transfer: ft) }
+
+    it "counts lines in each tsv file, skipping non-tsv files and directories" do
+      files = [
+        {"Name" => "umich_mon_2025.tsv", "Path" => "umich_mon_2025.tsv", "IsDir" => false},
+        {"Name" => "umich_ser_2025.tsv", "Path" => "umich_ser_2025.tsv", "IsDir" => false},
+        {"Name" => "umich_mon_2025.log", "Path" => "umich_mon_2025.log", "IsDir" => false},
+        {"Name" => "archive", "Path" => "archive", "IsDir" => true}
+      ]
+      allow(ft).to receive(:lsjson).with("dropbox:some/dir").and_return(files)
+      allow(ft).to receive(:cat).with("dropbox:some/dir/umich_mon_2025.tsv").and_yield(StringIO.new("a\nb\nc\n"))
+      allow(ft).to receive(:cat).with("dropbox:some/dir/umich_ser_2025.tsv").and_yield(StringIO.new("x\ny\n"))
+
+      result = preflight.dir_counts("dropbox:some/dir")
+
+      expect(result[:counts]).to eq([
+        {name: "umich_mon_2025.tsv", count: 3},
+        {name: "umich_ser_2025.tsv", count: 2}
+      ])
+      expect(result[:total]).to eq(5)
+    end
+
+    it "returns empty counts and zero total when no tsv files are present" do
+      files = [{"Name" => "umich_mon_2025.log", "Path" => "umich_mon_2025.log", "IsDir" => false}]
+      allow(ft).to receive(:lsjson).with("dropbox:some/dir").and_return(files)
+
+      result = preflight.dir_counts("dropbox:some/dir")
+
+      expect(result[:counts]).to eq([])
+      expect(result[:total]).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Adds `phctl holdings` subcommands for pre-flight checks before loading holdings.

New commands:

- `holdings count ORG` - breakdown by format (spm/ser/etc) with a total, from the DB
```
$ phctl holdings count umich
umich holdings by format:
  mpm:  12345
  ser:  67890
  spm:  1482903
Total: 1563138
```
- `holdings dir-counts PATH` - line counts for each .tsv in a directory, sorted alphabetically, skipping .log/.xml/.tar.gz and subdirectories, with a total
```
$ phctl holdings dir-counts umich/2025
umich_mon_full_20250902.tsv: 1482903
umich_ser_full_20250902.tsv: 67890
Total: 1550793
```
- `holdings file-count PATH` - line count for a single file
```
$ phctl holdings file-count umich/2025/umich_mon_full_20250902.tsv
1482903
```
- `holdings file-sample PATH` - first 50 lines of a file, or pass `--lines N` for a different count
```
$ phctl holdings file-sample umich/2025/umich_mon_full_20250902.tsv --lines 3
1234567	bib001	umich	CH		2025-01-01		spm			0	uuid-1
1234568	bib002	umich	CH		2025-01-01		spm			0	uuid-2
1234569	bib003	umich	CH		2025-01-01		spm			0	uuid-3
```

PATH can be a local path or a remote rclone path.