### PR TITLE
Correct image name for holdings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         name: Build Image
         uses: hathitrust/github_actions/.github/workflows/build.yml@98a7b0f67c16b968bb1f357ac50224dbfa789f3f # v2.0.2
         with:
-            image: ghcr.io/${{ github.repository }}
+            image: ghcr.io/hathitrust/holdings
             dockerfile: Dockerfile
             img_tag: ${{ inputs.img_tag }}
             tag: ${{ inputs.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     name: Deploy to ${{inputs.environments}}
     uses: hathitrust/github_actions/.github/workflows/deploy.yml@98a7b0f67c16b968bb1f357ac50224dbfa789f3f # v2.0.2
     with:
-      image: ghcr.io/${{ github.repository }}:${{ inputs.branch_hash || github.sha}}
-      file: environments/holdings/${{inputs.environments}}/holdings-client-image.txt
+      image: ghcr.io/holdings:${{ inputs.branch_hash || github.sha}}
+      file: environments/hathitrust/holdings/${{inputs.environments}}/holdings-client-image.txt
       CONFIG_REPO_FULL_NAME: ${{ vars.CONFIG_REPO_FULL_NAME }}
     secrets: inherit


### PR DESCRIPTION
Was using repo name (holdings-backend)

@eumalin @kron-spar I'm updating the 'old' actions because I want to build & deploy a branch to the staging environment; the current `release.yml` action doesn't account for that use case, although I think we could add it there if we wanted without too much trouble.