### PR TITLE
Reduce sidekiq retry notifications

### DIFF
--- a/lib/utils/sidekiq_failure_notifier.rb
+++ b/lib/utils/sidekiq_failure_notifier.rb
@@ -4,8 +4,8 @@ require "utils/slack_notifier"
 
 module Utils
   module SidekiqFailureNotifier
-    # retry_count is nil on 1st attempt, 0 on 2nd, 1 on 3rd — notify on 3rd+ failure
-    NOTIFY_AT_RETRY_COUNT = 1
+    # retry_count is nil on 1st attempt, 0 on 2nd, 1 on 3rd — notify at 3rd and 7th failures
+    NOTIFY_AT_RETRY_COUNTS = [1, 5]
 
     def self.alerts_url
       Settings.slack_alerts_webhook_url
@@ -25,7 +25,7 @@ module Utils
 
     def self.on_error(exception, ctx, _config = nil)
       job = ctx[:job]
-      return unless job && job["retry_count"].to_i >= NOTIFY_AT_RETRY_COUNT
+      return unless job && NOTIFY_AT_RETRY_COUNTS.include?(job["retry_count"].to_i)
       Utils::SlackNotifier.post(
         failure_message(job, exception),
         url: alerts_url

--- a/spec/utils/sidekiq_failure_notifier_spec.rb
+++ b/spec/utils/sidekiq_failure_notifier_spec.rb
@@ -8,12 +8,6 @@ RSpec.describe Utils::SidekiqFailureNotifier do
 
   let(:error) { RuntimeError.new("disk full") }
 
-  describe "NOTIFY_AT_RETRY_COUNTS" do
-    it "triggers on the 3rd and 7th failures" do
-      expect(described_class::NOTIFY_AT_RETRY_COUNTS).to eq [1, 5]
-    end
-  end
-
   describe ".failure_message" do
     it "includes will retry notice, job class, args, error class, and message" do
       job = {"class" => "Jobs::Load::Holdings", "args" => ["/data/umich.ndj"], "retry_count" => 1}

--- a/spec/utils/sidekiq_failure_notifier_spec.rb
+++ b/spec/utils/sidekiq_failure_notifier_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Utils::SidekiqFailureNotifier do
 
   let(:error) { RuntimeError.new("disk full") }
 
-  describe "NOTIFY_AT_RETRY_COUNT" do
-    it "is 1 (triggers on the 3rd failure and beyond)" do
-      expect(described_class::NOTIFY_AT_RETRY_COUNT).to eq 1
+  describe "NOTIFY_AT_RETRY_COUNTS" do
+    it "triggers on the 3rd and 7th failures" do
+      expect(described_class::NOTIFY_AT_RETRY_COUNTS).to eq [1, 5]
     end
   end
 
@@ -59,10 +59,20 @@ RSpec.describe Utils::SidekiqFailureNotifier do
       expect(stub).to have_been_requested.once
     end
 
-    it "posts to Slack on subsequent retries (retry_count 2+)" do
-      stub = stub_request(:post, alerts_webhook_url).to_return(status: 200)
+    it "does not post to Slack on retries between the two thresholds (retry_count 2)" do
       run_handler({"class" => "Jobs::Common", "retry_count" => 2})
+      expect(a_request(:post, alerts_webhook_url)).not_to have_been_made
+    end
+
+    it "posts to Slack on 7th attempt (retry_count 5)" do
+      stub = stub_request(:post, alerts_webhook_url).to_return(status: 200)
+      run_handler({"class" => "Jobs::Common", "retry_count" => 5})
       expect(stub).to have_been_requested.once
+    end
+
+    it "does not post to Slack on retries after the second threshold (retry_count 6+)" do
+      run_handler({"class" => "Jobs::Common", "retry_count" => 6})
+      expect(a_request(:post, alerts_webhook_url)).not_to have_been_made
     end
 
     it "does not post to Slack when ctx has no job" do


### PR DESCRIPTION
Reduce Sidekiq retry noise by notifying only at the 3rd and 7th failures instead of every retry.