### PR TITLE
Cleanup: remove unused configuration keys

### DIFF
--- a/config/environments/test.yml
+++ b/config/environments/test.yml
@@ -3,7 +3,6 @@ concordance_path: <%= ENV["TEST_TMP"] %>/concordance
 concordance_database_path: <%= ENV["TEST_TMP"] %>/concordance/db
 cost_report_freq_path: <%= ENV["TEST_TMP"] %>/cost_report_freq
 cost_report_path: <%= ENV["TEST_TMP"] %>/cost_reports
-deprecation_report_path: <%= ENV["TEST_TMP"] %>/deprecation_report
 estimates_path: <%= ENV["TEST_TMP"] %>/estimates
 etas_overlap_batch_size: 50
 overlap_reports_path: <%= ENV["TEST_TMP"] %>/overlap_reports
@@ -12,8 +11,6 @@ overlap_reports_remote_path_url: https://www.dropbox.com/home/test
 hathifile_path: <%= ENV["TEST_TMP"] %>/hathifiles
 local_member_data: <%= ENV["TEST_TMP"] %>/local_member_data
 local_report_path: <%= ENV["TEST_TMP"] %>/local_reports
-oclc_collection_id_map_path: spec/fixtures/oclc_collection_id_map.tsv
-oclc_registration_report_path: <%= ENV["TEST_TMP"] %>
 rclone_config_path: <%= ENV["TEST_TMP"] %>/rclone.conf
 remote_member_data: <%= ENV["TEST_TMP"] %>/remote_member_data
 scrub_base_path: <%= ENV["TEST_TMP"] %>/scrub_data
@@ -21,7 +18,5 @@ scrub_chunk_count: 4
 scrub_chunk_work_dir: <%= ENV["TEST_TMP"] %>
 scrub_line_count_diff_max: 0.05
 scrub_ocn_diff_max: 0.10
-sp_newly_ingested_report_path: <%= ENV["TEST_TMP"] %>/sp_newly_ingested_report
-slack_endpoint: http://slack.test/endpoint
 target_cost: 9999
 working_path: <%= ENV["TEST_TMP"] %>/work

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,7 +2,6 @@ concordance_path: <%= ENV["CONCORDANCE_PATH"] %>
 concordance_database_path: <%= ENV["CONCORDANCE_DATABASE_PATH"] %>
 cost_report_freq_path: <%= ENV["COST_REPORT_FREQ_PATH"] %>
 cost_report_path: <%= ENV["COST_REPORT_PATH"] %>
-deprecation_report_path: <%= ENV["DEPRECATION_REPORT_PATH"] %>
 estimates_path: <%= ENV["ESTIMATES_PATH"] %>
 etas_overlap_batch_size: <%= ENV["ETAS_OVERLAP_BATCH_SIZE"] %>
 overlap_reports_path: <%= ENV["OVERLAP_REPORTS_PATH"] %>


### PR DESCRIPTION
None of these configuration keys appear to be used anywhere in the code. I will remove them from the production config as well.